### PR TITLE
chore(orch): link project board and fix stale guard messages

### DIFF
--- a/.claude/hooks/ownership-check.py
+++ b/.claude/hooks/ownership-check.py
@@ -71,7 +71,7 @@ def check_hook(role, project_dir):
             "hook",
             f"ownership-check: role '{role}' may only edit its own worktree "
             f"(plus temp and ~/.claude). '{abs_path}' is outside it. "
-            "Never edit other worktrees directly — integrate through main (docs/rules.md §4).",
+            "Never edit other worktrees directly — integrate through main (docs/rules.md §5).",
         )
 
     rel = os.path.relpath(abs_path, real_project)
@@ -80,8 +80,8 @@ def check_hook(role, project_dir):
     fail(
         "hook",
         f"ownership-check: role '{role}' does not own '{rel}'. Do not edit it. "
-        "Request the change from the owning agent via Issue or PR comment "
-        "(docs/rules.md, config/ownership.json).",
+        "Open a [Request] Issue for the owning agent "
+        "(docs/rules.md §1·§3, config/ownership.json).",
     )
 
 
@@ -93,7 +93,7 @@ def check_paths(role, project_dir):
         print(f"pre-commit: role '{role}' is touching files it does not own (add/modify/delete/rename):", file=sys.stderr)
         for f in bad:
             print(f"  {f}", file=sys.stderr)
-        print("Request changes outside your ownership via Issue or PR comment (docs/rules.md).", file=sys.stderr)
+        print("Open a [Request] Issue for changes outside your ownership (docs/rules.md §1·§3).", file=sys.stderr)
         sys.exit(DENY_COMMIT)
 
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -80,7 +80,7 @@ related_issue: "#62"
 | surface | `surface:ui` `surface:db` `surface:auth` `surface:api` `surface:workflow` `surface:docs` |
 | risk | `risk:security` `risk:privacy` `risk:performance` `risk:concurrency` `risk:migration` `risk:external` |
 
-**Project Status** — 상태의 정본은 GitHub Project의 Status 필드다.
+**Project Status** — 상태의 정본은 GitHub Project [La Bie Belle](https://github.com/users/tkyoun0421/projects/8)의 Status 필드다. 새 Issue는 보드에 올린 뒤 상태를 지정한다 (`gh project item-add 8 --owner tkyoun0421 --url <issue-url>`).
 
 | Status | 의미 | 옮기는 손 |
 |--------|------|-----------|


### PR DESCRIPTION
## 목적
Project 보드 생성 완료 반영 + 리뷰 normal 후속 (#65)

## 내용
- `docs/rules.md`: Project Status 절에 보드 링크(users/tkyoun0421/projects/8)와 item-add 명령 추가
- `.claude/hooks/ownership-check.py`: 재넘버링으로 깨진 §4 참조를 §5로, 소유 밖 수정 안내를 `[Request]` Issue 경로로 통일 (실측: 거부 exit 2·허용 exit 0 확인)

## Impact
- Rules Impact: docs/rules.md §3 — 보드 위치 명시

보드 세팅: Status 6단계(Backlog/Todo/In Progress/In Review/Done/Blocked) 구성, 열린 Issue #63·#65·#66을 Backlog로 등록 완료.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)