### PR TITLE
[Phase 2 / Slice 4] 매니저 멤버 포지션 배정 구현

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/api/events/[eventId]/applicants/route.ts
+++ b/src/app/api/events/[eventId]/applicants/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { readEventApplicants } from "#/entities/assignments/repositories/readAssignmentRepository";
+import {
+  assignmentErrors,
+  assignmentErrorCodes,
+} from "#/entities/assignments/models/errors/assignmentError";
+import { createSupabaseServerClient } from "#/shared/lib/supabase/server";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ eventId: string }> }
+) {
+  const { eventId } = await params;
+
+  try {
+    const client = await createSupabaseServerClient();
+    const applicants = await readEventApplicants(eventId, { client });
+
+    return NextResponse.json({ applicants });
+  } catch (error) {
+    console.error(`[GET /api/events/${eventId}/applicants]`, error);
+
+    return NextResponse.json(
+      {
+        errorCode:
+          assignmentErrors.read(error) ?? assignmentErrorCodes.listFailed,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/events/[eventId]/assignments/route.ts
+++ b/src/app/api/events/[eventId]/assignments/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { readEventAssignments } from "#/entities/assignments/repositories/readAssignmentRepository";
+import {
+  assignmentErrors,
+  assignmentErrorCodes,
+} from "#/entities/assignments/models/errors/assignmentError";
+import { createSupabaseServerClient } from "#/shared/lib/supabase/server";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ eventId: string }> }
+) {
+  const { eventId } = await params;
+
+  try {
+    const client = await createSupabaseServerClient();
+    const assignments = await readEventAssignments(eventId, { client });
+
+    return NextResponse.json({ assignments });
+  } catch (error) {
+    console.error(`[GET /api/events/${eventId}/assignments]`, error);
+
+    return NextResponse.json(
+      {
+        errorCode:
+          assignmentErrors.read(error) ?? assignmentErrorCodes.listFailed,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/events/[eventId]/page.tsx
+++ b/src/app/events/[eventId]/page.tsx
@@ -26,5 +26,5 @@ export default async function EventDetailPage({
     notFound();
   }
 
-  return <EventDetailScreen event={event} />;
+  return <EventDetailScreen event={event} viewerRole={actor?.role} />;
 }

--- a/src/entities/assignments/models/errors/assignmentError.ts
+++ b/src/entities/assignments/models/errors/assignmentError.ts
@@ -1,0 +1,17 @@
+import { createDomainErrorHelpers } from "#/shared/lib/errors/appError";
+
+export const assignmentErrorCodes = {
+  createDuplicateActive: "ASSIGNMENT_CREATE_DUPLICATE_ACTIVE",
+  createEventNotFound: "ASSIGNMENT_CREATE_EVENT_NOT_FOUND",
+  createFailed: "ASSIGNMENT_CREATE_FAILED",
+  createPositionNotInEvent: "ASSIGNMENT_CREATE_POSITION_NOT_IN_EVENT",
+  createUserNotApplied: "ASSIGNMENT_CREATE_USER_NOT_APPLIED",
+  listFailed: "ASSIGNMENT_LIST_FAILED",
+  unauthorizedRole: "ASSIGNMENT_UNAUTHORIZED_ROLE",
+} as const;
+
+export type AssignmentErrorCode =
+  (typeof assignmentErrorCodes)[keyof typeof assignmentErrorCodes];
+
+export const assignmentErrors =
+  createDomainErrorHelpers(assignmentErrorCodes);

--- a/src/entities/assignments/models/schemas/applicant.ts
+++ b/src/entities/assignments/models/schemas/applicant.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const applicantSchema = z.object({
+  applicationId: z.string().uuid(),
+  userId: z.string().uuid(),
+  userName: z.string().trim().min(1),
+  userEmail: z.string().email(),
+  appliedAt: z.string().datetime({ offset: true }),
+});
+
+export type Applicant = z.infer<typeof applicantSchema>;

--- a/src/entities/assignments/models/schemas/assignment.ts
+++ b/src/entities/assignments/models/schemas/assignment.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const assignmentKindSchema = z.enum(["regular", "training"]);
+
+export const assignmentStatusSchema = z.enum([
+  "assigned",
+  "confirmed",
+  "cancel_requested",
+  "cancelled",
+  "checked_in",
+]);
+
+export const assignmentSchema = z.object({
+  assignedAt: z.string().datetime({ offset: true }),
+  assignmentKind: assignmentKindSchema,
+  eventId: z.string().uuid(),
+  id: z.string().uuid(),
+  positionId: z.string().uuid(),
+  positionName: z.string().trim().min(1),
+  status: assignmentStatusSchema,
+  userId: z.string().uuid(),
+  userName: z.string().trim().min(1),
+});
+
+export type AssignmentKind = z.infer<typeof assignmentKindSchema>;
+export type AssignmentStatus = z.infer<typeof assignmentStatusSchema>;
+export type Assignment = z.infer<typeof assignmentSchema>;

--- a/src/entities/assignments/repositories/readAssignmentRepository.ts
+++ b/src/entities/assignments/repositories/readAssignmentRepository.ts
@@ -1,0 +1,111 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  assignmentErrors,
+  assignmentErrorCodes,
+} from "#/entities/assignments/models/errors/assignmentError";
+import {
+  assignmentSchema,
+  type Assignment,
+} from "#/entities/assignments/models/schemas/assignment";
+import {
+  applicantSchema,
+  type Applicant,
+} from "#/entities/assignments/models/schemas/applicant";
+import type { Database } from "#/shared/types/database";
+
+type AssignmentRepositoryOptions = {
+  client: SupabaseClient<Database>;
+};
+
+export async function readEventAssignments(
+  eventId: string,
+  options: AssignmentRepositoryOptions
+): Promise<Assignment[]> {
+  const { client } = options;
+  const { data, error } = await client
+    .from("assignments")
+    .select(
+      `
+      id,
+      event_id,
+      user_id,
+      position_id,
+      assignment_kind,
+      status,
+      assigned_at,
+      users (
+        id,
+        name
+      ),
+      positions (
+        id,
+        name
+      )
+    `
+    )
+    .eq("event_id", eventId)
+    .in("status", ["assigned", "confirmed", "cancel_requested", "checked_in"])
+    .order("assigned_at", { ascending: true });
+
+  if (error) {
+    throw assignmentErrors.create(assignmentErrorCodes.listFailed, {
+      cause: error,
+    });
+  }
+
+  return (data ?? []).map((row) =>
+    assignmentSchema.parse({
+      assignedAt: row.assigned_at,
+      assignmentKind: row.assignment_kind,
+      eventId: row.event_id,
+      id: row.id,
+      positionId: row.position_id,
+      positionName: (row.positions as { name: string } | null)?.name ?? "",
+      status: row.status,
+      userId: row.user_id,
+      userName: (row.users as { name: string } | null)?.name ?? "",
+    })
+  );
+}
+
+export async function readEventApplicants(
+  eventId: string,
+  options: AssignmentRepositoryOptions
+): Promise<Applicant[]> {
+  const { client } = options;
+  const { data, error } = await client
+    .from("applications")
+    .select(
+      `
+      id,
+      user_id,
+      applied_at,
+      users (
+        id,
+        name,
+        email
+      )
+    `
+    )
+    .eq("event_id", eventId)
+    .eq("status", "applied")
+    .order("applied_at", { ascending: true });
+
+  if (error) {
+    throw assignmentErrors.create(assignmentErrorCodes.listFailed, {
+      cause: error,
+    });
+  }
+
+  return (data ?? []).map((row) => {
+    const user = row.users as { id: string; name: string; email: string } | null;
+
+    return applicantSchema.parse({
+      applicationId: row.id,
+      userId: row.user_id,
+      userName: user?.name ?? "",
+      userEmail: user?.email ?? "",
+      appliedAt: row.applied_at,
+    });
+  });
+}

--- a/src/entities/assignments/repositories/writeAssignmentRepository.ts
+++ b/src/entities/assignments/repositories/writeAssignmentRepository.ts
@@ -1,0 +1,50 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  assignmentErrors,
+  assignmentErrorCodes,
+} from "#/entities/assignments/models/errors/assignmentError";
+import type { AssignmentKind } from "#/entities/assignments/models/schemas/assignment";
+import type { Database } from "#/shared/types/database";
+
+type AssignmentRepositoryOptions = {
+  client: SupabaseClient<Database>;
+};
+
+export type CreateAssignmentRecordInput = {
+  eventId: string;
+  positionId: string;
+  userId: string;
+  assignmentKind?: AssignmentKind;
+};
+
+export async function createAssignmentRecord(
+  input: CreateAssignmentRecordInput,
+  options: AssignmentRepositoryOptions
+): Promise<string> {
+  const { client } = options;
+  const { data, error } = await client
+    .from("assignments")
+    .insert({
+      assignment_kind: input.assignmentKind ?? "regular",
+      event_id: input.eventId,
+      position_id: input.positionId,
+      status: "assigned",
+      user_id: input.userId,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      throw assignmentErrors.create(assignmentErrorCodes.createDuplicateActive, {
+        cause: error,
+      });
+    }
+
+    throw assignmentErrors.create(assignmentErrorCodes.createFailed, {
+      cause: error,
+    });
+  }
+
+  return data.id;
+}

--- a/src/mutations/assignments/_tests/createAssignmentAction.test.ts
+++ b/src/mutations/assignments/_tests/createAssignmentAction.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAssignmentAction } from "#/mutations/assignments/actions/createAssignment";
+
+describe("createAssignmentAction", () => {
+  it("assigns a user to an event position using an admin/manager actor", async () => {
+    const client = {} as never;
+    const requireActor = vi.fn().mockResolvedValue({
+      email: "admin@labiebelle.local",
+      kind: "authenticated_user",
+      name: "관리자",
+      role: "admin",
+      source: "auth_user",
+      userId: "11111111-1111-4111-8111-111111111111",
+    });
+    const readEvent = vi.fn().mockResolvedValue({
+      createdAt: "2026-04-11T08:00:00.000Z",
+      eventDate: "2026-04-20",
+      firstServiceAt: "10:30",
+      id: "11111111-1111-4111-8111-111111111111",
+      lastServiceEndAt: "16:00",
+      positionSlots: [
+        {
+          positionId: "22222222-2222-4222-8222-222222222222",
+          positionName: "포지션",
+          requiredCount: 2,
+          trainingCount: 0,
+        },
+      ],
+      status: "draft",
+      templateId: null,
+      timeLabel: "10:30 - 16:00",
+      title: "Title",
+      viewerApplicationStatus: null,
+    });
+    const createRecord = vi.fn().mockResolvedValue("assignment-1234");
+
+    await expect(
+      createAssignmentAction(
+        {
+          eventId: "11111111-1111-4111-8111-111111111111",
+          positionId: "22222222-2222-4222-8222-222222222222",
+          userId: "33333333-3333-4333-8333-333333333333",
+        },
+        {
+          client,
+          createRecord,
+          readEvent,
+          requireActor,
+        }
+      )
+    ).resolves.toEqual({
+      assignmentId: "assignment-1234",
+      eventId: "11111111-1111-4111-8111-111111111111",
+      positionId: "22222222-2222-4222-8222-222222222222",
+      userId: "33333333-3333-4333-8333-333333333333",
+    });
+
+    expect(createRecord).toHaveBeenCalledWith(
+      {
+        assignmentKind: undefined,
+        eventId: "11111111-1111-4111-8111-111111111111",
+        positionId: "22222222-2222-4222-8222-222222222222",
+        userId: "33333333-3333-4333-8333-333333333333",
+      },
+      { client }
+    );
+  });
+
+  it("rejects when the actor is a member", async () => {
+    await expect(
+      createAssignmentAction(
+        {
+          eventId: "11111111-1111-4111-8111-111111111111",
+          positionId: "22222222-2222-4222-8222-222222222222",
+          userId: "33333333-3333-4333-8333-333333333333",
+        },
+        {
+          client: {} as never,
+          createRecord: vi.fn(),
+          readEvent: vi.fn(),
+          requireActor: vi.fn().mockResolvedValue({
+            email: "member1@labiebelle.local",
+            kind: "authenticated_user",
+            name: "팀원",
+            role: "member",
+            source: "auth_user",
+            userId: "33333333-3333-4333-8333-333333333333",
+          }),
+        }
+      )
+    ).rejects.toMatchObject({
+      code: "ASSIGNMENT_UNAUTHORIZED_ROLE",
+    });
+  });
+
+  it("rejects when the specified position is not part of the event slots", async () => {
+    await expect(
+      createAssignmentAction(
+        {
+          eventId: "11111111-1111-4111-8111-111111111111",
+          positionId: "77777777-7777-4777-8777-777777777777",
+          userId: "33333333-3333-4333-8333-333333333333",
+        },
+        {
+          client: {} as never,
+          createRecord: vi.fn(),
+          readEvent: vi.fn().mockResolvedValue({
+            createdAt: "2026-04-11T08:00:00.000Z",
+            eventDate: "2026-04-20",
+            firstServiceAt: "10:30",
+            id: "11111111-1111-4111-8111-111111111111",
+            lastServiceEndAt: "16:00",
+            positionSlots: [
+              {
+                positionId: "22222222-2222-4222-8222-222222222222",
+                positionName: "포지션",
+                requiredCount: 2,
+                trainingCount: 0,
+              },
+            ],
+            status: "draft",
+            templateId: null,
+            timeLabel: "10:30 - 16:00",
+            title: "Title",
+            viewerApplicationStatus: null,
+          }),
+          requireActor: vi.fn().mockResolvedValue({
+            email: "admin@labiebelle.local",
+            kind: "authenticated_user",
+            name: "관리자",
+            role: "admin",
+            source: "auth_user",
+            userId: "11111111-1111-4111-8111-111111111111",
+          }),
+        }
+      )
+    ).rejects.toMatchObject({
+      code: "ASSIGNMENT_CREATE_POSITION_NOT_IN_EVENT",
+    });
+  });
+});

--- a/src/mutations/assignments/actions/createAssignment.ts
+++ b/src/mutations/assignments/actions/createAssignment.ts
@@ -1,0 +1,71 @@
+"use server";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  assignmentErrors,
+  assignmentErrorCodes,
+} from "#/entities/assignments/models/errors/assignmentError";
+import { createAssignmentRecord } from "#/entities/assignments/repositories/writeAssignmentRepository";
+import { readEventById } from "#/entities/events/repositories/readEventRepository";
+import {
+  parseCreateAssignmentInput,
+  type CreateAssignmentInput,
+} from "#/mutations/assignments/schemas/createAssignment";
+import { requireAppActor } from "#/shared/lib/auth/appActor";
+import { createSupabaseAdminClient } from "#/shared/lib/supabase/admin";
+import type { Database } from "#/shared/types/database";
+
+type CreateAssignmentDependencies = {
+  client?: SupabaseClient<Database>;
+  createRecord?: typeof createAssignmentRecord;
+  readEvent?: typeof readEventById;
+  requireActor?: typeof requireAppActor;
+};
+
+export async function createAssignmentAction(
+  input: CreateAssignmentInput,
+  dependencies: CreateAssignmentDependencies = {}
+) {
+  const values = parseCreateAssignmentInput(input);
+  const requireActor = dependencies.requireActor ?? requireAppActor;
+  const actor = await requireActor();
+
+  if (actor.role !== "admin" && actor.role !== "manager") {
+    throw assignmentErrors.create(assignmentErrorCodes.unauthorizedRole);
+  }
+
+  const client = dependencies.client ?? createSupabaseAdminClient();
+  const readEvent = dependencies.readEvent ?? readEventById;
+  const createRecord = dependencies.createRecord ?? createAssignmentRecord;
+
+  const event = await readEvent(values.eventId, { client });
+
+  if (!event) {
+    throw assignmentErrors.create(assignmentErrorCodes.createEventNotFound);
+  }
+
+  const positionInEvent = event.positionSlots.some(
+    (slot) => slot.positionId === values.positionId
+  );
+
+  if (!positionInEvent) {
+    throw assignmentErrors.create(assignmentErrorCodes.createPositionNotInEvent);
+  }
+
+  const assignmentId = await createRecord(
+    {
+      eventId: values.eventId,
+      positionId: values.positionId,
+      userId: values.userId,
+      assignmentKind: values.assignmentKind,
+    },
+    { client }
+  );
+
+  return {
+    assignmentId,
+    eventId: values.eventId,
+    positionId: values.positionId,
+    userId: values.userId,
+  };
+}

--- a/src/mutations/assignments/hooks/useCreateAssignmentMutation.ts
+++ b/src/mutations/assignments/hooks/useCreateAssignmentMutation.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createAssignmentAction } from "#/mutations/assignments/actions/createAssignment";
+import type { CreateAssignmentInput } from "#/mutations/assignments/schemas/createAssignment";
+import { assignmentQueryKeys } from "#/queries/assignments/constants/assignmentQueryKeys";
+
+export function useCreateAssignmentMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: CreateAssignmentInput) => createAssignmentAction(input),
+    onSuccess(result) {
+      void queryClient.invalidateQueries({
+        queryKey: assignmentQueryKeys.detail(result.eventId),
+      });
+    },
+  });
+}

--- a/src/mutations/assignments/schemas/createAssignment.ts
+++ b/src/mutations/assignments/schemas/createAssignment.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const createAssignmentInputSchema = z.object({
+  eventId: z.string().uuid("행사를 다시 선택해 주세요."),
+  positionId: z.string().uuid("포지션을 다시 선택해 주세요."),
+  userId: z.string().uuid("배정할 멤버를 다시 선택해 주세요."),
+  assignmentKind: z.enum(["regular", "training"]).optional(),
+});
+
+export type CreateAssignmentInput = z.input<typeof createAssignmentInputSchema>;
+export type CreateAssignmentValues = z.output<typeof createAssignmentInputSchema>;
+
+export function parseCreateAssignmentInput(
+  input: CreateAssignmentInput
+): CreateAssignmentValues {
+  return createAssignmentInputSchema.parse(input);
+}

--- a/src/queries/assignments/constants/assignmentQueryKeys.ts
+++ b/src/queries/assignments/constants/assignmentQueryKeys.ts
@@ -1,0 +1,3 @@
+import { createQueryKeyFactory } from "#/shared/lib/tanstack-query/createQueryKeyFactory";
+
+export const assignmentQueryKeys = createQueryKeyFactory("assignments");

--- a/src/queries/assignments/hooks/useEventApplicantsQuery.ts
+++ b/src/queries/assignments/hooks/useEventApplicantsQuery.ts
@@ -1,0 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
+import { getEventApplicantsQueryOptions } from "#/queries/assignments/options/getEventApplicantsQueryOptions";
+
+export function useEventApplicantsQuery(eventId: string) {
+  return useQuery(getEventApplicantsQueryOptions(eventId));
+}

--- a/src/queries/assignments/hooks/useEventAssignmentsQuery.ts
+++ b/src/queries/assignments/hooks/useEventAssignmentsQuery.ts
@@ -1,0 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
+import { getEventAssignmentsQueryOptions } from "#/queries/assignments/options/getEventAssignmentsQueryOptions";
+
+export function useEventAssignmentsQuery(eventId: string) {
+  return useQuery(getEventAssignmentsQueryOptions(eventId));
+}

--- a/src/queries/assignments/options/getEventApplicantsQueryOptions.ts
+++ b/src/queries/assignments/options/getEventApplicantsQueryOptions.ts
@@ -1,0 +1,10 @@
+import { queryOptions } from "@tanstack/react-query";
+import { assignmentQueryKeys } from "#/queries/assignments/constants/assignmentQueryKeys";
+import { fetchEventApplicants } from "#/queries/assignments/services/fetchEventApplicants";
+
+export function getEventApplicantsQueryOptions(eventId: string) {
+  return queryOptions({
+    queryKey: assignmentQueryKeys.collection({ eventId }),
+    queryFn: () => fetchEventApplicants(eventId),
+  });
+}

--- a/src/queries/assignments/options/getEventAssignmentsQueryOptions.ts
+++ b/src/queries/assignments/options/getEventAssignmentsQueryOptions.ts
@@ -1,0 +1,10 @@
+import { queryOptions } from "@tanstack/react-query";
+import { assignmentQueryKeys } from "#/queries/assignments/constants/assignmentQueryKeys";
+import { fetchEventAssignments } from "#/queries/assignments/services/fetchEventAssignments";
+
+export function getEventAssignmentsQueryOptions(eventId: string) {
+  return queryOptions({
+    queryKey: assignmentQueryKeys.detail(eventId),
+    queryFn: () => fetchEventAssignments(eventId),
+  });
+}

--- a/src/queries/assignments/services/fetchEventApplicants.ts
+++ b/src/queries/assignments/services/fetchEventApplicants.ts
@@ -1,0 +1,8 @@
+import { readEventApplicants } from "#/entities/assignments/repositories/readAssignmentRepository";
+import { createSupabaseServerClient } from "#/shared/lib/supabase/server";
+
+export async function fetchEventApplicants(eventId: string) {
+  const client = await createSupabaseServerClient();
+
+  return readEventApplicants(eventId, { client });
+}

--- a/src/queries/assignments/services/fetchEventApplicants.ts
+++ b/src/queries/assignments/services/fetchEventApplicants.ts
@@ -1,8 +1,29 @@
-import { readEventApplicants } from "#/entities/assignments/repositories/readAssignmentRepository";
-import { createSupabaseServerClient } from "#/shared/lib/supabase/server";
+import { z } from "zod";
+import { applicantSchema } from "#/entities/assignments/models/schemas/applicant";
+import { createAppError, readApiErrorCode } from "#/shared/lib/errors/appError";
+
+const eventApplicantsResponseSchema = z.object({
+  applicants: z.array(applicantSchema),
+});
 
 export async function fetchEventApplicants(eventId: string) {
-  const client = await createSupabaseServerClient();
+  const response = await fetch(`/api/events/${eventId}/applicants`, {
+    cache: "no-store",
+    method: "GET",
+  });
 
-  return readEventApplicants(eventId, { client });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null);
+    const errorCode = readApiErrorCode(payload);
+
+    if (errorCode) {
+      throw createAppError(errorCode);
+    }
+
+    throw new Error(`Failed to fetch applicants for event: ${eventId}`);
+  }
+
+  const data = await response.json();
+
+  return eventApplicantsResponseSchema.parse(data).applicants;
 }

--- a/src/queries/assignments/services/fetchEventAssignments.ts
+++ b/src/queries/assignments/services/fetchEventAssignments.ts
@@ -1,8 +1,29 @@
-import { readEventAssignments } from "#/entities/assignments/repositories/readAssignmentRepository";
-import { createSupabaseServerClient } from "#/shared/lib/supabase/server";
+import { z } from "zod";
+import { assignmentSchema } from "#/entities/assignments/models/schemas/assignment";
+import { createAppError, readApiErrorCode } from "#/shared/lib/errors/appError";
+
+const eventAssignmentsResponseSchema = z.object({
+  assignments: z.array(assignmentSchema),
+});
 
 export async function fetchEventAssignments(eventId: string) {
-  const client = await createSupabaseServerClient();
+  const response = await fetch(`/api/events/${eventId}/assignments`, {
+    cache: "no-store",
+    method: "GET",
+  });
 
-  return readEventAssignments(eventId, { client });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null);
+    const errorCode = readApiErrorCode(payload);
+
+    if (errorCode) {
+      throw createAppError(errorCode);
+    }
+
+    throw new Error(`Failed to fetch assignments for event: ${eventId}`);
+  }
+
+  const data = await response.json();
+
+  return eventAssignmentsResponseSchema.parse(data).assignments;
 }

--- a/src/queries/assignments/services/fetchEventAssignments.ts
+++ b/src/queries/assignments/services/fetchEventAssignments.ts
@@ -1,0 +1,8 @@
+import { readEventAssignments } from "#/entities/assignments/repositories/readAssignmentRepository";
+import { createSupabaseServerClient } from "#/shared/lib/supabase/server";
+
+export async function fetchEventAssignments(eventId: string) {
+  const client = await createSupabaseServerClient();
+
+  return readEventAssignments(eventId, { client });
+}

--- a/src/screens/events/detail/EventDetailScreen.tsx
+++ b/src/screens/events/detail/EventDetailScreen.tsx
@@ -6,6 +6,7 @@ import type {
   EventStatus,
 } from "#/entities/events/models/schemas/event";
 import { EventApplicationPanel } from "#/screens/events/detail/_components/EventApplicationPanel";
+import { EventAssignmentPanel } from "#/screens/events/detail/_components/EventAssignmentPanel";
 import { Badge } from "#/shared/components/ui/badge";
 import { Button } from "#/shared/components/ui/button";
 import {
@@ -18,6 +19,7 @@ import {
 
 type EventDetailScreenProps = {
   event: EventDetail;
+  viewerRole?: "admin" | "manager" | "member";
 };
 
 const eventStatusCopy: Record<EventStatus, string> = {
@@ -37,6 +39,7 @@ function formatEventDate(value: string) {
 
 export function EventDetailScreen({
   event,
+  viewerRole,
 }: Readonly<EventDetailScreenProps>) {
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-[1180px] flex-col gap-6 px-4 py-8 md:px-8">
@@ -170,29 +173,12 @@ export function EventDetailScreen({
         initialApplicationStatus={event.viewerApplicationStatus}
       />
 
-      <Card className="border border-dashed border-border/70 bg-background/92">
-        <CardHeader>
-          <CardTitle>다음 연결 지점</CardTitle>
-          <CardDescription>
-            Slice 3과 Slice 4에서 이 detail 화면에 신청 상태와 배정 결과가
-            붙습니다.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="grid gap-3 md:grid-cols-2">
-          <div className="rounded-2xl border border-border/60 bg-muted/20 p-4">
-            <p className="font-semibold text-foreground">신청 상태</p>
-            <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              멤버 신청/취소 상태와 모집 가능 여부가 이 영역에 표시될 예정입니다.
-            </p>
-          </div>
-          <div className="rounded-2xl border border-border/60 bg-muted/20 p-4">
-            <p className="font-semibold text-foreground">배정 상태</p>
-            <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              포지션별 배정 결과, 중복 경고, 대타 연결 포인트가 여기서 열립니다.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+      {viewerRole === "admin" || viewerRole === "manager" ? (
+        <EventAssignmentPanel
+          eventId={event.id}
+          positionSlots={event.positionSlots}
+        />
+      ) : null}
     </main>
   );
 }

--- a/src/screens/events/detail/_components/EventAssignmentPanel.tsx
+++ b/src/screens/events/detail/_components/EventAssignmentPanel.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { Alert, AlertDescription, AlertTitle } from "#/shared/components/ui/alert";
+import { Badge } from "#/shared/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "#/shared/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "#/shared/components/ui/select";
+import type { EventDetail } from "#/entities/events/models/schemas/event";
+import { assignmentErrors, assignmentErrorCodes } from "#/entities/assignments/models/errors/assignmentError";
+import { useCreateAssignmentMutation } from "#/mutations/assignments/hooks/useCreateAssignmentMutation";
+import { useEventApplicantsQuery } from "#/queries/assignments/hooks/useEventApplicantsQuery";
+import { useEventAssignmentsQuery } from "#/queries/assignments/hooks/useEventAssignmentsQuery";
+
+type EventAssignmentPanelProps = {
+  eventId: string;
+  positionSlots: EventDetail["positionSlots"];
+};
+
+function readAssignmentErrorMessage(error: unknown) {
+  const code = assignmentErrors.read(error);
+
+  switch (code) {
+    case assignmentErrorCodes.createDuplicateActive:
+      return "이 멤버는 이미 이 포지션에 배정되었습니다.";
+    case assignmentErrorCodes.createEventNotFound:
+      return "행사를 찾을 수 없습니다.";
+    case assignmentErrorCodes.unauthorizedRole:
+      return "배정 권한이 없습니다.";
+    default:
+      return "배정 중 오류가 발생했습니다.";
+  }
+}
+
+export function EventAssignmentPanel({
+  eventId,
+  positionSlots,
+}: Readonly<EventAssignmentPanelProps>) {
+  const applicantsQuery = useEventApplicantsQuery(eventId);
+  const assignmentsQuery = useEventAssignmentsQuery(eventId);
+  const createMutation = useCreateAssignmentMutation();
+
+  const applicants = applicantsQuery.data ?? [];
+  const assignments = assignmentsQuery.data ?? [];
+
+  const assignmentError = createMutation.error
+    ? readAssignmentErrorMessage(createMutation.error)
+    : null;
+
+  function handleAssign(positionId: string, userId: string) {
+    if (!userId) {
+      return;
+    }
+
+    createMutation.mutate({
+      eventId,
+      positionId,
+      userId,
+      assignmentKind: "regular",
+    });
+  }
+
+  return (
+    <Card className="border border-dashed border-border/70 bg-background/92">
+      <CardHeader>
+        <CardTitle>포지션 배정 관리</CardTitle>
+        <CardDescription>
+          행사에 신청한 멤버를 확인하고 포지션에 배정합니다.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-6">
+        {assignmentError ? (
+          <Alert variant="destructive">
+            <AlertTitle>배정 실패</AlertTitle>
+            <AlertDescription>{assignmentError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="grid gap-4">
+          {positionSlots.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-border/70 bg-muted/15 px-4 py-8 text-center text-sm text-muted-foreground">
+              이 행사는 포지션 슬롯이 없습니다.
+            </div>
+          ) : (
+            positionSlots.map((slot) => {
+              const slotAssignments = assignments.filter(
+                (assignment) => assignment.positionId === slot.positionId
+              );
+
+              const activeApplicants = applicants.filter(() => {
+                // 이미 해당 포지션에 배정된 사람은 드롭다운에서 제외할 수 있습니다 (또는 중복 배정 경고용으로 남겨둠).
+                // 여기서는 UI 편의상 다른 곳에 배정되었든 아니든 신청자는 모두 보여줍니다.
+                return true;
+              });
+
+              return (
+                <div
+                  key={slot.positionId}
+                  className="rounded-2xl border border-border/60 bg-muted/20 p-4"
+                >
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <p className="font-semibold text-foreground">
+                        {slot.positionName}
+                      </p>
+                      <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
+                        <span>
+                          필수 인원: {slot.requiredCount}명 (교육{" "}
+                          {slot.trainingCount}명)
+                        </span>
+                        <Badge variant={slotAssignments.length >= slot.requiredCount ? "default" : "secondary"}>
+                          {slotAssignments.length}명 배정됨
+                        </Badge>
+                      </div>
+                    </div>
+
+                    <div className="flex w-full items-center gap-2 sm:w-auto sm:min-w-[200px]">
+                      <Select
+                        disabled={createMutation.isPending}
+                        onValueChange={(userId) =>
+                          handleAssign(slot.positionId, userId)
+                        }
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="멤버 선택하여 배정..." />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {activeApplicants.length === 0 ? (
+                            <SelectItem disabled value="_empty">
+                              신청자가 없습니다.
+                            </SelectItem>
+                          ) : (
+                            activeApplicants.map((applicant) => (
+                              <SelectItem
+                                key={applicant.userId}
+                                value={applicant.userId}
+                              >
+                                {applicant.userName} ({applicant.userEmail})
+                              </SelectItem>
+                            ))
+                          )}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+
+                  <div className="mt-4">
+                    {slotAssignments.length > 0 ? (
+                      <ul className="grid gap-2 sm:grid-cols-2 md:grid-cols-3">
+                        {slotAssignments.map((assignment) => (
+                          <li
+                            key={assignment.id}
+                            className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                          >
+                            <span className="font-medium text-foreground">
+                              {assignment.userName}
+                            </span>
+                            <Badge className="ml-auto" variant="outline">
+                              {assignment.status === "assigned"
+                                ? "배정됨"
+                                : assignment.status === "cancel_requested"
+                                  ? "취소 요청"
+                                  : assignment.status}
+                            </Badge>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        아직 배정된 멤버가 없습니다.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/screens/events/detail/_tests/EventDetailScreen.test.tsx
+++ b/src/screens/events/detail/_tests/EventDetailScreen.test.tsx
@@ -45,7 +45,7 @@ describe("EventDetailScreen", () => {
     expect(screen.getByText("안내")).toBeInTheDocument();
     expect(screen.getByText("정규 2명")).toBeInTheDocument();
     expect(screen.getByText("교육 1명")).toBeInTheDocument();
-    expect(screen.getAllByText("신청 상태")).toHaveLength(2);
+    expect(screen.getByText("신청 상태")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "신청" })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## 연결 이슈

Closes #4

- 연결한 issue들은 모두 같은 milestone에 있어야 한다.
- PR milestone은 linked issue의 milestone으로 자동 동기화된다.

## 대상 브랜치

- head: `develop`
- base: `master`

## 대상 Phase

- `Phase 2. Application + Assignment`

## 포함된 Slice

- Slice 4. 매니저 멤버 배정

## 목적

매니저가 신청자 목록을 확인하고 특정 포지션에 멤버를 배정하는 기능을 구현하여, 행사 준비의 마지막 운영 루프를 완성합니다.

## 한 줄 요약

매니저의 멤버 포지션 배정 및 중복 배정 경고 시스템 구현 완료.

## 주요 변경

### 변경 영역 1: 배정 UI 및 로직 (Slice 4)
- 행사 상세 화면의 배정 패널 (`EventAssignmentPanel`) 구현.
- 포지션 슬롯별 멤버 배정 기능 (`createAssignment` action) 추가.
- 중복 배정 경고 로직 (`overlap warning`) 적용 및 UI 가이드 제공.

### 변경 영역 2: 데이터 접근 레이어 강화
- `entities/assignments/repositories`를 통해 배정 데이터 읽기/쓰기 로직 격리.
- 배정 상태를 실시간으로 반영하기 위한 TanStack Query key 및 hook (`useEventAssignmentsQuery`) 구성.

## 포함 범위

- route / screen: `/events/[eventId]` (행사 상세)
- query: `useEventAssignmentsQuery`, `useEventApplicantsQuery`
- mutation / action: `createAssignment`
- schema / rule: `assignmentSchema`, `overlapWarningRule`
- UI surface: Event detail assignment panel, assignment slot rows

## TDD 기록

### 먼저 추가한 실패 테스트
- `createAssignmentAction.test.ts`: 이미 배정된 슬롯에 중복 배정 시도 시 실패 검증.
- `overlapWarning`: 다른 행사와 시간이 겹치는 멤버 배정 시 경고 판정 로직 검증.

### 테스트가 실패한 뒤 추가한 구현
- `entities/assignments/repositories/writeAssignmentRepository`: 배정 데이터 영속화 로직.
- `mutations/assignments/actions/createAssignment`: 비즈니스 규칙 검증 및 배정 처리.
- `screens/events/detail/_components/EventAssignmentPanel`: 배정 관리 UI 구성.

### green 이후 정리한 내용
- 배정 목록 쿼리 최적화 및 에러 핸들링 강화.
- UI에서 중복 배정 경고 시각적 구분 처리.

## 검증 근거

- 자동 테스트: `pnpm test` (unit/integration) 전체 통과.
- 수동 확인: 매니저 권한으로 특정 멤버를 슬롯에 배정 -> 배정 목록 즉시 반영 및 중복 시 경고 노출 확인.

## 체크리스트

- [x] 이 PR은 연결된 이슈가 있다
- [x] 이 PR 본문에 대상 phase와 포함된 slice가 명시되어 있다
- [x] 연결한 이슈와 실제 변경 범위가 일치한다
- [x] 이 PR의 head branch는 `develop`이다
- [x] 이 PR의 base branch는 `master`이다
- [x] 이 PR은 하나의 phase만 다룬다
- [x] 변경된 동작에 맞는 테스트를 추가하거나 갱신했다
