### PR TITLE
[Harness] 실제 실행 run 기준 상태 표시 개선

### DIFF
--- a/.agents/harness/dashboard/data/runs.js
+++ b/.agents/harness/dashboard/data/runs.js
@@ -1,14 +1,230 @@
 window.AI_HARNESS_RUNS = {
-  "generated_at": "2026-05-11T05:35:56.581Z",
+  "generated_at": "2026-05-12T05:32:48.206Z",
   "summary": {
-    "issue_count": 1,
-    "average_issue_score": 89,
-    "pass_count": 1,
+    "issue_count": 2,
+    "average_issue_score": 92,
+    "pass_count": 2,
     "rework_count": 0,
     "fail_count": 0,
     "average_harness_score": 74
   },
   "runs": [
+    {
+      "issue_number": 45,
+      "title": "[Harness] 실제 실행 run 기준으로 상태 표시 개선",
+      "stage": "reviewed",
+      "decision": "PASS",
+      "total_score": 91,
+      "review_complete": true,
+      "data_quality_warnings": [],
+      "harness_score": null,
+      "priority": null,
+      "blocked": false,
+      "blockers": [],
+      "inbox_refs": [],
+      "dashboard_synced_at": null,
+      "attempt": 1,
+      "updated_at": "2026-05-12T05:50:00.000Z",
+      "strengths": [
+        "Template-only runs no longer appear as reviewed FAIL results.",
+        "Dashboard summary now distinguishes missing review data from real zero scores."
+      ],
+      "weaknesses": [
+        "Template detection is duplicated in two scripts.",
+        "No dedicated automated unit tests were added."
+      ],
+      "deductions": [
+        {
+          "category": "Requirement fulfillment",
+          "points": 1,
+          "reason": "Dashboard UI rendering was not updated; this issue focused on generated data and status output."
+        },
+        {
+          "category": "Implementation quality",
+          "points": 1,
+          "reason": "Template detection is duplicated between the two scripts instead of extracted to a shared module."
+        },
+        {
+          "category": "Verification sufficiency",
+          "points": 1,
+          "reason": "No separate automated unit test file was added."
+        },
+        {
+          "category": "Context usage",
+          "points": 2,
+          "reason": "The open PR #50 on develop means additional commits to develop may update that PR unless handled separately."
+        },
+        {
+          "category": "Handoff quality",
+          "points": 4,
+          "reason": "The issue-38 accidental local run remains as a known local cleanup item."
+        }
+      ],
+      "categories": [
+        {
+          "id": "requirement_fulfillment",
+          "label": "Requirement fulfillment",
+          "score": 24,
+          "max": 25
+        },
+        {
+          "id": "scope_control",
+          "label": "Scope control",
+          "score": 15,
+          "max": 15
+        },
+        {
+          "id": "implementation_quality",
+          "label": "Implementation quality",
+          "score": 14,
+          "max": 15
+        },
+        {
+          "id": "verification_sufficiency",
+          "label": "Verification sufficiency",
+          "score": 9,
+          "max": 10
+        },
+        {
+          "id": "risk_and_safety",
+          "label": "Risk and safety",
+          "score": 5,
+          "max": 5
+        },
+        {
+          "id": "requirement_interpretation",
+          "label": "Requirement interpretation",
+          "score": 10,
+          "max": 10
+        },
+        {
+          "id": "plan_appropriateness",
+          "label": "Plan appropriateness",
+          "score": 8,
+          "max": 8
+        },
+        {
+          "id": "context_usage",
+          "label": "Context usage",
+          "score": 4,
+          "max": 6
+        },
+        {
+          "id": "handoff_quality",
+          "label": "Handoff quality",
+          "score": 2,
+          "max": 6
+        }
+      ]
+    },
+    {
+      "issue_number": 44,
+      "title": "[Harness] Inbox 처리 정책 문서화",
+      "stage": "reviewed",
+      "decision": "PASS",
+      "total_score": 92,
+      "review_complete": true,
+      "data_quality_warnings": [],
+      "harness_score": null,
+      "priority": null,
+      "blocked": false,
+      "blockers": [],
+      "inbox_refs": [],
+      "dashboard_synced_at": null,
+      "attempt": 1,
+      "updated_at": "2026-05-12T05:30:00.000Z",
+      "strengths": [
+        "Clear central policy was added for inbox classification, PR-time handling, and removal.",
+        "Existing skills and workflow docs now point to the same policy instead of using loose wording."
+      ],
+      "weaknesses": [
+        "No automated enforcement exists yet.",
+        "A mistakenly started issue-38 run remains as local harness noise."
+      ],
+      "deductions": [
+        {
+          "category": "Requirement fulfillment",
+          "points": 1,
+          "reason": "No automated enforcement was added, matching scope but leaving compliance to skill execution."
+        },
+        {
+          "category": "Implementation quality",
+          "points": 1,
+          "reason": "The policy is English while several harness docs are Korean, which is acceptable but slightly mixed."
+        },
+        {
+          "category": "Verification sufficiency",
+          "points": 1,
+          "reason": "Build/test/lint were skipped because this is documentation-only."
+        },
+        {
+          "category": "Context usage",
+          "points": 2,
+          "reason": "An issue-38 run was accidentally started before the user redirected to #44; it was not modified after the redirect."
+        },
+        {
+          "category": "Handoff quality",
+          "points": 3,
+          "reason": "The accidental issue-38 run remains in the active run directory and may need separate cleanup."
+        }
+      ],
+      "categories": [
+        {
+          "id": "requirement_fulfillment",
+          "label": "Requirement fulfillment",
+          "score": 24,
+          "max": 25
+        },
+        {
+          "id": "scope_control",
+          "label": "Scope control",
+          "score": 15,
+          "max": 15
+        },
+        {
+          "id": "implementation_quality",
+          "label": "Implementation quality",
+          "score": 14,
+          "max": 15
+        },
+        {
+          "id": "verification_sufficiency",
+          "label": "Verification sufficiency",
+          "score": 9,
+          "max": 10
+        },
+        {
+          "id": "risk_and_safety",
+          "label": "Risk and safety",
+          "score": 5,
+          "max": 5
+        },
+        {
+          "id": "requirement_interpretation",
+          "label": "Requirement interpretation",
+          "score": 10,
+          "max": 10
+        },
+        {
+          "id": "plan_appropriateness",
+          "label": "Plan appropriateness",
+          "score": 8,
+          "max": 8
+        },
+        {
+          "id": "context_usage",
+          "label": "Context usage",
+          "score": 4,
+          "max": 6
+        },
+        {
+          "id": "handoff_quality",
+          "label": "Handoff quality",
+          "score": 3,
+          "max": 6
+        }
+      ]
+    },
     {
       "run_id": "issue-24",
       "issue_number": 24,

--- a/.agents/harness/dashboard/data/runs.js
+++ b/.agents/harness/dashboard/data/runs.js
@@ -1,12 +1,12 @@
 window.AI_HARNESS_RUNS = {
-  "generated_at": "2026-05-12T05:32:48.206Z",
+  "generated_at": "2026-05-12T05:43:54.119Z",
   "summary": {
     "issue_count": 2,
     "average_issue_score": 92,
     "pass_count": 2,
     "rework_count": 0,
     "fail_count": 0,
-    "average_harness_score": 74
+    "average_harness_score": null
   },
   "runs": [
     {
@@ -26,92 +26,92 @@ window.AI_HARNESS_RUNS = {
       "attempt": 1,
       "updated_at": "2026-05-12T05:50:00.000Z",
       "strengths": [
-        "Template-only runs no longer appear as reviewed FAIL results.",
-        "Dashboard summary now distinguishes missing review data from real zero scores."
+        "템플릿만 있는 run이 더 이상 reviewed FAIL 결과로 표시되지 않는다.",
+        "dashboard 요약이 누락된 review 데이터와 실제 0점을 구분한다."
       ],
       "weaknesses": [
-        "Template detection is duplicated in two scripts.",
-        "No dedicated automated unit tests were added."
+        "템플릿 판별 로직이 두 스크립트에 중복되어 있다.",
+        "전용 자동화 단위 테스트는 추가하지 않았다."
       ],
       "deductions": [
         {
-          "category": "Requirement fulfillment",
+          "category": "요구사항 충족",
           "points": 1,
-          "reason": "Dashboard UI rendering was not updated; this issue focused on generated data and status output."
+          "reason": "dashboard UI 전면 렌더링 개편은 하지 않았고, 이번 이슈는 생성 데이터와 status 출력 기준에 집중했다."
         },
         {
-          "category": "Implementation quality",
+          "category": "구현 품질",
           "points": 1,
-          "reason": "Template detection is duplicated between the two scripts instead of extracted to a shared module."
+          "reason": "템플릿 판별 로직이 공통 모듈로 분리되지 않고 두 스크립트에 중복되어 있다."
         },
         {
-          "category": "Verification sufficiency",
+          "category": "검증 충분성",
           "points": 1,
-          "reason": "No separate automated unit test file was added."
+          "reason": "별도 자동화 단위 테스트 파일은 추가하지 않았다."
         },
         {
-          "category": "Context usage",
+          "category": "컨텍스트 활용",
           "points": 2,
-          "reason": "The open PR #50 on develop means additional commits to develop may update that PR unless handled separately."
+          "reason": "작업 당시 develop 기반 PR #50이 열려 있어 추가 커밋이 같은 PR에 반영될 수 있는 상황이었다."
         },
         {
-          "category": "Handoff quality",
+          "category": "인수인계 품질",
           "points": 4,
-          "reason": "The issue-38 accidental local run remains as a known local cleanup item."
+          "reason": "실수로 생성된 issue-38 로컬 run은 별도 정리 항목으로 남아 있었다."
         }
       ],
       "categories": [
         {
           "id": "requirement_fulfillment",
-          "label": "Requirement fulfillment",
+          "label": "요구사항 충족",
           "score": 24,
           "max": 25
         },
         {
           "id": "scope_control",
-          "label": "Scope control",
+          "label": "범위 통제",
           "score": 15,
           "max": 15
         },
         {
           "id": "implementation_quality",
-          "label": "Implementation quality",
+          "label": "구현 품질",
           "score": 14,
           "max": 15
         },
         {
           "id": "verification_sufficiency",
-          "label": "Verification sufficiency",
+          "label": "검증 충분성",
           "score": 9,
           "max": 10
         },
         {
           "id": "risk_and_safety",
-          "label": "Risk and safety",
+          "label": "리스크와 안전",
           "score": 5,
           "max": 5
         },
         {
           "id": "requirement_interpretation",
-          "label": "Requirement interpretation",
+          "label": "요구사항 해석",
           "score": 10,
           "max": 10
         },
         {
           "id": "plan_appropriateness",
-          "label": "Plan appropriateness",
+          "label": "계획 적절성",
           "score": 8,
           "max": 8
         },
         {
           "id": "context_usage",
-          "label": "Context usage",
+          "label": "컨텍스트 활용",
           "score": 4,
           "max": 6
         },
         {
           "id": "handoff_quality",
-          "label": "Handoff quality",
+          "label": "인수인계 품질",
           "score": 2,
           "max": 6
         }
@@ -134,92 +134,92 @@ window.AI_HARNESS_RUNS = {
       "attempt": 1,
       "updated_at": "2026-05-12T05:30:00.000Z",
       "strengths": [
-        "Clear central policy was added for inbox classification, PR-time handling, and removal.",
-        "Existing skills and workflow docs now point to the same policy instead of using loose wording."
+        "inbox 분류, PR 전 처리, 제거 기준을 다루는 중앙 정책 문서가 추가됐다.",
+        "기존 스킬과 workflow 문서가 느슨한 표현 대신 같은 정책 문서를 참조하게 됐다."
       ],
       "weaknesses": [
-        "No automated enforcement exists yet.",
-        "A mistakenly started issue-38 run remains as local harness noise."
+        "아직 자동 강제 로직은 없다.",
+        "실수로 시작한 issue-38 run이 로컬 하네스 노이즈로 남아 있었다."
       ],
       "deductions": [
         {
-          "category": "Requirement fulfillment",
+          "category": "요구사항 충족",
           "points": 1,
-          "reason": "No automated enforcement was added, matching scope but leaving compliance to skill execution."
+          "reason": "이번 범위에 맞춰 자동 강제 로직은 추가하지 않았고, 준수 여부는 스킬 실행 단계에 남아 있다."
         },
         {
-          "category": "Implementation quality",
+          "category": "구현 품질",
           "points": 1,
-          "reason": "The policy is English while several harness docs are Korean, which is acceptable but slightly mixed."
+          "reason": "정책 문서 일부가 영어라 한글 하네스 문서와 언어가 섞여 있다."
         },
         {
-          "category": "Verification sufficiency",
+          "category": "검증 충분성",
           "points": 1,
-          "reason": "Build/test/lint were skipped because this is documentation-only."
+          "reason": "문서 변경만 포함하므로 build/test/lint는 생략했다."
         },
         {
-          "category": "Context usage",
+          "category": "컨텍스트 활용",
           "points": 2,
-          "reason": "An issue-38 run was accidentally started before the user redirected to #44; it was not modified after the redirect."
+          "reason": "사용자가 #44로 방향을 바꾸기 전에 issue-38 run을 실수로 시작했다."
         },
         {
-          "category": "Handoff quality",
+          "category": "인수인계 품질",
           "points": 3,
-          "reason": "The accidental issue-38 run remains in the active run directory and may need separate cleanup."
+          "reason": "실수로 생성된 issue-38 run은 별도 정리가 필요한 상태로 남아 있었다."
         }
       ],
       "categories": [
         {
           "id": "requirement_fulfillment",
-          "label": "Requirement fulfillment",
+          "label": "요구사항 충족",
           "score": 24,
           "max": 25
         },
         {
           "id": "scope_control",
-          "label": "Scope control",
+          "label": "범위 통제",
           "score": 15,
           "max": 15
         },
         {
           "id": "implementation_quality",
-          "label": "Implementation quality",
+          "label": "구현 품질",
           "score": 14,
           "max": 15
         },
         {
           "id": "verification_sufficiency",
-          "label": "Verification sufficiency",
+          "label": "검증 충분성",
           "score": 9,
           "max": 10
         },
         {
           "id": "risk_and_safety",
-          "label": "Risk and safety",
+          "label": "리스크와 안전",
           "score": 5,
           "max": 5
         },
         {
           "id": "requirement_interpretation",
-          "label": "Requirement interpretation",
+          "label": "요구사항 해석",
           "score": 10,
           "max": 10
         },
         {
           "id": "plan_appropriateness",
-          "label": "Plan appropriateness",
+          "label": "계획 적절성",
           "score": 8,
           "max": 8
         },
         {
           "id": "context_usage",
-          "label": "Context usage",
+          "label": "컨텍스트 활용",
           "score": 4,
           "max": 6
         },
         {
           "id": "handoff_quality",
-          "label": "Handoff quality",
+          "label": "인수인계 품질",
           "score": 3,
           "max": 6
         }
@@ -248,22 +248,22 @@ window.AI_HARNESS_RUNS = {
       "weaknesses": [],
       "deductions": [
         {
-          "category": "result_quality",
+          "category": "결과 품질",
           "points": 8,
           "reason": "Next.js build 경고가 남아 후속 정리가 가능하다."
         },
         {
-          "category": "result_quality",
+          "category": "결과 품질",
           "points": 8,
           "reason": "db:status는 Docker 없는 환경에서 상태 메시지로 흡수하는 방식이라 실제 스택 점검은 환경 의존적이다."
         },
         {
-          "category": "process_quality",
+          "category": "프로세스 품질",
           "points": 3,
           "reason": "초기 설치에서 TLS 인증서 문제를 우회해야 했다."
         },
         {
-          "category": "process_quality",
+          "category": "프로세스 품질",
           "points": 3,
           "reason": "검증 과정에서 환경 의존 경고와 경로 조정이 있었다."
         }
@@ -271,13 +271,13 @@ window.AI_HARNESS_RUNS = {
       "categories": [
         {
           "id": "result_quality",
-          "label": "result_quality",
+          "label": "결과 품질",
           "score": 62,
           "max": 70
         },
         {
           "id": "process_quality",
-          "label": "process_quality",
+          "label": "프로세스 품질",
           "score": 27,
           "max": 30
         }
@@ -373,92 +373,16 @@ window.AI_HARNESS_RUNS = {
     }
   ],
   "harness_health": {
-    "total_score": 74,
-    "categories": [
-      {
-        "label": "Task spec quality",
-        "score": 17,
-        "max": 20,
-        "evidence": [
-          "task-spec.md가 목표, 범위, 제외 범위, 검증 방법, 완료 기준, 리스크를 실행 가능한 수준으로 정리했다.",
-          "첫 스캐폴드 작업임에도 제품 기능 제외 범위가 명확했다."
-        ],
-        "deductions": [
-          "초기 완료 기준에 대시보드 갱신과 CI/커밋 정책의 세부 성공 조건이 충분히 구체화되지는 않았다."
-        ]
-      },
-      {
-        "label": "Context injection quality",
-        "score": 15,
-        "max": 20,
-        "evidence": [
-          "GitHub Issue, task-spec, plan, spec가 구현 단계에 필요한 기본 맥락을 제공했다.",
-          "사전 결정 사항은 이후 spec/status 스킬 보강으로 더 명확해졌다."
-        ],
-        "deductions": [
-          "초기 실행 당시 폴더 구조, 네이밍, CI 범위 같은 결정 항목을 자동으로 질문 큐화하는 절차가 약했다.",
-          "작업 중 추가 항목과 inbox 연결 규칙은 실행 이후에 보강됐다."
-        ]
-      },
-      {
-        "label": "Role handoff quality",
-        "score": 12,
-        "max": 15,
-        "evidence": [
-          "Red, Green, Verify, Review 산출물이 순서대로 남아 있고 Reviewer가 PASS 결정을 내렸다.",
-          "Green 이후 Verify 대응 리워크가 implementation-notes.md에 기록됐다."
-        ],
-        "deductions": [
-          "verification.md 안에 중간 FAIL/PARTIAL 매핑과 최종 PASS 요약이 함께 남아 있어 후속 독자가 최종 상태를 빠르게 판단하기 어렵다."
-        ]
-      },
-      {
-        "label": "Verification gate quality",
-        "score": 13,
-        "max": 20,
-        "evidence": [
-          "lint, format, typecheck, test, build, db:status, commitlint 샘플을 실행했고 최종 PASS 기록이 있다.",
-          "PR 브랜치에서 CI 실패 원인을 확인해 commitlint revision range 문제를 제거했다."
-        ],
-        "deductions": [
-          "초기 PR CI가 commitlint revision range 문제로 실패해 로컬 검증과 CI 검증 사이의 차이를 사전에 잡지 못했다.",
-          "Windows 줄끝과 Prettier check 불일치도 PR 브랜치에서 뒤늦게 발견됐다.",
-          "db:status는 실제 Supabase 스택 상태가 아니라 wrapper 메시지 성공이라 검증 강도가 낮다."
-        ]
-      },
-      {
-        "label": "Scoring rubric quality",
-        "score": 12,
-        "max": 15,
-        "evidence": [
-          "review-score.json이 result_quality와 process_quality를 분리하고 감점 사유를 남겼다.",
-          "PASS/REWORK/FAIL 기준은 명확하게 적용됐다."
-        ],
-        "deductions": [
-          "단일 실행 기준이라 반복 패턴을 판단하기 어렵고, CI 사후 실패가 리뷰 점수에 충분히 반영되지 않았다."
-        ]
-      },
-      {
-        "label": "Record and dashboard quality",
-        "score": 5,
-        "max": 10,
-        "evidence": [
-          "대시보드 데이터는 issue-24 PASS와 89점을 표시하도록 갱신됐다.",
-          "닫힌 issue-23 실행 산출물은 제거됐다."
-        ],
-        "deductions": [
-          "하네스 건강도 산출물이 없을 때 대시보드가 0점으로만 표시해 누락인지 실제 0점인지 구분하기 어렵다.",
-          "대시보드 갱신 단계가 건강도 산출물 부재를 먼저 보고하지 않았다."
-        ]
-      }
-    ],
+    "total_score": null,
+    "missing": true,
+    "categories": [],
     "proposals": [
       {
         "proposal_id": "2026-05-10-dashboard-health-missing-state",
         "target_area": "record_dashboard",
         "title": "2026-05-10-dashboard-health-missing-state",
-        "reason": "When harness-health-score.json is missing, dashboard data can show average_harness_score or harness_health.total_score as 0. That makes a missing evaluation hard to distinguish from a real zero score.",
-        "expected_impact": "Users can detect missing harness-health evaluation early and avoid mistaking missing data for a valid score.",
+        "reason": "harness-health-score.json이 없을 때 dashboard data가 average_harness_score 또는 harness_health.total_score를 0처럼 표시할 수 있다. 그러면 평가 누락과 실제 0점을 구분하기 어렵다.",
+        "expected_impact": "사용자가 하네스 건강도 평가 누락을 빠르게 알아차리고, 누락 데이터를 유효 점수로 오해하지 않는다.",
         "status": "proposed",
         "file": ".agents/harness/improvements/proposals/2026-05-10-dashboard-health-missing-state.json"
       },
@@ -466,8 +390,8 @@ window.AI_HARNESS_RUNS = {
         "proposal_id": "2026-05-10-verification-ci-parity",
         "target_area": "verification_gate",
         "title": "2026-05-10-verification-ci-parity",
-        "reason": "Issue #24 passed local verification, but PR-time CI still exposed configuration problems such as commitlint revision range handling and formatting differences. The verification step did not clearly separate local command results from PR CI readiness.",
-        "expected_impact": "PRs are more likely to be ready to merge immediately after review because CI-only failures are considered before PR creation.",
+        "reason": "Issue #24는 로컬 검증을 통과했지만 PR 시점 CI에서 commitlint revision range 처리와 포맷 차이 같은 설정 문제가 드러났다. 검증 단계가 로컬 명령 결과와 PR CI 준비 상태를 명확히 분리하지 못했다.",
+        "expected_impact": "PR 생성 전에 CI 전용 실패 가능성을 고려하므로 리뷰 직후 머지 가능한 PR 비율이 높아진다.",
         "status": "proposed",
         "file": ".agents/harness/improvements/proposals/2026-05-10-verification-ci-parity.json"
       }
@@ -477,101 +401,101 @@ window.AI_HARNESS_RUNS = {
     {
       "name": "Planner",
       "file": ".agents/harness/agents/planner.agent.md",
-      "purpose": "Convert a GitHub Issue into task-spec.md and plan.md.",
+      "purpose": "GitHub Issue를 task-spec.md와 plan.md로 변환한다.",
       "outputs": [
         "task-spec.md",
         "plan.md"
       ],
-      "handoff": "Pass a concrete task spec and plan to implementation."
+      "handoff": "구체화된 작업 명세와 계획을 구현 단계로 넘긴다."
     },
     {
       "name": "Spec",
       "file": ".agents/skills/ai-harness-spec/SKILL.md",
-      "purpose": "Clarify decisions and write spec.md before implementation.",
+      "purpose": "구현 전에 미확정 결정을 정리하고 spec.md를 작성한다.",
       "outputs": [
         "spec.md"
       ],
-      "handoff": "Pass detailed scenarios and Red priorities to Red."
+      "handoff": "상세 시나리오와 Red 우선순위를 Red 단계로 넘긴다."
     },
     {
       "name": "Implementer",
       "file": ".agents/harness/agents/implementer.agent.md",
-      "purpose": "Implement code or configuration changes.",
+      "purpose": "코드 또는 설정 변경을 구현한다.",
       "outputs": [
         "implementation-notes.md"
       ],
-      "handoff": "Pass changed files and notes to verification."
+      "handoff": "변경 파일과 구현 기록을 검증 단계로 넘긴다."
     },
     {
       "name": "Verifier",
       "file": ".agents/harness/agents/verifier.agent.md",
-      "purpose": "Run verification commands and record evidence.",
+      "purpose": "검증 명령을 실행하고 근거를 기록한다.",
       "outputs": [
         "verification.md"
       ],
-      "handoff": "Pass verification evidence and diff context to review."
+      "handoff": "검증 근거와 diff 맥락을 리뷰 단계로 넘긴다."
     },
     {
       "name": "Reviewer",
       "file": ".agents/harness/agents/reviewer.agent.md",
-      "purpose": "Score the run and decide PASS, REWORK, or FAIL.",
+      "purpose": "실행 결과를 채점하고 PASS, REWORK, FAIL을 결정한다.",
       "outputs": [
         "review-score.json",
         "review.md"
       ],
-      "handoff": "PASS goes to PR, REWORK returns to implementation, FAIL waits for human review."
+      "handoff": "PASS는 PR 단계로, REWORK는 구현 재작업으로, FAIL은 사람 확인으로 넘긴다."
     },
     {
       "name": "Harness Evaluator",
       "file": ".agents/harness/agents/harness-evaluator.agent.md",
-      "purpose": "Evaluate harness health and propose improvements.",
+      "purpose": "하네스 건강도를 평가하고 개선안을 제안한다.",
       "outputs": [
         "harness-health-score.json",
         "harness-improvements.md"
       ],
-      "handoff": "Approved improvements are implemented separately."
+      "handoff": "승인된 개선안은 별도 작업으로 구현한다."
     }
   ],
   "workflow": [
     {
       "step": "1",
       "name": "Planner",
-      "status": "Create task-spec.md and plan.md"
+      "status": "task-spec.md와 plan.md 작성"
     },
     {
       "step": "2",
       "name": "Spec",
-      "status": "Create spec.md and Red priorities"
+      "status": "spec.md와 Red 우선순위 작성"
     },
     {
       "step": "3",
       "name": "Red",
-      "status": "Write or record failing tests"
+      "status": "실패 테스트를 작성하거나 실패 근거 기록"
     },
     {
       "step": "4",
       "name": "Green",
-      "status": "Implement the minimum passing change"
+      "status": "통과에 필요한 최소 변경 구현"
     },
     {
       "step": "5",
       "name": "Verify",
-      "status": "Run verification and write verification.md"
+      "status": "검증 실행 후 verification.md 작성"
     },
     {
       "step": "6",
       "name": "Review",
-      "status": "Score and decide PASS, REWORK, or FAIL"
+      "status": "점수 산정 후 PASS, REWORK, FAIL 결정"
     },
     {
       "step": "7",
       "name": "Dashboard",
-      "status": "Project run state into dashboard data"
+      "status": "run 상태를 dashboard data로 변환"
     },
     {
       "step": "8",
       "name": "PR",
-      "status": "Draft a PR only for PASS runs"
+      "status": "PASS run만 PR로 정리"
     }
   ]
 };

--- a/.agents/harness/dashboard/data/runs.js
+++ b/.agents/harness/dashboard/data/runs.js
@@ -1,12 +1,12 @@
 window.AI_HARNESS_RUNS = {
-  "generated_at": "2026-05-12T05:43:54.119Z",
+  "generated_at": "2026-05-12T05:47:02.560Z",
   "summary": {
     "issue_count": 2,
     "average_issue_score": 92,
     "pass_count": 2,
     "rework_count": 0,
     "fail_count": 0,
-    "average_harness_score": null
+    "average_harness_score": 82
   },
   "runs": [
     {
@@ -17,14 +17,14 @@ window.AI_HARNESS_RUNS = {
       "total_score": 91,
       "review_complete": true,
       "data_quality_warnings": [],
-      "harness_score": null,
+      "harness_score": 82,
       "priority": null,
       "blocked": false,
       "blockers": [],
       "inbox_refs": [],
       "dashboard_synced_at": null,
       "attempt": 1,
-      "updated_at": "2026-05-12T05:50:00.000Z",
+      "updated_at": "2026-05-12T05:55:00.000Z",
       "strengths": [
         "템플릿만 있는 run이 더 이상 reviewed FAIL 결과로 표시되지 않는다.",
         "dashboard 요약이 누락된 review 데이터와 실제 0점을 구분한다."
@@ -373,9 +373,82 @@ window.AI_HARNESS_RUNS = {
     }
   ],
   "harness_health": {
-    "total_score": null,
-    "missing": true,
-    "categories": [],
+    "total_score": 82,
+    "categories": [
+      {
+        "label": "작업 명세 품질",
+        "score": 18,
+        "max": 20,
+        "evidence": [
+          "#45는 dashboard/status/review 표시 기준의 문제를 명확히 제기했고, 실제 템플릿 run과 작성된 run을 구분하는 완료 기준으로 구체화됐다.",
+          "Red 단계에서 false reviewed/FAIL 문제를 재현하도록 작업 명세와 스펙이 이어졌다."
+        ],
+        "deductions": [
+          "초기 이슈 본문에는 dashboard, status, review 중 어느 범위까지 포함할지 확인 필요가 남아 있어 계획 단계에서 범위를 확정해야 했다."
+        ]
+      },
+      {
+        "label": "컨텍스트 주입 품질",
+        "score": 17,
+        "max": 20,
+        "evidence": [
+          "기존 start-issue 템플릿, #38 accidental run, #44 PASS run, dashboard data를 함께 사용해 재현 조건을 잡았다.",
+          "과거 archived #24의 harness health 점수가 현재 평균처럼 보이는 문제도 후속 보정에서 확인됐다."
+        ],
+        "deductions": [
+          "열린 PR #50과 develop 브랜치 상태가 실행 도중 혼재되어 PR 반영 전략을 다시 조정해야 했다."
+        ]
+      },
+      {
+        "label": "역할 분리와 인수인계 품질",
+        "score": 12,
+        "max": 15,
+        "evidence": [
+          "task-spec, plan, spec, implementation-notes, verification, review가 모두 남아 있고 #45 PASS 판단으로 이어졌다.",
+          "사용자 피드백 이후 dashboard 문구와 하네스 점수 표시 보정도 verification에 추가 기록됐다."
+        ],
+        "deductions": [
+          "하네스 평가 단계가 PR 생성 이후 사용자 지적을 받은 뒤 수행되어 순서가 매끄럽지 않았다."
+        ]
+      },
+      {
+        "label": "검증 게이트 품질",
+        "score": 14,
+        "max": 20,
+        "evidence": [
+          "diagnose-status, build-dashboard-data, validate-score를 실행해 템플릿 false FAIL과 dashboard 집계 개선을 확인했다.",
+          "dashboard data에서 평균 실행 점수와 하네스 평균의 null 처리까지 확인했다."
+        ],
+        "deductions": [
+          "템플릿 판별과 dashboard summary 기준을 검증하는 별도 자동 테스트가 없어 회귀 방지가 약하다.",
+          "dashboard 문구 언어 문제와 하네스 평균 이상 표시를 첫 검증 단계에서 잡지 못했다."
+        ]
+      },
+      {
+        "label": "스코어링 루브릭 품질",
+        "score": 12,
+        "max": 15,
+        "evidence": [
+          "issue execution 점수는 91점 PASS로 산출됐고, template-only run과 review-missing run의 차이를 리뷰 근거에 반영했다.",
+          "감점 사유가 템플릿 판별 중복과 테스트 부재로 구체화됐다."
+        ],
+        "deductions": [
+          "하네스 건강도 평가는 사용자 지적 전에는 누락되어 PR 본문과 dashboard에 처음부터 포함되지 않았다."
+        ]
+      },
+      {
+        "label": "기록과 대시보드 품질",
+        "score": 9,
+        "max": 10,
+        "evidence": [
+          "dashboard data가 review 완료 run만 집계하고, 활성 harness health가 없으면 평가 없음으로 표시하도록 개선됐다.",
+          "리뷰 근거, 감점 사유, 카테고리 라벨, 개선 제안, agent/workflow 설명이 한글로 정리됐다."
+        ],
+        "deductions": [
+          "dashboard UI 자체의 데이터 품질 경고 시각화는 아직 제한적이다."
+        ]
+      }
+    ],
     "proposals": [
       {
         "proposal_id": "2026-05-10-dashboard-health-missing-state",
@@ -394,6 +467,15 @@ window.AI_HARNESS_RUNS = {
         "expected_impact": "PR 생성 전에 CI 전용 실패 가능성을 고려하므로 리뷰 직후 머지 가능한 PR 비율이 높아진다.",
         "status": "proposed",
         "file": ".agents/harness/improvements/proposals/2026-05-10-verification-ci-parity.json"
+      },
+      {
+        "proposal_id": "2026-05-12-template-artifact-regression-tests",
+        "target_area": "verification_gate",
+        "title": "2026-05-12-template-artifact-regression-tests",
+        "reason": "템플릿 판별 로직이 diagnose-status와 build-dashboard-data에 중복되어 있고, 자동 테스트가 없어 빈 템플릿을 다시 FAIL로 집계하는 회귀를 놓칠 수 있다.",
+        "expected_impact": "dashboard/status가 누락 데이터와 실제 실패를 안정적으로 구분하고, 후속 템플릿 변경에도 회귀를 빨리 잡을 수 있다.",
+        "status": "proposed",
+        "file": ".agents/harness/improvements/proposals/2026-05-12-template-artifact-regression-tests.json"
       }
     ]
   },

--- a/.agents/harness/dashboard/index.html
+++ b/.agents/harness/dashboard/index.html
@@ -440,6 +440,8 @@
 
       const decisionClass = (decision) => decision.toLowerCase();
       const percent = (score, max) => Math.round((score / max) * 100);
+      const scoreText = (score) => score === null || score === undefined ? "평가 없음" : score;
+      const scorePercent = (score) => score === null || score === undefined ? 0 : score;
       const fmtDate = (value) => new Intl.DateTimeFormat("ko-KR", {
         dateStyle: "medium",
         timeStyle: "short"
@@ -458,7 +460,7 @@
         document.querySelector("#summaryCards").innerHTML = cards.map(([label, value]) => `
           <div class="panel metric">
             <span class="subtle">${label}</span>
-            <span class="value">${value}</span>
+            <span class="value">${scoreText(value)}</span>
           </div>
         `).join("");
       }
@@ -482,12 +484,12 @@
             </td>
             <td><span class="badge ${decisionClass(run.decision)}">${run.decision}</span></td>
             <td>
-              <span class="score">${run.total_score}</span> / 100
-              <div class="bar" aria-hidden="true"><span style="width:${run.total_score}%"></span></div>
+              <span class="score">${scoreText(run.total_score)}</span>${run.total_score === null || run.total_score === undefined ? "" : " / 100"}
+              <div class="bar" aria-hidden="true"><span style="width:${scorePercent(run.total_score)}%"></span></div>
             </td>
             <td>
-              <span class="score">${run.harness_score}</span> / 100
-              <div class="bar" aria-hidden="true"><span style="width:${run.harness_score}%"></span></div>
+              <span class="score">${scoreText(run.harness_score)}</span>${run.harness_score === null || run.harness_score === undefined ? "" : " / 100"}
+              <div class="bar" aria-hidden="true"><span style="width:${scorePercent(run.harness_score)}%"></span></div>
             </td>
             <td>${run.attempt}</td>
             <td>${run.deductions.slice(0, 2).map((item) => item.reason).join("<br>")}</td>
@@ -574,7 +576,7 @@
         const harnessCategories = data.harness_health.categories || [];
         const proposals = data.harness_health.proposals || [];
         document.querySelector("#harnessHealth").innerHTML = `
-          <div class="score" style="font-size:32px;margin-bottom:14px;">${data.harness_health.total_score} / 100</div>
+          <div class="score" style="font-size:32px;margin-bottom:14px;">${scoreText(data.harness_health.total_score)}${data.harness_health.total_score === null || data.harness_health.total_score === undefined ? "" : " / 100"}</div>
           ${harnessCategories.length ? harnessCategories.map((item) => `
             <details class="category-detail">
               <summary class="category-row">

--- a/.agents/harness/improvements/proposals/2026-05-10-dashboard-health-missing-state.json
+++ b/.agents/harness/improvements/proposals/2026-05-10-dashboard-health-missing-state.json
@@ -6,10 +6,10 @@
     "harness_health_score_id": "issue-24-harness-health"
   },
   "target_area": "record_dashboard",
-  "problem": "When harness-health-score.json is missing, dashboard data can show average_harness_score or harness_health.total_score as 0. That makes a missing evaluation hard to distinguish from a real zero score.",
-  "proposal": "Record a separate missing state when harness health artifacts are absent. The dashboard step should report missing health artifacts and suggest ai-harness-evaluate. The UI should display missing or not evaluated instead of treating the value as a real score.",
-  "expected_impact": "Users can detect missing harness-health evaluation early and avoid mistaking missing data for a valid score.",
-  "risk": "Dashboard consumers may need to handle a new missing-state field instead of assuming numeric scores are always present.",
+  "problem": "harness-health-score.json이 없을 때 dashboard data가 average_harness_score 또는 harness_health.total_score를 0처럼 표시할 수 있다. 그러면 평가 누락과 실제 0점을 구분하기 어렵다.",
+  "proposal": "하네스 건강도 산출물이 없으면 별도 missing 상태를 기록한다. dashboard 단계는 누락된 건강도 산출물을 보고하고 ai-harness-evaluate를 제안해야 한다. UI는 값을 실제 점수로 취급하지 말고 누락 또는 미평가로 표시해야 한다.",
+  "expected_impact": "사용자가 하네스 건강도 평가 누락을 빠르게 알아차리고, 누락 데이터를 유효 점수로 오해하지 않는다.",
+  "risk": "dashboard 소비자는 점수가 항상 숫자라고 가정하지 않고 새로운 missing 상태를 처리해야 할 수 있다.",
   "status": "proposed",
   "created_at": "2026-05-10T00:00:00.000Z",
   "decided_at": null

--- a/.agents/harness/improvements/proposals/2026-05-10-verification-ci-parity.json
+++ b/.agents/harness/improvements/proposals/2026-05-10-verification-ci-parity.json
@@ -6,10 +6,10 @@
     "harness_health_score_id": "issue-24-harness-health"
   },
   "target_area": "verification_gate",
-  "problem": "Issue #24 passed local verification, but PR-time CI still exposed configuration problems such as commitlint revision range handling and formatting differences. The verification step did not clearly separate local command results from PR CI readiness.",
-  "proposal": "Require verification notes to record local command results and PR CI assumptions separately. Add checklist coverage for checkout depth, base/head revision availability, commitlint fallback behavior, and line-ending or formatting differences between local Windows checkout and CI.",
-  "expected_impact": "PRs are more likely to be ready to merge immediately after review because CI-only failures are considered before PR creation.",
-  "risk": "The verification step can become too heavy if one early CI issue is generalized into broad mandatory checks. Keep the checklist focused on known CI parity risks.",
+  "problem": "Issue #24는 로컬 검증을 통과했지만 PR 시점 CI에서 commitlint revision range 처리와 포맷 차이 같은 설정 문제가 드러났다. 검증 단계가 로컬 명령 결과와 PR CI 준비 상태를 명확히 분리하지 못했다.",
+  "proposal": "verification 기록에 로컬 명령 결과와 PR CI 가정을 분리해 남기도록 한다. checkout depth, base/head revision 사용 가능 여부, commitlint fallback 동작, 로컬 Windows checkout과 CI 사이의 줄끝/포맷 차이를 체크리스트에 포함한다.",
+  "expected_impact": "PR 생성 전에 CI 전용 실패 가능성을 고려하므로 리뷰 직후 머지 가능한 PR 비율이 높아진다.",
+  "risk": "초기 CI 문제 하나를 지나치게 일반화하면 검증 단계가 무거워질 수 있다. 체크리스트는 알려진 CI parity 리스크에 집중해야 한다.",
   "status": "proposed",
   "created_at": "2026-05-10T00:00:00.000Z",
   "decided_at": null

--- a/.agents/harness/improvements/proposals/2026-05-12-template-artifact-regression-tests.json
+++ b/.agents/harness/improvements/proposals/2026-05-12-template-artifact-regression-tests.json
@@ -1,0 +1,16 @@
+{
+  "proposal_id": "2026-05-12-template-artifact-regression-tests",
+  "source": {
+    "run_id": "issue-45",
+    "issue_number": 45,
+    "harness_health_score_id": "issue-45-harness-health"
+  },
+  "target_area": "verification_gate",
+  "problem": "템플릿 판별 로직이 diagnose-status와 build-dashboard-data에 중복되어 있고, 자동 테스트가 없어 빈 템플릿을 다시 FAIL로 집계하는 회귀를 놓칠 수 있다.",
+  "proposal": "새 run 템플릿, 실제 PASS review, 실제 0점 FAIL review fixture를 만들어 diagnose-status와 build-dashboard-data의 판별 결과를 자동 검증한다. 가능하면 템플릿 판별 헬퍼를 공통 모듈로 분리한다.",
+  "expected_impact": "dashboard/status가 누락 데이터와 실제 실패를 안정적으로 구분하고, 후속 템플릿 변경에도 회귀를 빨리 잡을 수 있다.",
+  "risk": "fixture 기반 테스트가 실제 run 파일 구조 변경을 따라가지 못하면 유지보수 비용이 생길 수 있다.",
+  "status": "proposed",
+  "created_at": "2026-05-12T05:55:00.000Z",
+  "decided_at": null
+}

--- a/.agents/harness/scripts/build-dashboard-data.mjs
+++ b/.agents/harness/scripts/build-dashboard-data.mjs
@@ -24,6 +24,45 @@ function safeReadScore(runDir, artifactPath) {
   return safeReadJson(join(runDir, artifactPath));
 }
 
+function readText(path) {
+  return readFileSync(path, "utf8");
+}
+
+function isMarkdownTemplate(path) {
+  if (!existsSync(path)) return true;
+  const text = readText(path).trim();
+  const placeholderLines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line === "작성 필요." || line === "- 작성 필요.");
+  return !text || placeholderLines.length > 0;
+}
+
+function isReviewScoreTemplate(score) {
+  if (!score) return true;
+
+  const hasEvidence = (score.categories || []).some(
+    (category) => (category.evidence || []).length > 0 || (category.deductions || []).length > 0
+  );
+
+  return (
+    score.score_id === "issue-000-review-attempt-1" ||
+    score.scored_at === "1970-01-01T00:00:00.000Z" ||
+    String(score.recommended_next_action || "").includes("작성 필요") ||
+    (score.decision === "FAIL" && score.total_score === 0 && !hasEvidence)
+  );
+}
+
+function completeReviewScore(runDir, artifactPath) {
+  const score = safeReadScore(runDir, artifactPath);
+  return isReviewScoreTemplate(score) ? null : score;
+}
+
+function artifactComplete(runDir, artifactPath) {
+  if (!artifactPath) return false;
+  return !isMarkdownTemplate(join(runDir, artifactPath));
+}
+
 function readImprovementProposals() {
   if (!existsSync(proposalsRoot)) return [];
 
@@ -71,15 +110,15 @@ function decisionFromStatus(status, score, state) {
   if (status === "pass" || status === "draft_pr_created") return "PASS";
   if (status === "rework") return "REWORK";
   if (status === "fail") return "FAIL";
-  return "FAIL";
+  return null;
 }
 
-function stageFromArtifacts(runDir) {
-  if (existsSync(join(runDir, "review-score.json")) && existsSync(join(runDir, "review.md"))) return "reviewed";
-  if (existsSync(join(runDir, "verification.md"))) return "verified";
-  if (existsSync(join(runDir, "implementation-notes.md"))) return "green";
-  if (existsSync(join(runDir, "spec.md"))) return "specified";
-  if (existsSync(join(runDir, "task-spec.md")) && existsSync(join(runDir, "plan.md"))) return "planned";
+function stageFromArtifacts(runDir, record, reviewScore) {
+  if (reviewScore && artifactComplete(runDir, record.artifacts?.review)) return "reviewed";
+  if (artifactComplete(runDir, record.artifacts?.verification)) return "verified";
+  if (artifactComplete(runDir, record.artifacts?.implementation_notes)) return "green";
+  if (artifactComplete(runDir, record.artifacts?.spec)) return "specified";
+  if (artifactComplete(runDir, record.artifacts?.task_spec) && artifactComplete(runDir, record.artifacts?.plan)) return "planned";
   return "unplanned";
 }
 
@@ -99,7 +138,7 @@ for (const runDir of runDirs) {
 
   const record = readJson(runRecordPath);
   const state = safeReadJson(join(runDir, "state.json"));
-  const reviewScore = safeReadScore(runDir, record.artifacts?.review_score);
+  const reviewScore = completeReviewScore(runDir, record.artifacts?.review_score);
   const harnessScore = safeReadScore(
     runDir,
     record.artifacts?.harness_health_score || "harness-health-score.json"
@@ -122,12 +161,23 @@ for (const runDir of runDirs) {
     }))
   );
 
+  const inferredStage = stageFromArtifacts(runDir, record, reviewScore);
+  if (inferredStage === "unplanned") continue;
+
+  const dataQualityWarnings = [];
+  if (!reviewScore) dataQualityWarnings.push("review score is missing or still an unfilled template");
+  if (record.artifacts?.review && isMarkdownTemplate(join(runDir, record.artifacts.review))) {
+    dataQualityWarnings.push("review artifact is missing or still an unfilled template");
+  }
+
   runs.push({
     issue_number: record.issue.number,
     title: record.issue.title,
-    stage: state?.stage || stageFromArtifacts(runDir),
+    stage: state?.stage || inferredStage,
     decision: decisionFromStatus(record.status, reviewScore, state),
-    total_score: reviewScore?.total_score ?? 0,
+    total_score: reviewScore?.total_score ?? null,
+    review_complete: Boolean(reviewScore),
+    data_quality_warnings: dataQualityWarnings,
     harness_score: harnessScore?.total_score ?? null,
     priority: state?.priority ?? null,
     blocked: state?.blocked ?? false,
@@ -159,14 +209,15 @@ for (const historicalRun of history.runs || []) {
 
 runs.sort((a, b) => b.issue_number - a.issue_number);
 
-const issueCount = runs.length;
+const scoredRuns = runs.filter((run) => run.review_complete);
+const issueCount = scoredRuns.length;
 const proposals = readImprovementProposals();
-const passCount = runs.filter((run) => run.decision === "PASS").length;
-const reworkCount = runs.filter((run) => run.decision === "REWORK").length;
-const failCount = runs.filter((run) => run.decision === "FAIL").length;
+const passCount = scoredRuns.filter((run) => run.decision === "PASS").length;
+const reworkCount = scoredRuns.filter((run) => run.decision === "REWORK").length;
+const failCount = scoredRuns.filter((run) => run.decision === "FAIL").length;
 const averageIssueScore = issueCount
-  ? Math.round(runs.reduce((sum, run) => sum + run.total_score, 0) / issueCount)
-  : 0;
+  ? Math.round(scoredRuns.reduce((sum, run) => sum + run.total_score, 0) / issueCount)
+  : null;
 const averageHarnessScore = harnessScores.length
   ? Math.round(harnessScores.reduce((sum, score) => sum + score.total_score, 0) / harnessScores.length)
   : null;

--- a/.agents/harness/scripts/build-dashboard-data.mjs
+++ b/.agents/harness/scripts/build-dashboard-data.mjs
@@ -85,21 +85,23 @@ function readImprovementProposals() {
 
 function labelForCategory(id) {
   const labels = {
-    requirement_fulfillment: "Requirement fulfillment",
-    scope_control: "Scope control",
-    implementation_quality: "Implementation quality",
-    verification_sufficiency: "Verification sufficiency",
-    risk_and_safety: "Risk and safety",
-    requirement_interpretation: "Requirement interpretation",
-    plan_appropriateness: "Plan appropriateness",
-    context_usage: "Context usage",
-    handoff_quality: "Handoff quality",
-    task_spec_quality: "Task spec quality",
-    context_injection_quality: "Context injection quality",
-    role_handoff_quality: "Role handoff quality",
-    verification_gate_quality: "Verification gate quality",
-    scoring_rubric_quality: "Scoring rubric quality",
-    record_and_dashboard_quality: "Record and dashboard quality"
+    requirement_fulfillment: "요구사항 충족",
+    scope_control: "범위 통제",
+    implementation_quality: "구현 품질",
+    verification_sufficiency: "검증 충분성",
+    risk_and_safety: "리스크와 안전",
+    requirement_interpretation: "요구사항 해석",
+    plan_appropriateness: "계획 적절성",
+    context_usage: "컨텍스트 활용",
+    handoff_quality: "인수인계 품질",
+    result_quality: "결과 품질",
+    process_quality: "프로세스 품질",
+    task_spec_quality: "작업 명세 품질",
+    context_injection_quality: "컨텍스트 주입 품질",
+    role_handoff_quality: "역할 분리와 인수인계 품질",
+    verification_gate_quality: "검증 게이트 품질",
+    scoring_rubric_quality: "스코어링 루브릭 품질",
+    record_and_dashboard_quality: "기록과 대시보드 품질"
   };
   return labels[id] || id;
 }
@@ -130,6 +132,7 @@ const runDirs = existsSync(runsRoot)
 
 const runs = [];
 const harnessScores = [];
+const activeHarnessScores = [];
 const history = safeReadJson(historyPath) || { schema_version: 1, runs: [] };
 
 for (const runDir of runDirs) {
@@ -144,7 +147,10 @@ for (const runDir of runDirs) {
     record.artifacts?.harness_health_score || "harness-health-score.json"
   );
 
-  if (harnessScore) harnessScores.push(harnessScore);
+  if (harnessScore) {
+    harnessScores.push(harnessScore);
+    activeHarnessScores.push(harnessScore);
+  }
 
   const categories = (reviewScore?.categories || []).map((category) => ({
     id: category.id,
@@ -199,6 +205,14 @@ for (const historicalRun of history.runs || []) {
 
   runs.push({
     ...historicalRun,
+    deductions: (historicalRun.deductions || []).map((deduction) => ({
+      ...deduction,
+      category: labelForCategory(deduction.category)
+    })),
+    categories: (historicalRun.categories || []).map((category) => ({
+      ...category,
+      label: labelForCategory(category.id)
+    })),
     archived: true
   });
 
@@ -218,11 +232,11 @@ const failCount = scoredRuns.filter((run) => run.decision === "FAIL").length;
 const averageIssueScore = issueCount
   ? Math.round(scoredRuns.reduce((sum, run) => sum + run.total_score, 0) / issueCount)
   : null;
-const averageHarnessScore = harnessScores.length
-  ? Math.round(harnessScores.reduce((sum, score) => sum + score.total_score, 0) / harnessScores.length)
+const averageHarnessScore = activeHarnessScores.length
+  ? Math.round(activeHarnessScores.reduce((sum, score) => sum + score.total_score, 0) / activeHarnessScores.length)
   : null;
 
-const latestHarnessScore = harnessScores[harnessScores.length - 1];
+const latestHarnessScore = activeHarnessScores[activeHarnessScores.length - 1];
 const harnessHealth = latestHarnessScore ? {
   total_score: latestHarnessScore.total_score,
   categories: (latestHarnessScore.categories || []).map((category) => ({
@@ -256,55 +270,55 @@ const dashboardData = {
     {
       name: "Planner",
       file: ".agents/harness/agents/planner.agent.md",
-      purpose: "Convert a GitHub Issue into task-spec.md and plan.md.",
+      purpose: "GitHub Issue를 task-spec.md와 plan.md로 변환한다.",
       outputs: ["task-spec.md", "plan.md"],
-      handoff: "Pass a concrete task spec and plan to implementation."
+      handoff: "구체화된 작업 명세와 계획을 구현 단계로 넘긴다."
     },
     {
       name: "Spec",
       file: ".agents/skills/ai-harness-spec/SKILL.md",
-      purpose: "Clarify decisions and write spec.md before implementation.",
+      purpose: "구현 전에 미확정 결정을 정리하고 spec.md를 작성한다.",
       outputs: ["spec.md"],
-      handoff: "Pass detailed scenarios and Red priorities to Red."
+      handoff: "상세 시나리오와 Red 우선순위를 Red 단계로 넘긴다."
     },
     {
       name: "Implementer",
       file: ".agents/harness/agents/implementer.agent.md",
-      purpose: "Implement code or configuration changes.",
+      purpose: "코드 또는 설정 변경을 구현한다.",
       outputs: ["implementation-notes.md"],
-      handoff: "Pass changed files and notes to verification."
+      handoff: "변경 파일과 구현 기록을 검증 단계로 넘긴다."
     },
     {
       name: "Verifier",
       file: ".agents/harness/agents/verifier.agent.md",
-      purpose: "Run verification commands and record evidence.",
+      purpose: "검증 명령을 실행하고 근거를 기록한다.",
       outputs: ["verification.md"],
-      handoff: "Pass verification evidence and diff context to review."
+      handoff: "검증 근거와 diff 맥락을 리뷰 단계로 넘긴다."
     },
     {
       name: "Reviewer",
       file: ".agents/harness/agents/reviewer.agent.md",
-      purpose: "Score the run and decide PASS, REWORK, or FAIL.",
+      purpose: "실행 결과를 채점하고 PASS, REWORK, FAIL을 결정한다.",
       outputs: ["review-score.json", "review.md"],
-      handoff: "PASS goes to PR, REWORK returns to implementation, FAIL waits for human review."
+      handoff: "PASS는 PR 단계로, REWORK는 구현 재작업으로, FAIL은 사람 확인으로 넘긴다."
     },
     {
       name: "Harness Evaluator",
       file: ".agents/harness/agents/harness-evaluator.agent.md",
-      purpose: "Evaluate harness health and propose improvements.",
+      purpose: "하네스 건강도를 평가하고 개선안을 제안한다.",
       outputs: ["harness-health-score.json", "harness-improvements.md"],
-      handoff: "Approved improvements are implemented separately."
+      handoff: "승인된 개선안은 별도 작업으로 구현한다."
     }
   ],
   workflow: [
-    { step: "1", name: "Planner", status: "Create task-spec.md and plan.md" },
-    { step: "2", name: "Spec", status: "Create spec.md and Red priorities" },
-    { step: "3", name: "Red", status: "Write or record failing tests" },
-    { step: "4", name: "Green", status: "Implement the minimum passing change" },
-    { step: "5", name: "Verify", status: "Run verification and write verification.md" },
-    { step: "6", name: "Review", status: "Score and decide PASS, REWORK, or FAIL" },
-    { step: "7", name: "Dashboard", status: "Project run state into dashboard data" },
-    { step: "8", name: "PR", status: "Draft a PR only for PASS runs" }
+    { step: "1", name: "Planner", status: "task-spec.md와 plan.md 작성" },
+    { step: "2", name: "Spec", status: "spec.md와 Red 우선순위 작성" },
+    { step: "3", name: "Red", status: "실패 테스트를 작성하거나 실패 근거 기록" },
+    { step: "4", name: "Green", status: "통과에 필요한 최소 변경 구현" },
+    { step: "5", name: "Verify", status: "검증 실행 후 verification.md 작성" },
+    { step: "6", name: "Review", status: "점수 산정 후 PASS, REWORK, FAIL 결정" },
+    { step: "7", name: "Dashboard", status: "run 상태를 dashboard data로 변환" },
+    { step: "8", name: "PR", status: "PASS run만 PR로 정리" }
   ]
 };
 

--- a/.agents/harness/scripts/diagnose-status.mjs
+++ b/.agents/harness/scripts/diagnose-status.mjs
@@ -26,7 +26,54 @@ function fileInfo(path) {
   return {
     exists: true,
     bytes: stats.size,
-    updated_at: stats.mtime.toISOString()
+    updated_at: stats.mtime.toISOString(),
+    complete: true,
+    template: false,
+    quality_warnings: []
+  };
+}
+
+function markdownArtifactInfo(path) {
+  const info = fileInfo(path);
+  if (!info.exists) return { ...info, complete: false, template: false, quality_warnings: [] };
+
+  const text = readText(path).trim();
+  const placeholderLines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line === "작성 필요." || line === "- 작성 필요.");
+  const template = !text || placeholderLines.length > 0;
+
+  return {
+    ...info,
+    complete: !template,
+    template,
+    quality_warnings: template ? ["artifact appears to be an unfilled template"] : []
+  };
+}
+
+function reviewScoreArtifactInfo(path) {
+  const info = fileInfo(path);
+  if (!info.exists) return { ...info, complete: false, template: false, quality_warnings: [] };
+
+  const warnings = [];
+  const score = readJson(path);
+  const hasEvidence = (score?.categories || []).some(
+    (category) => (category.evidence || []).length > 0 || (category.deductions || []).length > 0
+  );
+  const template =
+    score?.score_id === "issue-000-review-attempt-1" ||
+    score?.scored_at === "1970-01-01T00:00:00.000Z" ||
+    String(score?.recommended_next_action || "").includes("작성 필요") ||
+    (score?.decision === "FAIL" && score?.total_score === 0 && !hasEvidence);
+
+  if (template) warnings.push("review score appears to be an unfilled template");
+
+  return {
+    ...info,
+    complete: !template,
+    template,
+    quality_warnings: warnings
   };
 }
 
@@ -121,11 +168,11 @@ function parseInboxItem(checked, raw) {
 }
 
 function artifactStage(artifacts) {
-  if (artifacts.review_score.exists && artifacts.review.exists) return "reviewed";
-  if (artifacts.verification.exists) return "verified";
-  if (artifacts.implementation_notes.exists) return "implemented";
-  if (artifacts.spec.exists) return "specified";
-  if (artifacts.task_spec.exists && artifacts.plan.exists) return "planned";
+  if (artifacts.review_score.complete && artifacts.review.complete) return "reviewed";
+  if (artifacts.verification.complete) return "verified";
+  if (artifacts.implementation_notes.complete) return "implemented";
+  if (artifacts.spec.complete) return "specified";
+  if (artifacts.task_spec.complete && artifacts.plan.complete) return "planned";
   return "unplanned";
 }
 
@@ -136,24 +183,28 @@ function diagnoseRun(runDir) {
   const state = readJson(statePath);
 
   const artifacts = {
-    task_spec: fileInfo(join(runDir, "task-spec.md")),
-    plan: fileInfo(join(runDir, "plan.md")),
-    spec: fileInfo(join(runDir, "spec.md")),
-    implementation_notes: fileInfo(join(runDir, "implementation-notes.md")),
-    verification: fileInfo(join(runDir, "verification.md")),
-    review_score: fileInfo(join(runDir, "review-score.json")),
-    review: fileInfo(join(runDir, "review.md"))
+    task_spec: markdownArtifactInfo(join(runDir, "task-spec.md")),
+    plan: markdownArtifactInfo(join(runDir, "plan.md")),
+    spec: markdownArtifactInfo(join(runDir, "spec.md")),
+    implementation_notes: markdownArtifactInfo(join(runDir, "implementation-notes.md")),
+    verification: markdownArtifactInfo(join(runDir, "verification.md")),
+    review_score: reviewScoreArtifactInfo(join(runDir, "review-score.json")),
+    review: markdownArtifactInfo(join(runDir, "review.md"))
   };
 
-  const reviewScore = readJson(join(runDir, "review-score.json"));
+  const reviewScore = artifacts.review_score.complete ? readJson(join(runDir, "review-score.json")) : null;
   const inferredStage = artifactStage(artifacts);
   const decision = reviewScore?.decision ?? state?.decision ?? null;
   const cleanupCandidate = inferredStage === "reviewed" && ["PASS", "REWORK", "FAIL"].includes(decision);
   const warnings = [];
+  const artifactWarnings = Object.entries(artifacts).flatMap(([name, artifact]) =>
+    (artifact.quality_warnings || []).map((warning) => `${name}: ${warning}`)
+  );
 
   if (!state) warnings.push("missing state.json");
   if (state && state.run_id !== runRecord?.run_id) warnings.push("state run_id differs from run-record run_id");
   if (state?.stage && state.stage !== inferredStage) warnings.push(`state stage '${state.stage}' differs from artifact stage '${inferredStage}'`);
+  warnings.push(...artifactWarnings);
   if (runRecord?.status && ["pass", "rework", "fail"].includes(runRecord.status) && !reviewScore?.decision) {
     warnings.push("run-record terminal status has no review decision");
   }

--- a/.agents/runs/issue-44/review-score.json
+++ b/.agents/runs/issue-44/review-score.json
@@ -12,11 +12,11 @@
       "score": 24,
       "max_score": 25,
       "evidence": [
-        "Added `.agents/harness/inbox-policy.md` with classification tags, PR-time outcomes, completion/removal rules, and status interpretation rules.",
-        "Updated `.agents/inbox.md`, draft-pr docs, capture skill, status skill, and issue workflow to reference the policy."
+        "분류 태그, PR 전 처리 결과, 완료/제거 규칙, status 해석 규칙을 담은 `.agents/harness/inbox-policy.md`를 추가했다.",
+        "`.agents/inbox.md`, draft-pr 문서, capture/status 스킬, issue workflow가 새 정책을 참조하도록 갱신했다."
       ],
       "deductions": [
-        "No automated enforcement was added, matching scope but leaving compliance to skill execution."
+        "이번 범위에 맞춰 자동 강제 로직은 추가하지 않았고, 준수 여부는 스킬 실행 단계에 남아 있다."
       ]
     },
     {
@@ -24,8 +24,8 @@
       "score": 15,
       "max_score": 15,
       "evidence": [
-        "Changes were limited to harness documentation, skills, and issue-44 run artifacts.",
-        "No product code, dashboard behavior, GitHub label sync, or automation scripts were changed."
+        "변경 범위를 하네스 문서, 스킬, issue-44 run 산출물로 제한했다.",
+        "제품 코드, dashboard 동작, GitHub 라벨 동기화, 자동화 스크립트는 변경하지 않았다."
       ],
       "deductions": []
     },
@@ -34,11 +34,11 @@
       "score": 14,
       "max_score": 15,
       "evidence": [
-        "The policy separates unresolved classification tags from PR-time outcomes.",
-        "The policy keeps `.agents/inbox.md` as an active queue instead of a long-term archive."
+        "정책 문서가 미해결 항목 분류 태그와 PR 전 처리 결과를 분리했다.",
+        "`.agents/inbox.md`를 장기 보관소가 아니라 active queue로 유지한다는 원칙을 명확히 했다."
       ],
       "deductions": [
-        "The policy is English while several harness docs are Korean, which is acceptable but slightly mixed."
+        "정책 문서 일부가 영어라 한글 하네스 문서와 언어가 섞여 있다."
       ]
     },
     {
@@ -46,10 +46,10 @@
       "score": 9,
       "max_score": 10,
       "evidence": [
-        "Verified policy file existence, required term coverage with `rg`, inbox parsing with `diagnose-status.mjs`, and diff scope."
+        "정책 파일 존재, `rg` 기반 필수 용어 포함 여부, `diagnose-status.mjs` inbox 파싱, diff 범위를 확인했다."
       ],
       "deductions": [
-        "Build/test/lint were skipped because this is documentation-only."
+        "문서 변경만 포함하므로 build/test/lint는 생략했다."
       ]
     },
     {
@@ -57,8 +57,8 @@
       "score": 5,
       "max_score": 5,
       "evidence": [
-        "No destructive operations or production-affecting code changes were made.",
-        "Inbox removal rules require a durable record before removal."
+        "파괴적인 작업이나 프로덕션에 영향을 주는 코드 변경은 없었다.",
+        "inbox 제거 규칙은 제거 전 장기 기록을 남기도록 요구한다."
       ],
       "deductions": []
     },
@@ -67,7 +67,7 @@
       "score": 10,
       "max_score": 10,
       "evidence": [
-        "The user explicitly selected separate policy documentation and removal-after-recording behavior; both were implemented."
+        "사용자가 별도 정책 문서와 기록 후 제거 방식을 명시적으로 선택했고, 두 결정을 모두 반영했다."
       ],
       "deductions": []
     },
@@ -76,7 +76,7 @@
       "score": 8,
       "max_score": 8,
       "evidence": [
-        "Planner, spec, Red, Green, verification, and review stages were followed for the harness task."
+        "하네스 작업에 대해 계획, 상세 스펙, Red, Green, 검증, 리뷰 단계를 순서대로 수행했다."
       ],
       "deductions": []
     },
@@ -85,10 +85,10 @@
       "score": 4,
       "max_score": 6,
       "evidence": [
-        "Existing inbox, workflow, draft-pr, capture, and status docs were inspected and aligned."
+        "기존 inbox, workflow, draft-pr, capture, status 문서를 확인하고 같은 정책을 참조하도록 정리했다."
       ],
       "deductions": [
-        "An issue-38 run was accidentally started before the user redirected to #44; it was not modified after the redirect."
+        "사용자가 #44로 방향을 바꾸기 전에 issue-38 run을 실수로 시작했다."
       ]
     },
     {
@@ -96,21 +96,21 @@
       "score": 3,
       "max_score": 6,
       "evidence": [
-        "Run artifacts describe decisions, verification, and remaining risk."
+        "run 산출물이 결정 사항, 검증 결과, 남은 리스크를 설명한다."
       ],
       "deductions": [
-        "The accidental issue-38 run remains in the active run directory and may need separate cleanup."
+        "실수로 생성된 issue-38 run은 별도 정리가 필요한 상태로 남아 있었다."
       ]
     }
   ],
   "strengths": [
-    "Clear central policy was added for inbox classification, PR-time handling, and removal.",
-    "Existing skills and workflow docs now point to the same policy instead of using loose wording."
+    "inbox 분류, PR 전 처리, 제거 기준을 다루는 중앙 정책 문서가 추가됐다.",
+    "기존 스킬과 workflow 문서가 느슨한 표현 대신 같은 정책 문서를 참조하게 됐다."
   ],
   "weaknesses": [
-    "No automated enforcement exists yet.",
-    "A mistakenly started issue-38 run remains as local harness noise."
+    "아직 자동 강제 로직은 없다.",
+    "실수로 시작한 issue-38 run이 로컬 하네스 노이즈로 남아 있었다."
   ],
-  "recommended_next_action": "Create a PR for issue #44 after confirming whether to clean up the accidental issue-38 run separately.",
+  "recommended_next_action": "issue #44 PR을 생성하고 CI 결과를 확인한다.",
   "scored_at": "2026-05-12T05:28:00.000Z"
 }

--- a/.agents/runs/issue-45/harness-health-score.json
+++ b/.agents/runs/issue-45/harness-health-score.json
@@ -1,0 +1,94 @@
+{
+  "score_id": "issue-45-harness-health",
+  "rubric": {
+    "name": "harness_health",
+    "version": 1
+  },
+  "total_score": 82,
+  "categories": [
+    {
+      "id": "task_spec_quality",
+      "score": 18,
+      "max_score": 20,
+      "evidence": [
+        "#45는 dashboard/status/review 표시 기준의 문제를 명확히 제기했고, 실제 템플릿 run과 작성된 run을 구분하는 완료 기준으로 구체화됐다.",
+        "Red 단계에서 false reviewed/FAIL 문제를 재현하도록 작업 명세와 스펙이 이어졌다."
+      ],
+      "deductions": [
+        "초기 이슈 본문에는 dashboard, status, review 중 어느 범위까지 포함할지 확인 필요가 남아 있어 계획 단계에서 범위를 확정해야 했다."
+      ]
+    },
+    {
+      "id": "context_injection_quality",
+      "score": 17,
+      "max_score": 20,
+      "evidence": [
+        "기존 start-issue 템플릿, #38 accidental run, #44 PASS run, dashboard data를 함께 사용해 재현 조건을 잡았다.",
+        "과거 archived #24의 harness health 점수가 현재 평균처럼 보이는 문제도 후속 보정에서 확인됐다."
+      ],
+      "deductions": [
+        "열린 PR #50과 develop 브랜치 상태가 실행 도중 혼재되어 PR 반영 전략을 다시 조정해야 했다."
+      ]
+    },
+    {
+      "id": "role_handoff_quality",
+      "score": 12,
+      "max_score": 15,
+      "evidence": [
+        "task-spec, plan, spec, implementation-notes, verification, review가 모두 남아 있고 #45 PASS 판단으로 이어졌다.",
+        "사용자 피드백 이후 dashboard 문구와 하네스 점수 표시 보정도 verification에 추가 기록됐다."
+      ],
+      "deductions": [
+        "하네스 평가 단계가 PR 생성 이후 사용자 지적을 받은 뒤 수행되어 순서가 매끄럽지 않았다."
+      ]
+    },
+    {
+      "id": "verification_gate_quality",
+      "score": 14,
+      "max_score": 20,
+      "evidence": [
+        "diagnose-status, build-dashboard-data, validate-score를 실행해 템플릿 false FAIL과 dashboard 집계 개선을 확인했다.",
+        "dashboard data에서 평균 실행 점수와 하네스 평균의 null 처리까지 확인했다."
+      ],
+      "deductions": [
+        "템플릿 판별과 dashboard summary 기준을 검증하는 별도 자동 테스트가 없어 회귀 방지가 약하다.",
+        "dashboard 문구 언어 문제와 하네스 평균 이상 표시를 첫 검증 단계에서 잡지 못했다."
+      ]
+    },
+    {
+      "id": "scoring_rubric_quality",
+      "score": 12,
+      "max_score": 15,
+      "evidence": [
+        "issue execution 점수는 91점 PASS로 산출됐고, template-only run과 review-missing run의 차이를 리뷰 근거에 반영했다.",
+        "감점 사유가 템플릿 판별 중복과 테스트 부재로 구체화됐다."
+      ],
+      "deductions": [
+        "하네스 건강도 평가는 사용자 지적 전에는 누락되어 PR 본문과 dashboard에 처음부터 포함되지 않았다."
+      ]
+    },
+    {
+      "id": "record_and_dashboard_quality",
+      "score": 9,
+      "max_score": 10,
+      "evidence": [
+        "dashboard data가 review 완료 run만 집계하고, 활성 harness health가 없으면 평가 없음으로 표시하도록 개선됐다.",
+        "리뷰 근거, 감점 사유, 카테고리 라벨, 개선 제안, agent/workflow 설명이 한글로 정리됐다."
+      ],
+      "deductions": [
+        "dashboard UI 자체의 데이터 품질 경고 시각화는 아직 제한적이다."
+      ]
+    }
+  ],
+  "proposals": [
+    {
+      "proposal_id": "2026-05-12-template-artifact-regression-tests",
+      "target_area": "verification_gate",
+      "title": "템플릿 산출물 판별 회귀 테스트 추가",
+      "reason": "템플릿 판별 로직이 diagnose-status와 build-dashboard-data에 중복되어 있고, 자동 테스트가 없어 빈 템플릿을 다시 FAIL로 집계하는 회귀를 놓칠 수 있다.",
+      "expected_impact": "새 run 템플릿, 실제 PASS review, 실제 0점 FAIL review를 구분하는 기준을 자동으로 검증해 dashboard/status 신뢰도를 유지한다.",
+      "status": "proposed"
+    }
+  ],
+  "scored_at": "2026-05-12T05:55:00.000Z"
+}

--- a/.agents/runs/issue-45/harness-improvements.md
+++ b/.agents/runs/issue-45/harness-improvements.md
@@ -1,0 +1,23 @@
+# 하네스 개선 평가
+
+## 결정
+
+- 하네스 건강도: 82/100
+- 평가 대상: issue #45 실행과 #44/#45 dashboard 반영 상태
+
+## 주요 개선
+
+- 빈 템플릿 산출물을 실제 reviewed/FAIL 결과와 구분하게 됐다.
+- dashboard summary가 실제 review 완료 run만 평균과 PASS/FAIL count에 반영한다.
+- 활성 run에 하네스 건강도 평가가 없으면 archived 점수를 현재 평균으로 표시하지 않고 `평가 없음`으로 표시한다.
+- dashboard에 노출되는 리뷰 근거, 감점 사유, 카테고리 라벨, 개선 제안 설명을 한글로 정리했다.
+
+## 남은 리스크
+
+- 템플릿 판별 로직이 `diagnose-status.mjs`와 `build-dashboard-data.mjs`에 중복되어 있다.
+- 템플릿 산출물, 실제 PASS, 실제 0점 FAIL을 구분하는 자동 회귀 테스트가 없다.
+- 하네스 평가 단계가 PR 생성 이후 사용자 지적을 받고 수행되어 단계 순서가 늦었다.
+
+## 제안
+
+- `2026-05-12-template-artifact-regression-tests`: 템플릿 산출물 판별 회귀 테스트 추가

--- a/.agents/runs/issue-45/implementation-notes.md
+++ b/.agents/runs/issue-45/implementation-notes.md
@@ -1,0 +1,24 @@
+# 구현 기록
+
+## 변경 파일
+
+- `.agents/harness/scripts/diagnose-status.mjs`
+- `.agents/harness/scripts/build-dashboard-data.mjs`
+- `.agents/harness/dashboard/data/runs.js`
+- `.agents/runs/issue-45/*`
+
+## 주요 결정
+
+- Markdown 산출물은 플레이스홀더 라인(`작성 필요.`, `- 작성 필요.`)이 남아 있으면 템플릿으로 본다.
+- `review-score.json`은 template sentinel 값(`issue-000-review-attempt-1`, `1970-01-01T00:00:00.000Z`, `작성 필요`, evidence 없는 0점 FAIL)을 기준으로 템플릿 여부를 판단한다.
+- `diagnose-status.mjs`는 artifact별 `complete`, `template`, `quality_warnings`를 표시하고 complete artifact만 stage/decision 추론에 사용한다.
+- `build-dashboard-data.mjs`는 유효한 review score가 있는 run만 summary 평균과 PASS/REWORK/FAIL count에 반영한다.
+- dashboard data는 작성된 산출물이 없는 template-only run을 제외하고, review 전 run은 `review_complete: false`, `total_score: null`, `data_quality_warnings`로 표시한다.
+
+## 계획에서 달라진 점
+
+- 없음.
+
+## 알려진 리스크
+
+- 템플릿 판별은 현재 템플릿 문구와 sentinel 값에 기반한다. 템플릿 형식이 바뀌면 판별 조건도 함께 갱신해야 한다.

--- a/.agents/runs/issue-45/plan.md
+++ b/.agents/runs/issue-45/plan.md
@@ -1,0 +1,35 @@
+# 구현 계획
+
+## 가정
+
+- `start-issue.mjs`는 호환성을 위해 템플릿 파일을 계속 생성한다.
+- 빈 템플릿 파일은 산출물 파일이 존재하더라도 완료 산출물로 보지 않는다.
+- 실제 0점/FAIL review는 템플릿의 sentinel 값과 작성 필요 문구가 제거된 경우에만 유효한 review로 본다.
+
+## 단계
+
+1. 현재 `diagnose-status.mjs`와 `build-dashboard-data.mjs`에서 파일 존재만으로 stage/decision을 추론하는 지점을 확인한다.
+2. Red 단계로 템플릿 run이 `reviewed`/`FAIL`로 오인되는 현재 출력을 기록한다.
+3. 공통 템플릿 판별 헬퍼를 각 스크립트에 추가한다.
+4. status 진단에서 artifact별 `complete`/`template`/`quality_warnings`를 표시하고, stage 추론은 complete artifact만 사용하게 한다.
+5. dashboard data에서 유효한 review score가 있는 run만 summary 평균과 PASS/REWORK/FAIL count에 반영하고, 누락 데이터는 `data_quality_warnings`로 노출한다.
+6. #44 PASS와 #45 진행 상태, issue-38 템플릿 상태를 함께 검증한다.
+7. #45 산출물과 review score를 작성하고 점수 검증을 실행한다.
+
+## 예상 변경 파일
+
+- `.agents/harness/scripts/diagnose-status.mjs`
+- `.agents/harness/scripts/build-dashboard-data.mjs`
+- `.agents/runs/issue-45/task-spec.md`
+- `.agents/runs/issue-45/plan.md`
+- `.agents/runs/issue-45/spec.md`
+- `.agents/runs/issue-45/implementation-notes.md`
+- `.agents/runs/issue-45/verification.md`
+- `.agents/runs/issue-45/review-score.json`
+- `.agents/runs/issue-45/review.md`
+- `.agents/runs/issue-45/state.json`
+- `.agents/runs/issue-45/run-record.json`
+
+## 열린 질문
+
+- 없음. 이슈 본문은 dashboard/status/review 표시 기준 점검을 모두 범위로 제시하므로 세 영역 모두 다룬다.

--- a/.agents/runs/issue-45/review-score.json
+++ b/.agents/runs/issue-45/review-score.json
@@ -1,0 +1,117 @@
+{
+  "score_id": "issue-45-review-attempt-1",
+  "rubric": {
+    "name": "issue_execution",
+    "version": 1
+  },
+  "total_score": 91,
+  "decision": "PASS",
+  "categories": [
+    {
+      "id": "requirement_fulfillment",
+      "score": 24,
+      "max_score": 25,
+      "evidence": [
+        "Status diagnosis now marks template artifacts with `complete`, `template`, and `quality_warnings` and does not infer terminal decisions from template review scores.",
+        "Dashboard data now uses complete review scores for summary counts and averages, with null score and warnings for review-missing runs."
+      ],
+      "deductions": [
+        "Dashboard UI rendering was not updated; this issue focused on generated data and status output."
+      ]
+    },
+    {
+      "id": "scope_control",
+      "score": 15,
+      "max_score": 15,
+      "evidence": [
+        "Changes were limited to harness scripts, dashboard data, and issue-45 run artifacts.",
+        "No product code or unrelated GitHub labels/Project fields were changed."
+      ],
+      "deductions": []
+    },
+    {
+      "id": "implementation_quality",
+      "score": 14,
+      "max_score": 15,
+      "evidence": [
+        "Template detection avoids using score value alone, so a real 0-point FAIL can still be valid when sentinel values are removed and evidence exists.",
+        "Template-only runs are excluded from dashboard runs while review-missing active runs remain visible with data quality warnings."
+      ],
+      "deductions": [
+        "Template detection is duplicated between the two scripts instead of extracted to a shared module."
+      ]
+    },
+    {
+      "id": "verification_sufficiency",
+      "score": 9,
+      "max_score": 10,
+      "evidence": [
+        "Verified diagnose-status output for template issue-38, PASS issue-44, and in-progress issue-45.",
+        "Verified dashboard summary no longer counts template/incomplete review scores as zero-point failures."
+      ],
+      "deductions": [
+        "No separate automated unit test file was added."
+      ]
+    },
+    {
+      "id": "risk_and_safety",
+      "score": 5,
+      "max_score": 5,
+      "evidence": [
+        "No destructive operations were performed.",
+        "The accidental issue-38 directory remains untracked and is not committed."
+      ],
+      "deductions": []
+    },
+    {
+      "id": "requirement_interpretation",
+      "score": 10,
+      "max_score": 10,
+      "evidence": [
+        "The issue's dashboard/status/review display scope was addressed through status output, dashboard data, and review score validity rules."
+      ],
+      "deductions": []
+    },
+    {
+      "id": "plan_appropriateness",
+      "score": 8,
+      "max_score": 8,
+      "evidence": [
+        "Red captured the existing false FAIL behavior before Green fixed the status and dashboard criteria."
+      ],
+      "deductions": []
+    },
+    {
+      "id": "context_usage",
+      "score": 4,
+      "max_score": 6,
+      "evidence": [
+        "The implementation used the existing start-issue templates, diagnose-status behavior, dashboard data generation, and issue-44 PASS run as fixtures."
+      ],
+      "deductions": [
+        "The open PR #50 on develop means additional commits to develop may update that PR unless handled separately."
+      ]
+    },
+    {
+      "id": "handoff_quality",
+      "score": 2,
+      "max_score": 6,
+      "evidence": [
+        "Run artifacts record the Red evidence, implementation decisions, verification, and review outcome."
+      ],
+      "deductions": [
+        "The issue-38 accidental local run remains as a known local cleanup item."
+      ]
+    }
+  ],
+  "strengths": [
+    "Template-only runs no longer appear as reviewed FAIL results.",
+    "Dashboard summary now distinguishes missing review data from real zero scores."
+  ],
+  "weaknesses": [
+    "Template detection is duplicated in two scripts.",
+    "No dedicated automated unit tests were added."
+  ],
+  "recommended_next_action": "Commit issue #45 changes on develop and decide whether to update the open PR or create a separate follow-up flow after merge.",
+  "scored_at": "2026-05-12T05:50:00.000Z"
+}

--- a/.agents/runs/issue-45/review-score.json
+++ b/.agents/runs/issue-45/review-score.json
@@ -12,11 +12,11 @@
       "score": 24,
       "max_score": 25,
       "evidence": [
-        "Status diagnosis now marks template artifacts with `complete`, `template`, and `quality_warnings` and does not infer terminal decisions from template review scores.",
-        "Dashboard data now uses complete review scores for summary counts and averages, with null score and warnings for review-missing runs."
+        "status 진단이 템플릿 산출물에 `complete`, `template`, `quality_warnings`를 표시하고, 템플릿 review 점수에서 최종 결정을 추론하지 않게 됐다.",
+        "dashboard 데이터가 작성 완료된 review 점수만 요약 카운트와 평균에 사용하고, review가 없는 run은 null 점수와 경고로 표시한다."
       ],
       "deductions": [
-        "Dashboard UI rendering was not updated; this issue focused on generated data and status output."
+        "dashboard UI 전면 렌더링 개편은 하지 않았고, 이번 이슈는 생성 데이터와 status 출력 기준에 집중했다."
       ]
     },
     {
@@ -24,8 +24,8 @@
       "score": 15,
       "max_score": 15,
       "evidence": [
-        "Changes were limited to harness scripts, dashboard data, and issue-45 run artifacts.",
-        "No product code or unrelated GitHub labels/Project fields were changed."
+        "변경 범위를 하네스 스크립트, dashboard 데이터, issue-45 run 산출물로 제한했다.",
+        "제품 코드나 관련 없는 GitHub 라벨/Project 필드는 변경하지 않았다."
       ],
       "deductions": []
     },
@@ -34,11 +34,11 @@
       "score": 14,
       "max_score": 15,
       "evidence": [
-        "Template detection avoids using score value alone, so a real 0-point FAIL can still be valid when sentinel values are removed and evidence exists.",
-        "Template-only runs are excluded from dashboard runs while review-missing active runs remain visible with data quality warnings."
+        "템플릿 판별이 점수값만 보지 않으므로, sentinel 값이 제거되고 근거가 작성된 실제 0점 FAIL은 유효 결과로 남을 수 있다.",
+        "템플릿만 있는 run은 dashboard 목록에서 제외하고, review가 아직 없는 활성 run은 데이터 품질 경고와 함께 표시한다."
       ],
       "deductions": [
-        "Template detection is duplicated between the two scripts instead of extracted to a shared module."
+        "템플릿 판별 로직이 공통 모듈로 분리되지 않고 두 스크립트에 중복되어 있다."
       ]
     },
     {
@@ -46,11 +46,11 @@
       "score": 9,
       "max_score": 10,
       "evidence": [
-        "Verified diagnose-status output for template issue-38, PASS issue-44, and in-progress issue-45.",
-        "Verified dashboard summary no longer counts template/incomplete review scores as zero-point failures."
+        "템플릿 issue-38, PASS issue-44, 진행 중 issue-45에 대한 diagnose-status 출력을 확인했다.",
+        "dashboard 요약이 템플릿/미완료 review 점수를 0점 실패로 집계하지 않는 것을 확인했다."
       ],
       "deductions": [
-        "No separate automated unit test file was added."
+        "별도 자동화 단위 테스트 파일은 추가하지 않았다."
       ]
     },
     {
@@ -58,8 +58,8 @@
       "score": 5,
       "max_score": 5,
       "evidence": [
-        "No destructive operations were performed.",
-        "The accidental issue-38 directory remains untracked and is not committed."
+        "파괴적인 작업은 수행하지 않았다.",
+        "실수로 생성된 issue-38 디렉터리는 추적하지 않았고 커밋에 포함하지 않았다."
       ],
       "deductions": []
     },
@@ -68,7 +68,7 @@
       "score": 10,
       "max_score": 10,
       "evidence": [
-        "The issue's dashboard/status/review display scope was addressed through status output, dashboard data, and review score validity rules."
+        "이슈의 dashboard/status/review 표시 기준 범위를 status 출력, dashboard 데이터, review 점수 유효성 규칙으로 처리했다."
       ],
       "deductions": []
     },
@@ -77,7 +77,7 @@
       "score": 8,
       "max_score": 8,
       "evidence": [
-        "Red captured the existing false FAIL behavior before Green fixed the status and dashboard criteria."
+        "Red 단계에서 기존 false FAIL 동작을 먼저 확인한 뒤 Green 단계에서 status와 dashboard 기준을 수정했다."
       ],
       "deductions": []
     },
@@ -86,10 +86,10 @@
       "score": 4,
       "max_score": 6,
       "evidence": [
-        "The implementation used the existing start-issue templates, diagnose-status behavior, dashboard data generation, and issue-44 PASS run as fixtures."
+        "기존 start-issue 템플릿, diagnose-status 동작, dashboard 데이터 생성, issue-44 PASS run을 검증 기준으로 활용했다."
       ],
       "deductions": [
-        "The open PR #50 on develop means additional commits to develop may update that PR unless handled separately."
+        "작업 당시 develop 기반 PR #50이 열려 있어 추가 커밋이 같은 PR에 반영될 수 있는 상황이었다."
       ]
     },
     {
@@ -97,21 +97,21 @@
       "score": 2,
       "max_score": 6,
       "evidence": [
-        "Run artifacts record the Red evidence, implementation decisions, verification, and review outcome."
+        "run 산출물에 Red 근거, 구현 결정, 검증 결과, 리뷰 결정을 기록했다."
       ],
       "deductions": [
-        "The issue-38 accidental local run remains as a known local cleanup item."
+        "실수로 생성된 issue-38 로컬 run은 별도 정리 항목으로 남아 있었다."
       ]
     }
   ],
   "strengths": [
-    "Template-only runs no longer appear as reviewed FAIL results.",
-    "Dashboard summary now distinguishes missing review data from real zero scores."
+    "템플릿만 있는 run이 더 이상 reviewed FAIL 결과로 표시되지 않는다.",
+    "dashboard 요약이 누락된 review 데이터와 실제 0점을 구분한다."
   ],
   "weaknesses": [
-    "Template detection is duplicated in two scripts.",
-    "No dedicated automated unit tests were added."
+    "템플릿 판별 로직이 두 스크립트에 중복되어 있다.",
+    "전용 자동화 단위 테스트는 추가하지 않았다."
   ],
-  "recommended_next_action": "Commit issue #45 changes on develop and decide whether to update the open PR or create a separate follow-up flow after merge.",
+  "recommended_next_action": "issue #45 변경을 PR에 반영하고 CI 결과를 확인한다.",
   "scored_at": "2026-05-12T05:50:00.000Z"
 }

--- a/.agents/runs/issue-45/review.md
+++ b/.agents/runs/issue-45/review.md
@@ -1,0 +1,29 @@
+# Reviewer 검토
+
+## 결정
+
+PASS
+
+## 요약
+
+Issue #45의 핵심 문제였던 빈 템플릿 산출물의 false reviewed/FAIL 표시가 해결됐다. status와 dashboard summary가 실제 작성된 review score만 terminal result로 다루고, 누락 데이터는 null score와 data quality warning으로 표현한다.
+
+## 잘된 부분
+
+- `diagnose-status.mjs`가 artifact별 `complete`, `template`, `quality_warnings`를 제공한다.
+- `build-dashboard-data.mjs`가 template-only run을 제외하고, review 전 run을 실패가 아니라 incomplete data로 표시한다.
+- #44 PASS 결과는 유지하면서 #38 템플릿 run과 #45 진행 중 run을 구분한다.
+
+## 부족한 부분
+
+- 템플릿 판별 헬퍼가 두 스크립트에 중복되어 있다.
+- 별도 단위 테스트 파일은 추가하지 않았다.
+
+## 필요한 재작업
+
+- #45 범위에서 재작업은 필요 없다.
+- 헬퍼 공통화나 테스트 파일 추가는 후속 개선으로 다룰 수 있다.
+
+## PR 게이트
+
+PASS. 일반 PR에 포함 가능.

--- a/.agents/runs/issue-45/run-record.json
+++ b/.agents/runs/issue-45/run-record.json
@@ -1,0 +1,34 @@
+{
+  "run_id": "issue-45",
+  "issue": {
+    "number": 45,
+    "title": "[Harness] 실제 실행 run 기준으로 상태 표시 개선",
+    "url": "https://github.com/tkyoun0421/la-bie-belle/issues/45"
+  },
+  "status": "reviewed",
+  "attempt": 1,
+  "artifacts": {
+    "task_spec": "task-spec.md",
+    "plan": "plan.md",
+    "spec": "spec.md",
+    "implementation_notes": "implementation-notes.md",
+    "verification": "verification.md",
+    "review_score": "review-score.json",
+    "review": "review.md"
+  },
+  "changed_files": [
+    ".agents/harness/scripts/diagnose-status.mjs",
+    ".agents/harness/scripts/build-dashboard-data.mjs",
+    ".agents/harness/dashboard/data/runs.js"
+  ],
+  "scores": [
+    {
+      "score_id": "issue-45-review-attempt-1",
+      "total_score": 91,
+      "decision": "PASS",
+      "file": "review-score.json"
+    }
+  ],
+  "created_at": "2026-05-12T05:28:11.698Z",
+  "updated_at": "2026-05-12T05:50:00.000Z"
+}

--- a/.agents/runs/issue-45/run-record.json
+++ b/.agents/runs/issue-45/run-record.json
@@ -14,7 +14,9 @@
     "implementation_notes": "implementation-notes.md",
     "verification": "verification.md",
     "review_score": "review-score.json",
-    "review": "review.md"
+    "review": "review.md",
+    "harness_health_score": "harness-health-score.json",
+    "harness_improvements": "harness-improvements.md"
   },
   "changed_files": [
     ".agents/harness/scripts/diagnose-status.mjs",
@@ -27,6 +29,12 @@
       "total_score": 91,
       "decision": "PASS",
       "file": "review-score.json"
+    },
+    {
+      "score_id": "issue-45-harness-health",
+      "total_score": 82,
+      "decision": "HEALTH_RECORDED",
+      "file": "harness-health-score.json"
     }
   ],
   "created_at": "2026-05-12T05:28:11.698Z",

--- a/.agents/runs/issue-45/spec.md
+++ b/.agents/runs/issue-45/spec.md
@@ -1,0 +1,77 @@
+# 기능 상세 스펙
+
+## 사용자 시나리오
+
+- 작업자가 새 issue run을 시작한 직후 status를 보면, 템플릿 파일이 존재하더라도 실제 review 완료처럼 보이지 않아야 한다.
+- 작업자가 dashboard를 보면, 실제 review가 작성되지 않은 run이 0점 FAIL로 평균과 실패 수를 왜곡하지 않아야 한다.
+- Reviewer가 실제 0점 FAIL을 작성한 경우에는 템플릿이 아니라 유효한 review 결과로 표시되어야 한다.
+
+## 정상 흐름
+
+- `start-issue.mjs`가 생성한 템플릿 파일은 `template: true`, `complete: false`로 진단한다.
+- stage 추론은 complete artifact만 사용한다.
+- review decision은 complete review score에서만 가져온다.
+- dashboard summary의 평균 점수와 PASS/REWORK/FAIL count는 유효한 review score가 있는 run만 반영한다.
+- review score가 없는 run은 dashboard 개별 run에 `total_score: null`, `decision: null`, data quality warning을 갖는다.
+
+## 엣지케이스
+
+- 실제 review가 0점 FAIL일 수 있으므로, 점수값만으로 템플릿 여부를 판단하지 않는다.
+- `score_id`가 아직 템플릿 sentinel(`issue-000-review-attempt-1`)이거나 `recommended_next_action`에 `작성 필요`가 있으면 템플릿으로 본다.
+- markdown 산출물에 `작성 필요`만 남아 있으면 템플릿으로 본다.
+- 일부 섹션만 작성된 중간 산출물은 complete로 보지 않고 quality warning을 남긴다.
+
+## 에러 상태
+
+- JSON 파싱 실패는 parse error warning으로 표시하고 complete artifact로 보지 않는다.
+- run-record가 없으면 dashboard 대상에서 제외한다.
+
+## 빈 상태
+
+- active run이 없으면 기존처럼 빈 runs 목록을 반환한다.
+- review score가 하나도 없으면 dashboard average issue score는 `null`로 둔다.
+
+## 로딩 상태
+
+- 해당 없음. CLI 스크립트와 dashboard data 생성 기준 변경이다.
+
+## 권한과 인증 조건
+
+- 로컬 파일 읽기/쓰기 권한이 필요하다.
+- GitHub API 권한은 이 구현 자체에는 필요하지 않다.
+
+## 입력 검증
+
+- `review-score.json`은 JSON parse가 가능해야 한다.
+- review decision은 complete review score에서만 PASS/REWORK/FAIL로 사용한다.
+- artifact 경로는 기존 run-record artifact contract를 따른다.
+
+## 데이터 규칙
+
+- artifact info는 `exists`, `bytes`, `updated_at`에 더해 `complete`, `template`, `quality_warnings`를 제공한다.
+- dashboard run은 `data_quality_warnings` 배열을 제공한다.
+- summary count/average는 complete review score가 있는 reviewed run만 대상으로 한다.
+
+## UI 동작
+
+- dashboard UI 코드는 변경하지 않는다.
+- dashboard data에 null score와 warning 배열을 제공해 후속 UI 개선이 가능하게 한다.
+
+## API 또는 모듈 계약
+
+- `diagnose-status.mjs` 출력은 기존 필드를 유지하고 artifact별 메타데이터를 추가한다.
+- `build-dashboard-data.mjs`의 `window.AI_HARNESS_RUNS` 구조는 기존 필드를 유지하되 `data_quality_warnings`, `review_complete`, nullable score/decision을 추가한다.
+
+## 테스트 케이스
+
+- 템플릿 상태의 issue-38은 `inferred_artifact_stage: planned`, `decision: null`로 진단된다.
+- 실제 PASS review가 있는 issue-44는 `reviewed`, `PASS`로 유지된다.
+- issue-45가 review 작성 전에는 dashboard summary에 실패로 집계되지 않는다.
+- dashboard data 생성 후 review 없는 run은 `data_quality_warnings`를 가진다.
+- #45 review score 작성 후 `validate-score.mjs`가 통과한다.
+
+## Red 단계 우선순위
+
+1. 현재 `diagnose-status.mjs`가 템플릿 issue-38을 `reviewed`/`FAIL`로 오인하는 것을 기록한다.
+2. 현재 `build-dashboard-data.mjs`가 템플릿 review score를 summary 평균과 FAIL count에 포함하는 것을 기록한다.
+3. Green 이후 같은 명령에서 issue-38이 실제 완료 run으로 집계되지 않는지 확인한다.

--- a/.agents/runs/issue-45/state.json
+++ b/.agents/runs/issue-45/state.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "issue-45",
+  "issue_number": 45,
+  "stage": "reviewed",
+  "decision": "PASS",
+  "priority": null,
+  "blocked": false,
+  "blockers": [],
+  "inbox_refs": [],
+  "dashboard_synced_at": null,
+  "updated_at": "2026-05-12T05:50:00.000Z"
+}

--- a/.agents/runs/issue-45/state.json
+++ b/.agents/runs/issue-45/state.json
@@ -8,5 +8,6 @@
   "blockers": [],
   "inbox_refs": [],
   "dashboard_synced_at": null,
-  "updated_at": "2026-05-12T05:50:00.000Z"
+  "harness_health_score": 82,
+  "updated_at": "2026-05-12T05:55:00.000Z"
 }

--- a/.agents/runs/issue-45/task-spec.md
+++ b/.agents/runs/issue-45/task-spec.md
@@ -1,0 +1,48 @@
+# 작업 명세
+
+## 목표
+
+하네스 status/dashboard/review 표시가 빈 템플릿 산출물을 실제 실행 결과로 오인하지 않도록, 실제 작성된 run과 누락/초기 템플릿 데이터를 구분한다.
+
+## 범위
+
+- `diagnose-status.mjs`가 빈 템플릿 산출물을 완료 산출물로 추론하지 않도록 개선
+- `build-dashboard-data.mjs`가 빈 템플릿 review score를 실제 0점/FAIL run으로 표시하지 않도록 개선
+- 누락 또는 템플릿 상태인 데이터에 데이터 품질 경고를 노출
+- #45 run 산출물에 Red/Green/검증/리뷰 기록 남김
+
+## 제외 범위
+
+- dashboard UI 레이아웃 전면 개편
+- 리뷰 루브릭 세분화
+- PR follow-up 추적 자동화
+- 기존 GitHub Issue 라벨/Project 필드 정리
+- 제품 코드 변경
+
+## 관련 파일 또는 영역
+
+- `.agents/harness/scripts/diagnose-status.mjs`
+- `.agents/harness/scripts/build-dashboard-data.mjs`
+- `.agents/harness/templates/*`
+- `.agents/harness/dashboard/data/runs.js`
+- `.agents/runs/issue-45/*`
+
+## 검증 방법
+
+- 템플릿만 있는 `issue-38` 또는 신규 run이 `reviewed`/`FAIL`로 추론되지 않는지 확인
+- #44처럼 실제 review score가 작성된 run은 PASS로 유지되는지 확인
+- dashboard data에서 템플릿 run이 평균 점수와 FAIL count를 왜곡하지 않는지 확인
+- `validate-score.mjs`로 #45 review score 검증
+
+## 완료 기준
+
+- 빈 템플릿 review 산출물이 status에서 terminal decision으로 표시되지 않는다.
+- dashboard summary가 실제 review score가 있는 run만 issue score 평균과 pass/rework/fail count에 반영한다.
+- 누락/템플릿 데이터는 실제 0점 대신 데이터 품질 경고 또는 missing 상태로 표현된다.
+- #44 PASS run은 계속 정상 PASS로 표시된다.
+
+## 리스크
+
+- 템플릿 판별 조건이 너무 넓으면 실제 낮은 점수의 review를 누락할 수 있다.
+- 템플릿 판별 조건이 너무 좁으면 기존처럼 빈 산출물이 실제 실패로 보일 수 있다.
+- dashboard summary 계산 기준 변경으로 과거 수치가 달라질 수 있다.

--- a/.agents/runs/issue-45/verification.md
+++ b/.agents/runs/issue-45/verification.md
@@ -16,6 +16,9 @@ Get-Content .agents\harness\dashboard\data\runs.js -Encoding UTF8 | Select-Objec
 - `build-dashboard-data.mjs`는 template-only issue-38을 dashboard runs에서 제외했다.
 - dashboard summary는 review 완료 run만 집계해 `issue_count: 1`, `average_issue_score: 92`, `pass_count: 1`, `fail_count: 0`을 표시했다.
 - review 전 #45는 `review_complete: false`, `total_score: null`, `data_quality_warnings`를 표시했다.
+- 후속 보정에서 dashboard 리뷰 근거, 감점 사유, 카테고리 라벨, 개선 제안 설명, agent/workflow 설명을 한글로 표시하도록 갱신했다.
+- 활성 run에 하네스 건강도 평가가 없으면 archived run의 74점을 현재 `average_harness_score`로 표시하지 않고 `null`로 표시하도록 수정했다.
+- dashboard 화면은 null 점수를 `평가 없음`으로 표시한다.
 
 ## 완료 기준 매핑
 
@@ -23,6 +26,7 @@ Get-Content .agents\harness\dashboard\data\runs.js -Encoding UTF8 | Select-Objec
 - dashboard summary는 실제 review score가 있는 run만 평균과 결정 count에 반영한다.
 - 누락/템플릿 데이터는 실제 0점 대신 `null` score와 data quality warning으로 표시된다.
 - #44 PASS run은 정상 PASS로 유지된다.
+- dashboard 근거 문구와 하네스 표시가 한글/미평가 상태로 정리됐다.
 
 ## 건너뛴 검증
 

--- a/.agents/runs/issue-45/verification.md
+++ b/.agents/runs/issue-45/verification.md
@@ -1,0 +1,33 @@
+# 검증 기록
+
+## 실행한 명령
+
+```txt
+node .agents/harness/scripts/diagnose-status.mjs
+node .agents/harness/scripts/build-dashboard-data.mjs
+Get-Content .agents\harness\dashboard\data\runs.js -Encoding UTF8 | Select-Object -First 120
+```
+
+## 결과
+
+- `diagnose-status.mjs`에서 template-only issue-38은 `inferred_artifact_stage: unplanned`, `decision: null`, `cleanup_candidate: false`로 표시됐다.
+- #44는 실제 작성된 review artifact를 기준으로 `reviewed`, `PASS`를 유지했다.
+- #45는 review 작성 전 상태에서 `specified`, `decision: null`로 표시됐고 템플릿 review/verification artifact 경고를 표시했다.
+- `build-dashboard-data.mjs`는 template-only issue-38을 dashboard runs에서 제외했다.
+- dashboard summary는 review 완료 run만 집계해 `issue_count: 1`, `average_issue_score: 92`, `pass_count: 1`, `fail_count: 0`을 표시했다.
+- review 전 #45는 `review_complete: false`, `total_score: null`, `data_quality_warnings`를 표시했다.
+
+## 완료 기준 매핑
+
+- 빈 템플릿 review 산출물은 더 이상 status에서 terminal decision으로 표시되지 않는다.
+- dashboard summary는 실제 review score가 있는 run만 평균과 결정 count에 반영한다.
+- 누락/템플릿 데이터는 실제 0점 대신 `null` score와 data quality warning으로 표시된다.
+- #44 PASS run은 정상 PASS로 유지된다.
+
+## 건너뛴 검증
+
+- 없음.
+
+## 남은 리스크
+
+- 실제 0점 FAIL review가 템플릿 sentinel 값을 제거하고 evidence/deductions를 작성해야 유효 review로 집계된다.


### PR DESCRIPTION
Closes #45

## 요약

- 빈 하네스 템플릿 산출물을 실제 완료 산출물과 구분하도록 status 진단 기준을 개선했습니다.
- dashboard data가 실제 review score가 있는 run만 평균/결정 카운트에 반영하도록 수정했습니다.
- 누락 또는 템플릿 review 데이터는 실제 0점 대신 `null` score와 data quality warning으로 표시합니다.
- dashboard 리뷰 근거, 감점 사유, 카테고리 라벨, 개선 제안, agent/workflow 설명을 한글로 정리했습니다.
- 하네스 건강도 평가를 수행하고 활성 run 기준 하네스 점수 82점을 dashboard에 반영했습니다.

## 관련 이슈

- Closes #45

> 원본 이슈가 있으면 반드시 `Closes #이슈번호`를 남겨 머지 시 자동 종료되게 한다.
> 별도 원본 이슈가 없는 운영 보강 PR이면 그 이유를 적는다.

## 하네스 단계

- [x] 계획: `ai-harness-plan`
- [x] 상세 스펙: `ai-harness-spec`
- [x] Red: `ai-harness-red`
- [x] Green: `ai-harness-green`
- [ ] 리팩토링: `ai-harness-refactor` / 생략 사유: 동작 기준 수정이 작고 후속 공통화는 별도 개선으로 충분함
- [x] 검증: `ai-harness-verify`
- [x] 리뷰: `ai-harness-review`
- [x] 하네스 건강도 평가: `ai-harness-evaluate`
- [x] 대시보드 갱신: `ai-harness-dashboard`
- [x] PR 생성: `ai-harness-draft-pr`

## 완료 기준 체크

- [x] 원본 이슈 완료 기준을 모두 대조했다.
- [x] 작업 중 추가된 사항을 현재 PR 반영 / 후속 이슈 / 명시적 보류 중 하나로 정리했다.
- [x] 현재 이슈 관련 `.agents/inbox.md` 항목을 완료 / 승격 / 보류 중 하나로 정리했다.
- [x] PR 본문 첫 부분에 원본 이슈 closing keyword를 포함했다.

## Reviewer 점수

- 결정: `PASS`
- 총점: `91/100`
- 점수 파일: `.agents/runs/issue-45/review-score.json`

## 하네스 건강도

- 총점: `82/100`
- 점수 파일: `.agents/runs/issue-45/harness-health-score.json`
- 개선 제안:
  - `.agents/harness/improvements/proposals/2026-05-12-template-artifact-regression-tests.json`
  - 템플릿 산출물 판별 회귀 테스트와 판별 헬퍼 공통화 제안

## 검증

실행한 명령과 결과를 적습니다.

```txt
node .agents/harness/scripts/validate-score.mjs .agents/runs/issue-45/review-score.json -> passed
node .agents/harness/scripts/validate-score.mjs .agents/runs/issue-44/review-score.json -> passed
node .agents/harness/scripts/diagnose-status.mjs -> #45 PASS, #44 PASS, template-only #38 removed from committed state
node .agents/harness/scripts/build-dashboard-data.mjs -> dashboard data regenerated
rg average_harness_score .agents/harness/dashboard/data/runs.js -> active harness average is 82 after evaluation
```

## 추가 작업 처리

- inbox: 미처리 항목 없음.
- 후속 이슈: 없음.
- 보류: 템플릿 판별 로직 공통화와 단위 테스트 추가는 개선 제안으로 기록하고 별도 승인 후 진행.

## 변경 범위

- `diagnose-status.mjs` artifact completion/template 판단
- `build-dashboard-data.mjs` summary 집계, data quality warning, 한글 라벨, 활성 하네스 점수 집계 기준
- dashboard 화면의 null 점수 `평가 없음` 표시
- dashboard generated data 갱신
- issue #44/#45 review 근거 한글화
- issue #45 run 산출물, 하네스 건강도 평가, 개선 제안 기록

## 제외 범위

- dashboard UI 레이아웃 전면 개편
- 리뷰 루브릭 세분화
- PR follow-up 추적 자동화
- 제품 코드 변경
- 템플릿 판별 단위 테스트 구현

## 리스크와 남은 작업

- 템플릿 형식이 바뀌면 sentinel/placeholder 판별 기준도 갱신해야 합니다.
- 실제 0점 FAIL review는 템플릿 sentinel 값 없이 evidence/deductions가 작성되어야 유효 결과로 집계됩니다.
- 템플릿 판별 로직이 두 스크립트에 중복되어 있어 후속 공통화가 필요합니다.

## 하네스 영향

- [ ] AI-impact 변경 아님
- [x] AI-impact 변경임

AI-impact인 경우 영향 영역을 적습니다.

- 입력 / 판단 / 출력 / 평가 / 권한 / 안전 경계: run 산출물 완료 판단, dashboard 평가 집계, status 출력 기준, 하네스 건강도 표시 기준