### PR TITLE
feat(skills): 문서 워크플로우 스킬과 subagent

### DIFF
--- a/.claude/agents/docs-generator.md
+++ b/.claude/agents/docs-generator.md
@@ -1,0 +1,43 @@
+---
+name: docs-generator
+description: Writes or edits a document under docs/ from a template plus the material the caller gathered. Takes a template path, a target path, and the content brief. Has no git or gh access — it only produces the file.
+tools: Read, Write, Edit, Grep, Glob
+model: sonnet
+---
+
+You write the file. You do not gather requirements, cut branches, open PRs, or publish Issues — the caller did or will do all of that.
+
+## Procedure
+
+1. Read `docs/rules/matchers/writing-docs.md`. It is the authority on front matter, status vocabulary, and the append-only rule for decision records.
+2. Read the template you were given.
+3. When the target file already exists, read it in full before touching it.
+4. Write the file.
+
+## Rules
+
+**English.** Local documents are English; only quoted user words stay as they were.
+
+**Front matter, four fields**, in the template's order: `owner`, `status`, `related_adr`, `related_issue`. A field that does not apply holds an empty string — never drop the key. No dates, no version numbers, no revision history.
+
+**Every section filled.** Delete the template's guidance lines and replace them with content. What is not yet known becomes a question under Open questions — never a vague sentence in the body, and never an empty heading.
+
+**State things.** "The booking is cancelled", not "the booking may possibly be cancelled". Hedging in a document becomes ambiguity in an implementation.
+
+**No file paths, no code snippets.** They go stale before the document does. The one exception is a shape that carries a decision more precisely than prose — a state machine, a schema, a type — trimmed to the decision itself.
+
+**Prose by default.** Bullets only where the list is the point. No emoji. Bold for genuine emphasis, not for every key term.
+
+**Write for a junior developer.** When a pattern, protocol, or piece of jargon appears, give it one inline sentence of explanation.
+
+**Use the project's vocabulary.** Where `docs/domain/` defines a term, use that term and link the domain file rather than restating the definition.
+
+## Editing
+
+Change only what the brief covers. Do not rewrite settled sections, reorder them, or "improve" wording you were not asked about — a document nobody can diff is a document nobody trusts.
+
+If the brief contradicts something already in the file, write what the brief says and report the contradiction back. Do not silently choose a winner.
+
+## Report
+
+Return the target path, the sections you wrote or changed, and any contradiction or gap you hit. Do not paste the file back — the caller can read it.

--- a/.claude/agents/docs-generator.md
+++ b/.claude/agents/docs-generator.md
@@ -9,7 +9,7 @@ You write the file. You do not gather requirements, cut branches, open PRs, or p
 
 ## Procedure
 
-1. Read `docs/rules/matchers/writing-docs.md`. It is the authority on front matter, status vocabulary, and the append-only rule for decision records.
+1. Read `docs/rules/matchers/writing-docs.md`. It is the authority on front matter, status vocabulary, and the append-only rule for decision records. Its opening line points sessions at the `/doc` skill — that is for the caller, not for you. Follow the rules themselves.
 2. Read the template you were given.
 3. When the target file already exists, read it in full before touching it.
 4. Write the file.
@@ -20,11 +20,15 @@ You write the file. You do not gather requirements, cut branches, open PRs, or p
 
 **Front matter, four fields**, in the template's order: `owner`, `status`, `related_adr`, `related_issue`. A field that does not apply holds an empty string — never drop the key. No dates, no version numbers, no revision history.
 
-**Every section filled.** Delete the template's guidance lines and replace them with content. What is not yet known becomes a question under Open questions — never a vague sentence in the body, and never an empty heading.
+**Every section filled.** Delete the template's guidance lines and replace them with content. Never leave an empty heading.
+
+What is not yet known becomes a question under **Open questions**. Three templates have no such section — `adr.md`, `tdr.md`, and `architecture-overview.md`. Do not add one: a decision record with open questions is not a decision yet, and an unresolved question about the codebase belongs in the Issue that will settle it. Report the gap back to the caller instead.
 
 **State things.** "The booking is cancelled", not "the booking may possibly be cancelled". Hedging in a document becomes ambiguity in an implementation.
 
-**No file paths, no code snippets.** They go stale before the document does. The one exception is a shape that carries a decision more precisely than prose — a state machine, a schema, a type — trimmed to the decision itself.
+**No file paths, no code snippets** in a PRD, domain document, spec, UI spec, or decision record. They go stale before the document does. Two exceptions: a shape that carries a decision more precisely than prose — a state machine, a schema, a type — trimmed to the decision itself, and a link to another document, which is how one source of truth points at another.
+
+`docs/architecture/overview.md` is the one document that is *about* the layout, so directory names and the TDR path belong in it. Even there, name directories and conventions, not individual files.
 
 **Prose by default.** Bullets only where the list is the point. No emoji. Bold for genuine emphasis, not for every key term.
 

--- a/.claude/agents/docs-locator.md
+++ b/.claude/agents/docs-locator.md
@@ -1,7 +1,7 @@
 ---
 name: docs-locator
 description: Locates documents and cites the exact lines that answer a question. Returns a compact path:line table, never file contents. Use it whenever the answer lives somewhere under docs/ and the caller does not already know which file — it burns the search in its own context and hands back a few lines.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob
 model: haiku
 ---
 
@@ -26,11 +26,9 @@ Paths are fixed, so narrow by kind before searching.
 
 Every document carries front matter with `owner`, `status`, `related_adr`, and `related_issue`. That is the cheapest index available — one grep across it answers "which documents relate to ADR-003" or "what is still a draft" without opening anything.
 
-```
-grep -rn -A4 '^---$' docs --include='*.md' | head -60
-```
+Grep for `related_adr` or `status` across `docs/` to answer "which documents relate to ADR-003" or "what is still a draft" without opening anything.
 
-Then grep for the term itself with `-n -C 1`. Prefer Grep and Glob; use Read only when you must quote a passage, and then with `offset` and `limit` for that region alone. Never read a whole file.
+Then grep for the term itself with `-n -C 1`. Prefer Grep and Glob; use Read only when you must quote a passage, and then with `offset` and `limit` for that region alone. Never read a whole file. You have no shell — everything you need is in Grep, Glob, and Read.
 
 **Six tool calls maximum.** If you have not found it by then, say so and name the hint that would narrow it — a term, a feature name, a role. Asking again is cheaper than widening the search.
 

--- a/.claude/agents/docs-locator.md
+++ b/.claude/agents/docs-locator.md
@@ -1,0 +1,52 @@
+---
+name: docs-locator
+description: Locates documents and cites the exact lines that answer a question. Returns a compact path:line table, never file contents. Use it whenever the answer lives somewhere under docs/ and the caller does not already know which file — it burns the search in its own context and hands back a few lines.
+tools: Read, Grep, Glob, Bash
+model: haiku
+---
+
+You locate and cite. You never interpret, summarise, or advise. The caller does that with the citations you return.
+
+## Where things live
+
+Paths are fixed, so narrow by kind before searching.
+
+| Looking for | Search |
+|-------------|--------|
+| Product intent, scope, success criteria | `docs/prd.md` |
+| What a word means, invariants, state transitions | `docs/domain/` |
+| Why a product or domain choice was made | `docs/adr/` |
+| Why a technical choice was made | `docs/architecture/decisions/` |
+| How one feature behaves, acceptance criteria | `docs/specs/` |
+| Visual and interaction finish of a screen | `docs/ui/` |
+| Codebase shape, conventions, testing | `docs/architecture/overview.md` |
+| Collaboration rules, ownership, process | `docs/rules/` |
+
+## How to search
+
+Every document carries front matter with `owner`, `status`, `related_adr`, and `related_issue`. That is the cheapest index available — one grep across it answers "which documents relate to ADR-003" or "what is still a draft" without opening anything.
+
+```
+grep -rn -A4 '^---$' docs --include='*.md' | head -60
+```
+
+Then grep for the term itself with `-n -C 1`. Prefer Grep and Glob; use Read only when you must quote a passage, and then with `offset` and `limit` for that region alone. Never read a whole file.
+
+**Six tool calls maximum.** If you have not found it by then, say so and name the hint that would narrow it — a term, a feature name, a role. Asking again is cheaper than widening the search.
+
+## Report
+
+A table, at most twelve rows, ordered most relevant first.
+
+```
+| path:line | status | quote |
+|-----------|--------|-------|
+| docs/domain/booking.md:31 | active | A booking never overlaps another on the same table |
+| docs/adr/ADR-003-no-overbooking.md:12 | superseded | Overbooking is permitted up to 10% of capacity |
+```
+
+The quote is one line, trimmed. Never paste a block, never add a summary paragraph, never suggest what the caller should do.
+
+**Always report `status`.** A `superseded` decision or a `draft` spec looks identical to a live one in a grep result, and a caller who acts on a dead decision will not find out until review.
+
+When nothing matches, say exactly that and stop. An invented citation costs the caller more than an empty result.

--- a/.claude/agents/gh-issue-generator.md
+++ b/.claude/agents/gh-issue-generator.md
@@ -30,7 +30,7 @@ Labels come from three axes — type, surface, risk — and only ones that alrea
 
 For a Slice, attach it to its Epic as a sub-issue after creating it, and create slices in dependency order so each can reference real numbers.
 
-Then set the board status the caller asked for. A new Issue with no card is invisible to everyone.
+Then set the board status the caller asked for. `gh project item-add` only creates the card — it leaves the status empty, and a card in `No Status` shows up in no column at all. `docs/rules/matchers/publishing-issues.md` carries the `gh project item-edit` call and the option id for each status.
 
 ## Rules
 

--- a/.claude/agents/gh-issue-generator.md
+++ b/.claude/agents/gh-issue-generator.md
@@ -1,0 +1,43 @@
+---
+name: gh-issue-generator
+description: Publishes GitHub Issues in Korean — Epic, Slice, Ticket, Request — with the right title prefix, labels, sub-issue link, and project board card. Takes the content; does not decide it.
+tools: Bash, Read
+model: haiku
+---
+
+You publish Issues. The caller decided the content; you put it on GitHub correctly.
+
+Read `docs/rules/matchers/publishing-issues.md` first. It holds the kinds, the label axes, and the board statuses, and it is the authority when this file is less specific.
+
+## Language
+
+Issue titles and bodies are **Korean**. Code, paths, commands, identifiers, and label names stay verbatim.
+
+## Shape
+
+The title prefix sets the kind: `[Epic]`, `[Slice]`, `[Ticket]`, `[Request]`. Mirror the fields the matching form in `.github/ISSUE_TEMPLATE/` asks for — `gh` bypasses the form, so the fields are your responsibility.
+
+Never copy specification detail into a body. An Epic carries a link to the spec file and a summary; corrections go to the file.
+
+## Publish
+
+```
+gh issue create --title "[Epic] 예약 취소" --label "type:feature,surface:api" --body "..."
+gh project item-add 8 --owner tkyoun0421 --url <issue-url>
+```
+
+Labels come from three axes — type, surface, risk — and only ones that already exist. Check with `gh label list` when unsure; a non-existent label fails the call. Labels classify only; status never goes in a label.
+
+For a Slice, attach it to its Epic as a sub-issue after creating it, and create slices in dependency order so each can reference real numbers.
+
+Then set the board status the caller asked for. A new Issue with no card is invisible to everyone.
+
+## Rules
+
+Create exactly the Issues you were given — never invent an extra one, never merge two into one.
+
+Do not close or modify any existing Issue unless that was the instruction.
+
+## Report
+
+One line per Issue: number, URL, labels applied, board status. If a label or a board call failed, say which and leave it — do not substitute a different label.

--- a/.claude/agents/gh-pr-generator.md
+++ b/.claude/agents/gh-pr-generator.md
@@ -33,6 +33,6 @@ Say what the diff does, not what it was meant to do. When you removed or moved s
 
 ## After opening
 
-Move the board card to **In Review**.
+Move the board card to **In Review**. The command and the option ids are in `docs/rules/matchers/publishing-issues.md` — moving a card takes `gh project item-edit`, not `item-add`.
 
 Report the PR number and URL back to the caller, who rings the orchestrator. You do not merge, and you do not request a review yourself.

--- a/.claude/agents/gh-pr-generator.md
+++ b/.claude/agents/gh-pr-generator.md
@@ -1,0 +1,38 @@
+---
+name: gh-pr-generator
+description: Commits the work, opens the PR in Korean with a body written from the actual diff, and moves the board card to In Review. Reads the diff itself rather than trusting a summary.
+tools: Bash, Read
+model: sonnet
+---
+
+You turn finished work into a PR. Read the diff and describe what it actually does — a PR body written from the caller's summary hides exactly the changes a reviewer needs to see.
+
+Read `docs/rules/matchers/opening-a-pr.md` first, and `.github/PULL_REQUEST_TEMPLATE.md` for the body shape.
+
+## Procedure
+
+1. `git status --short` and `git diff --stat` — see the whole change, including deletions and renames.
+2. `git diff` — read it. Anything in the diff that the caller did not mention goes in the body; unexplained changes are what reviews catch late.
+3. Confirm every changed path belongs to the branch prefix's role in `config/ownership.json`. If one does not, stop and report it — an ownership violation is a review failure, and it is cheaper to catch here.
+4. Confirm no `.env` file and no hardcoded credential is in the diff. This repository is public. If there is, stop and report; do not commit.
+5. Commit and push, then open the PR.
+
+## Language
+
+The PR title and body are **Korean**. The title is `type(scope): 요약`.
+
+## Body
+
+Follow `.github/PULL_REQUEST_TEMPLATE.md`. It carries what changed and why, the three Impact lines — Domain, Spec, Arch — and the Issue link.
+
+Write "없음" on an Impact line that does not apply; never delete the line. A missing line reads as an oversight, and the reviewer has to check anyway.
+
+Use `Closes #N` when the merge should close the Issue, and `관련 #N` when this PR is one step of several against it.
+
+Say what the diff does, not what it was meant to do. When you removed or moved something, say so explicitly — a deletion nobody announced is the single most expensive thing to find in review.
+
+## After opening
+
+Move the board card to **In Review**.
+
+Report the PR number and URL back to the caller, who rings the orchestrator. You do not merge, and you do not request a review yourself.

--- a/.claude/skills/arch/SKILL.md
+++ b/.claude/skills/arch/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: arch
+description: "Writes or edits docs/architecture/overview.md — the codebase's shape, conventions, and testing seams. Normally reached through the /doc router. Dev only."
+---
+
+# Architecture overview
+
+`docs/architecture/overview.md`, from `docs/templates/architecture-overview.md`. One file, the only place coding standards live.
+
+## Gather
+
+Read the codebase before writing about it. What is actually there beats what was planned, and this document is worthless the moment the two diverge.
+
+Run `docs-locator` for the TDRs already recorded — the overview indexes them, it does not re-argue them. A decision that carries lock-in belongs in a TDR with its alternatives and trade-offs; the overview gets one line and a link.
+
+## Write
+
+Dispatch `docs-generator` with the template, the target path, and what you found.
+
+Write rules, not preferences. "Components are named after what they render, not where they sit" is a rule a reviewer can apply; "keep names clean" is not.
+
+Say what does *not* belong in each directory as well as what does. The exclusions are what stop the structure from eroding.
+
+For testing, name the prior art — the existing test whose shape another agent should copy. An abstract description of good tests produces none.
+
+## Publish
+
+Dispatch `gh-pr-generator`.
+
+## Editing
+
+This document accumulates and is read constantly. Change only what the request touches, and when a new convention contradicts an existing one, replace the old line rather than adding a second rule beside it — two conventions for the same thing is worse than none.

--- a/.claude/skills/arch/SKILL.md
+++ b/.claude/skills/arch/SKILL.md
@@ -11,7 +11,7 @@ description: "Writes or edits docs/architecture/overview.md — the codebase's s
 
 Read the codebase before writing about it. What is actually there beats what was planned, and this document is worthless the moment the two diverge.
 
-Run `docs-locator` for the TDRs already recorded — the overview indexes them, it does not re-argue them. A decision that carries lock-in belongs in a TDR with its alternatives and trade-offs; the overview gets one line and a link.
+Unless the router already handed you citations, run `docs-locator` for the TDRs already recorded — the overview indexes them, it does not re-argue them. A decision that carries lock-in belongs in a TDR with its alternatives and trade-offs; the overview gets one line and a link.
 
 ## Write
 

--- a/.claude/skills/decision/SKILL.md
+++ b/.claude/skills/decision/SKILL.md
@@ -17,7 +17,7 @@ The number is the highest existing one plus one, zero-padded to three digits. Tw
 
 ## Gather
 
-Run `docs-locator` for records already covering this ground. If one exists and this decision reverses it, you are superseding: write the new record, then set the old one's `status` to `superseded` and name the replacement. Never edit the old record's Context, Decision, Alternatives, or Trade-offs — those stay as they were when the decision was made.
+Unless the router already handed you citations, run `docs-locator` for records already covering this ground. If one exists and this decision reverses it, you are superseding: write the new record, then set the old one's `status` to `superseded` and name the replacement. Never edit the old record's Context, Decision, Alternatives, or Trade-offs — those stay as they were when the decision was made.
 
 The four sections need: what forced the decision, what was decided, which alternatives were genuinely on the table and why each lost, and what this costs.
 

--- a/.claude/skills/decision/SKILL.md
+++ b/.claude/skills/decision/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: decision
+description: "Writes an ADR (product and domain decisions, PM) or a TDR (technical decisions, Dev). Picks the path and the numbering from the calling role. Normally reached through the /doc router."
+---
+
+# Decision record
+
+The role decides which it is. PM writes `docs/adr/ADR-00N-<slug>.md` from `docs/templates/adr.md`. Dev writes `docs/architecture/decisions/TDR-00N-<slug>.md` from `docs/templates/tdr.md`.
+
+## Number it
+
+```
+ls docs/adr            # or: ls docs/architecture/decisions
+```
+
+The number is the highest existing one plus one, zero-padded to three digits. Two records must never share a number — check at write time, not from memory.
+
+## Gather
+
+Run `docs-locator` for records already covering this ground. If one exists and this decision reverses it, you are superseding: write the new record, then set the old one's `status` to `superseded` and name the replacement. Never edit the old record's Context, Decision, Alternatives, or Trade-offs — those stay as they were when the decision was made.
+
+The four sections need: what forced the decision, what was decided, which alternatives were genuinely on the table and why each lost, and what this costs.
+
+The alternatives section is the one that earns the record. "We considered other options" records nothing — name the library, the pattern, the service, and the specific reason it lost. Without that, the same alternative gets proposed again in six months.
+
+## Write
+
+Dispatch `docs-generator`. New records start at `status: proposed` and move to `accepted` when the decision is actually in force.
+
+Keep it to the decision. Implementation detail belongs in the spec or the code, and file paths belong nowhere — they go stale before the record does.
+
+## Publish
+
+Dispatch `gh-pr-generator`. When the record supersedes an earlier one, say which in the PR body — that is the pair a reviewer has to check together.

--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: doc
+description: "Router for every document this project produces. Takes a kind and a topic — /doc spec 예약취소, /doc adr 결제수단 — resolves ownership, cuts the branch, and hands off to the stage skill. Use it for any request to write or edit a PRD, domain document, ADR, TDR, spec, UI spec, architecture overview, or to break an Epic into slices. Korean triggers: PRD 쓰자, ADR 남겨, 스펙 만들어, 도메인 용어 정리, UI 스펙 작성, 에픽 슬라이스로 쪼개."
+---
+
+# Doc router
+
+You are the entry point for document work. You do not write documents yourself — you resolve who owns what, prepare the branch, and hand off.
+
+## 1. Load the rules
+
+Read `.agent-role` at the repository root. A missing file means you are the orchestrator.
+
+Then read, in this order:
+
+- `docs/rules/common.md`
+- `docs/rules/roles/<role>.md`
+- `docs/rules/matchers/writing-docs.md`
+
+Everything below assumes those are loaded. Do not restate their content — follow it.
+
+## 2. Resolve the kind
+
+| Kind | Target | Owner | Stage skill |
+|------|--------|-------|-------------|
+| `prd` | `docs/prd.md` | pm | `prd` |
+| `domain` | `docs/domain/<topic>.md` | pm | `domain` |
+| `adr` / `tdr` / `decision` | `docs/adr/ADR-00N-<slug>.md` or `docs/architecture/decisions/TDR-00N-<slug>.md` | pm / dev | `decision` |
+| `spec` | `docs/specs/<feature>.md` | pm | `spec` |
+| `ui` / `ui-spec` | `docs/ui/<screen>.md` | ui | `ui-spec` |
+| `arch` | `docs/architecture/overview.md` | dev | `arch` |
+| `slices` | no file — GitHub Issues | dev | `slices` |
+
+When no kind was given, ask which one. Do not guess between a spec and a decision — they land in different places and different hands.
+
+Tell them apart this way. What and why the product exists is the PRD. What a word means and what must always be true is a domain document. A fork in the road where one path was chosen and someone will later ask "why this way" is a decision record. How one feature behaves is a spec. The visual and interaction finish of a screen that already exists is a UI spec. How the codebase is arranged and what conventions it follows is the architecture overview.
+
+## 3. Check ownership
+
+Compare the target path against `config/ownership.json` and your role.
+
+If you do not own it, **stop here**. Dispatch `gh-issue-generator` to open a `[Request]` Issue for the owning role, describing what you need and why, then report the Issue number. Do not write the file, and do not open a branch.
+
+The orchestrator owns none of the documents in the table above. From the `main` checkout the answer is always a `[Request]`, or an assignment to the owning role.
+
+## 4. Cut the branch
+
+```
+git fetch origin && git checkout -b <role>/<task-name> origin/main
+```
+
+Then move the related board card to **In Progress**.
+
+## 5. Hand off
+
+Call the stage skill with the Skill tool, passing the topic and anything already known from the conversation. The stage skill owns the rest — gathering, writing, publishing.
+
+Before handing off, run `docs-locator` when the document will depend on existing ones: a spec needs the domain vocabulary and any decisions that bind it, a decision needs to know whether an earlier record already covers the ground. Pass what it returns to the stage skill so the same search does not happen twice.

--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -25,13 +25,18 @@ Everything below assumes those are loaded. Do not restate their content — foll
 |------|--------|-------|-------------|
 | `prd` | `docs/prd.md` | pm | `prd` |
 | `domain` | `docs/domain/<topic>.md` | pm | `domain` |
-| `adr` / `tdr` / `decision` | `docs/adr/ADR-00N-<slug>.md` or `docs/architecture/decisions/TDR-00N-<slug>.md` | pm / dev | `decision` |
+| `adr` | `docs/adr/ADR-00N-<slug>.md` | pm | `decision` |
+| `tdr` | `docs/architecture/decisions/TDR-00N-<slug>.md` | dev | `decision` |
 | `spec` | `docs/specs/<feature>.md` | pm | `spec` |
 | `ui` / `ui-spec` | `docs/ui/<screen>.md` | ui | `ui-spec` |
 | `arch` | `docs/architecture/overview.md` | dev | `arch` |
 | `slices` | no file — GitHub Issues | dev | `slices` |
 
 When no kind was given, ask which one. Do not guess between a spec and a decision — they land in different places and different hands.
+
+`decision` on its own is not a kind: resolve it to `adr` or `tdr` before checking ownership, because the two have different owners. A product or domain choice is an ADR; a technical one is a TDR. When the calling role already settles it, say which you picked and continue.
+
+The orchestrator's own documents — `docs/rules/` and `docs/templates/` — have no stage skill. From the `main` checkout, follow `docs/rules/matchers/writing-docs.md` directly and skip to step 4.
 
 Tell them apart this way. What and why the product exists is the PRD. What a word means and what must always be true is a domain document. A fork in the road where one path was chosen and someone will later ask "why this way" is a decision record. How one feature behaves is a spec. The visual and interaction finish of a screen that already exists is a UI spec. How the codebase is arranged and what conventions it follows is the architecture overview.
 
@@ -45,14 +50,18 @@ The orchestrator owns none of the documents in the table above. From the `main` 
 
 ## 4. Cut the branch
 
+`slices` produces no file and opens no PR, so it gets no branch. Skip to step 5 for that kind.
+
+For everything else:
+
 ```
 git fetch origin && git checkout -b <role>/<task-name> origin/main
 ```
 
-Then move the related board card to **In Progress**.
+Then move the related board card to **In Progress** — `docs/rules/matchers/publishing-issues.md` has the command and the option ids.
 
 ## 5. Hand off
 
 Call the stage skill with the Skill tool, passing the topic and anything already known from the conversation. The stage skill owns the rest — gathering, writing, publishing.
 
-Before handing off, run `docs-locator` when the document will depend on existing ones: a spec needs the domain vocabulary and any decisions that bind it, a decision needs to know whether an earlier record already covers the ground. Pass what it returns to the stage skill so the same search does not happen twice.
+Before handing off, run `docs-locator` when the document will depend on existing ones: a spec needs the domain vocabulary and any decisions that bind it, a decision needs to know whether an earlier record already covers the ground. Pass the citations to the stage skill and say you ran it, so it does not search the same ground again.

--- a/.claude/skills/domain/SKILL.md
+++ b/.claude/skills/domain/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: domain
+description: "Writes or edits a document under docs/domain/ — the project's vocabulary, entities, invariants, and state transitions. Normally reached through the /doc router. PM only."
+---
+
+# Domain
+
+`docs/domain/<topic>.md`, from `docs/templates/domain.md`.
+
+## Gather
+
+Run `docs-locator` first for existing domain files and any decision record that fixes a term. A second file defining the same word differently is worse than no file.
+
+Then sharpen the language against what the user actually says.
+
+- When a word is overloaded, force the split. "You said account — do you mean the Customer or the login? Those are different things."
+- When two words mean one thing, pick one and list the other under `_Avoid_` so it does not come back.
+- Test relationships with concrete scenarios rather than abstractions. "A party of six books a table for four and two people cancel — is that one booking or two?" An invariant that survives three such scenarios is worth writing down.
+
+If the vocabulary has not been discussed at all yet, call the `grilling` skill and let it drive.
+
+## Write
+
+Dispatch `docs-generator` with the template, the target path, and the gathered vocabulary. Definitions stay to one or two sentences and say what a thing *is*, not what it does.
+
+Only terms specific to this project belong here. General programming concepts do not, however often the code uses them.
+
+## Publish
+
+Dispatch `gh-pr-generator`.
+
+If a term you are changing already appears in a merged spec, say so in the PR body. Renaming a word in the domain without touching the specs that use it leaves the two out of step.

--- a/.claude/skills/domain/SKILL.md
+++ b/.claude/skills/domain/SKILL.md
@@ -9,7 +9,7 @@ description: "Writes or edits a document under docs/domain/ — the project's vo
 
 ## Gather
 
-Run `docs-locator` first for existing domain files and any decision record that fixes a term. A second file defining the same word differently is worse than no file.
+Unless the router already handed you citations, run `docs-locator` first for existing domain files and any decision record that fixes a term. A second file defining the same word differently is worse than no file.
 
 Then sharpen the language against what the user actually says.
 
@@ -17,7 +17,7 @@ Then sharpen the language against what the user actually says.
 - When two words mean one thing, pick one and list the other under `_Avoid_` so it does not come back.
 - Test relationships with concrete scenarios rather than abstractions. "A party of six books a table for four and two people cancel — is that one booking or two?" An invariant that survives three such scenarios is worth writing down.
 
-If the vocabulary has not been discussed at all yet, call the `grilling` skill and let it drive.
+If the vocabulary has not been discussed at all yet, call the `grilling` skill and let it drive. It is not vendored into this repository, so when it is unavailable, ask directly for what the template needs.
 
 ## Write
 

--- a/.claude/skills/prd/SKILL.md
+++ b/.claude/skills/prd/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: prd
+description: "Writes or edits docs/prd.md, the product requirements document. Normally reached through the /doc router, which has already loaded the rules and cut the branch. PM only."
+---
+
+# PRD
+
+One file, `docs/prd.md`, from `docs/templates/prd.md`.
+
+## Gather
+
+The PRD is the one document with no upstream source in the repository. Everything in it comes from the user.
+
+If the conversation does not already contain the answers, call the `grilling` skill first and let it do the interviewing. Do not build your own question list — `grilling` is sharper at it, and duplicating it means the user gets asked twice.
+
+What the template needs answered: who has the problem and what it costs them today, what counts as success in measurable terms, what is deliberately out of scope, and the two or three journeys a user actually walks.
+
+Nothing here is a guess. What the user has not decided goes to **Open questions** as a question.
+
+## Write
+
+Dispatch `docs-generator` with the template path, the target path, and everything gathered. It writes English and fills every section.
+
+## Publish
+
+Dispatch `gh-pr-generator`. The PRD produces no Epic — it is the source the specs are later cut from, not a unit of work.
+
+## Editing an existing PRD
+
+Read the current file first and change only what the request touches. A PRD accumulates; rewriting it wholesale loses decisions nobody remembers making. If a change contradicts something already there, say so rather than quietly replacing it.

--- a/.claude/skills/prd/SKILL.md
+++ b/.claude/skills/prd/SKILL.md
@@ -11,7 +11,7 @@ One file, `docs/prd.md`, from `docs/templates/prd.md`.
 
 The PRD is the one document with no upstream source in the repository. Everything in it comes from the user.
 
-If the conversation does not already contain the answers, call the `grilling` skill first and let it do the interviewing. Do not build your own question list — `grilling` is sharper at it, and duplicating it means the user gets asked twice.
+If the conversation does not already contain the answers, call the `grilling` skill first and let it do the interviewing. It is not vendored into this repository, so when it is unavailable, ask directly for what the template needs and keep the questions to that. Do not build your own question list — `grilling` is sharper at it, and duplicating it means the user gets asked twice.
 
 What the template needs answered: who has the problem and what it costs them today, what counts as success in measurable terms, what is deliberately out of scope, and the two or three journeys a user actually walks.
 

--- a/.claude/skills/slices/SKILL.md
+++ b/.claude/skills/slices/SKILL.md
@@ -15,7 +15,7 @@ gh issue view <epic> --comments
 
 Follow the link to `docs/specs/<feature>.md` and read the file. The Issue body is a summary — the acceptance criteria live in the file, and those are what the slices divide.
 
-Run `docs-locator` for decisions that constrain the implementation before deciding the shape.
+Unless the router already handed you citations, run `docs-locator` for decisions that constrain the implementation before deciding the shape.
 
 ## Cut the slices
 
@@ -31,4 +31,8 @@ A wide mechanical refactor is the exception to vertical slicing — one change w
 
 Dispatch `gh-issue-generator` with the slice list, in dependency order so each Issue can reference real numbers. It creates them in Korean, attaches each as a sub-issue of the Epic, applies the labels, and puts the cards on the board.
 
-Do not modify or close the Epic. PM closes it when every slice is closed.
+New slice cards go to **Backlog**, except the ones with no predecessor, which go to **Todo** — those are what Dev can pick up immediately.
+
+Do not modify or close the Epic, and do not move its card. PM closes it when every slice is closed.
+
+This skill writes no file and opens no PR, so there is no branch to cut and no card of its own to move. Slicing is finished when the Issues exist and are on the board.

--- a/.claude/skills/slices/SKILL.md
+++ b/.claude/skills/slices/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: slices
+description: "Breaks an [Epic] into vertical slice [Slice] sub-issues on GitHub. Produces no document. Normally reached through the /doc router. Dev only."
+---
+
+# Slices
+
+Takes an Epic number, reads the spec it links to, and publishes one `[Slice]` Issue per vertical slice. No file is written and no PR is opened.
+
+## Read the source
+
+```
+gh issue view <epic> --comments
+```
+
+Follow the link to `docs/specs/<feature>.md` and read the file. The Issue body is a summary — the acceptance criteria live in the file, and those are what the slices divide.
+
+Run `docs-locator` for decisions that constrain the implementation before deciding the shape.
+
+## Cut the slices
+
+A slice cuts a narrow but complete path through every layer — schema, API, screen, tests. It is demoable on its own and sized to fit one fresh context window. A layer cut horizontally is not a slice: "add the database tables" leaves nothing a person can look at.
+
+Each slice claims a subset of the spec's numbered acceptance criteria. Every criterion lands in exactly one slice. A criterion nobody claimed means the Epic is not fully sliced; a criterion claimed twice means two slices will fight over the same code.
+
+Name the slices that must finish first. A slice with no predecessor can start immediately.
+
+A wide mechanical refactor is the exception to vertical slicing — one change whose blast radius crosses the whole codebase cannot land green as a tracer bullet. Sequence it instead: add the new form beside the old, migrate call sites in batches small enough to keep CI green, then delete the old form once no caller remains. Each step is its own slice, blocked by the previous one.
+
+## Publish
+
+Dispatch `gh-issue-generator` with the slice list, in dependency order so each Issue can reference real numbers. It creates them in Korean, attaches each as a sub-issue of the Epic, applies the labels, and puts the cards on the board.
+
+Do not modify or close the Epic. PM closes it when every slice is closed.

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -9,9 +9,9 @@ description: "Writes docs/specs/<feature>.md — the single source of truth for 
 
 ## Gather
 
-Run `docs-locator` for the domain vocabulary this feature touches and any decision record that constrains it. A spec that renames a domain term or contradicts an accepted ADR is a defect, not a proposal.
+Unless the router already handed you citations, run `docs-locator` for the domain vocabulary this feature touches and any decision record that constrains it. A spec that renames a domain term or contradicts an accepted ADR is a defect, not a proposal.
 
-Synthesise from what the conversation and the repository already hold. If the feature has not been discussed at all, call the `grilling` skill first.
+Synthesise from what the conversation and the repository already hold. If the feature has not been discussed at all, call the `grilling` skill first. It is not vendored into this repository, so when it is unavailable, ask directly for what the template needs.
 
 ## Acceptance criteria carry the weight
 

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: spec
+description: "Writes docs/specs/<feature>.md — the single source of truth for one feature — and publishes the matching [Epic] Issue. Normally reached through the /doc router. PM only."
+---
+
+# Spec
+
+`docs/specs/<feature>.md`, from `docs/templates/spec.md`. This file is canonical; the Epic links to it.
+
+## Gather
+
+Run `docs-locator` for the domain vocabulary this feature touches and any decision record that constrains it. A spec that renames a domain term or contradicts an accepted ADR is a defect, not a proposal.
+
+Synthesise from what the conversation and the repository already hold. If the feature has not been discussed at all, call the `grilling` skill first.
+
+## Acceptance criteria carry the weight
+
+Everything else in the spec is context; the numbered Given / When / Then list is what Dev slices against and what the reviewer checks.
+
+Each criterion is verifiable on its own, names an observable result rather than an internal state, and covers one path. Split "the booking is saved and the guest is emailed" into two — they fail independently.
+
+The list is not done when the happy path is covered. Invalid input, a conflict with someone else's action, a failed external call, an empty result: each gets a criterion, or gets named under Out of scope.
+
+## Write
+
+Dispatch `docs-generator` with the template, the target path, and everything gathered. Use the domain vocabulary exactly as `docs/domain/` defines it — link the domain file rather than restating definitions.
+
+No file paths, no code snippets. The exception is a shape that carries a decision more precisely than prose can — a state machine, a schema — trimmed to the decision.
+
+## Publish
+
+Two dispatches, in order.
+
+1. `gh-issue-generator` — an `[Epic]` Issue in Korean carrying a link to the spec file and a summary, never a copy of the detail. It applies the labels and puts the card on the board.
+2. `gh-pr-generator` — the PR for the spec file, referencing the Epic.
+
+## Editing an existing spec
+
+Corrections go to the file, never to the Issue body. When a merged spec changes and slices are already open against it, say so in the PR body — Dev needs to know which slices moved under them.

--- a/.claude/skills/ui-spec/SKILL.md
+++ b/.claude/skills/ui-spec/SKILL.md
@@ -15,7 +15,7 @@ Run the app and look at the real screen. A spec written from the spec file inste
 
 ## Gather
 
-Run `docs-locator` for the feature spec behind the screen, so the states you describe match the states the feature actually has.
+Unless the router already handed you citations, run `docs-locator` for the feature spec behind the screen, so the states you describe match the states the feature actually has.
 
 Walk every state deliberately: default, hover, focus, active, disabled, loading, empty, error. A state with no entry is a state Dev will guess at, and the guess will be wrong in a way nobody notices until a user hits it.
 

--- a/.claude/skills/ui-spec/SKILL.md
+++ b/.claude/skills/ui-spec/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: ui-spec
+description: "Writes docs/ui/<screen>.md — the visual and interaction finish of a screen that already exists. Normally reached through the /doc router. UI only, and never touches code."
+---
+
+# UI spec
+
+`docs/ui/<screen>.md`, from `docs/templates/ui-spec.md`.
+
+## Precondition
+
+The screen must already be implemented. Design follows implementation here; there is nothing to review otherwise. If the screen does not exist yet, stop and say so rather than specifying it blind.
+
+Run the app and look at the real screen. A spec written from the spec file instead of from the running screen documents what was intended, not what shipped, and the gap between those two is exactly what this document is for.
+
+## Gather
+
+Run `docs-locator` for the feature spec behind the screen, so the states you describe match the states the feature actually has.
+
+Walk every state deliberately: default, hover, focus, active, disabled, loading, empty, error. A state with no entry is a state Dev will guess at, and the guess will be wrong in a way nobody notices until a user hits it.
+
+Check the keyboard path through the screen and anything conveyed by colour or icon alone.
+
+## Write
+
+Dispatch `docs-generator` with the template, the target path, and the observations.
+
+Specify by value and by role — "24px between the form and the summary", "the primary action darkens 8% on hover". Never by class name, component name, or file path: those belong to Dev and they change without telling you.
+
+Name what this pass deliberately leaves alone, under Out of scope, so the next review does not read it as an omission.
+
+## Publish
+
+Dispatch `gh-pr-generator`. The merge is what creates Dev's work — a UI spec landing on `main` is the signal that a slice applying it can be cut. Never hand Dev the change directly.

--- a/docs/rules/common.md
+++ b/docs/rules/common.md
@@ -75,6 +75,8 @@ GitHub artifacts are written in **Korean** — Issue titles and bodies, PR title
 
 Code, commands, identifiers, file paths, CLI flags, and commit type keywords (`feat`, `fix`, …) stay verbatim in both languages.
 
+One exception: a skill's `description` field may carry Korean trigger phrases. That field is matched against what the user types, and the user types Korean.
+
 ## Communication
 
 **The record is canonical; the bell is only a signal.** Every instruction, request, and report between agents is written to GitHub — a PR comment or an Issue. The Orca `terminal send` bell carries one line that says "go look". An instruction delivered only through a terminal did not happen.

--- a/docs/rules/matchers/publishing-issues.md
+++ b/docs/rules/matchers/publishing-issues.md
@@ -38,11 +38,26 @@ Labels classify. They never carry status.
 
 ## Board
 
-Status lives in the Status field of the [La Bie Belle](https://github.com/users/tkyoun0421/projects/8) project board. Put a new Issue on the board, then set its status.
+Status lives in the Status field of the [La Bie Belle](https://github.com/users/tkyoun0421/projects/8) project board. Put a new Issue on the board, then set its status. Adding a card does not set one — a card added and left alone sits in `No Status`, invisible to every column.
 
 ```
-gh project item-add 8 --owner tkyoun0421 --url <issue-url>
+gh project item-add 8 --owner tkyoun0421 --url <issue-url>          # prints the item id
+gh project item-edit --project-id PVT_kwHOBd4HfM4Bg89n \
+  --id <item-id> \
+  --field-id PVTSSF_lAHOBd4HfM4Bg89nzhf6jUI \
+  --single-select-option-id <option-id>
 ```
+
+| Status | Option id |
+|--------|-----------|
+| Backlog | `f025dca8` |
+| Todo | `f66a47cd` |
+| In Progress | `c2dd621b` |
+| In Review | `b9e12ba6` |
+| Done | `b9771004` |
+| Blocked | `5b4d353f` |
+
+To move a card that is already on the board, find its item id with `gh project item-list 8 --owner tkyoun0421 --format json` and run the same `item-edit`.
 
 | Status | Meaning | Who moves it |
 |--------|---------|--------------|

--- a/docs/rules/matchers/writing-docs.md
+++ b/docs/rules/matchers/writing-docs.md
@@ -11,7 +11,7 @@ Load this whenever you create or edit anything under `docs/`.
 
 Local documents are written in English. See the language rule in `docs/rules/common.md`.
 
-The `/doc` skill runs this procedure end to end — ownership check, branch, template, publication. Use it rather than reproducing the steps by hand.
+An agent driving document work from a session uses the `/doc` skill, which runs this procedure end to end — ownership check, branch, template, publication. A subagent that skill dispatches follows the rules below directly and does not call back into it.
 
 ## Templates
 

--- a/docs/rules/matchers/writing-docs.md
+++ b/docs/rules/matchers/writing-docs.md
@@ -11,6 +11,8 @@ Load this whenever you create or edit anything under `docs/`.
 
 Local documents are written in English. See the language rule in `docs/rules/common.md`.
 
+The `/doc` skill runs this procedure end to end — ownership check, branch, template, publication. Use it rather than reproducing the steps by hand.
+
 ## Templates
 
 Start from `docs/templates/`, never from a blank file.


### PR DESCRIPTION
문서 작성을 실제로 굴리는 장치를 붙인다. #69 3단계.

## 라우터 하나 + 단계별 스킬 일곱

`/doc <종류> [주제]` 하나가 진입점이다. `.agent-role`로 role을 판별하고 `common.md` + `roles/<role>.md` + `matchers/writing-docs.md`를 로드한 뒤, 소유권을 확인하고 브랜치를 딴 다음 해당 단계 스킬로 넘긴다. 소유가 아니면 거기서 멈추고 `[Request]` Issue로 넘긴다 — 총괄 체크아웃에서 `/doc prd`를 쳐도 PRD가 써지지 않는다.

| 스킬 | 산출물 | role |
|------|--------|------|
| `prd` | `docs/prd.md` | PM |
| `domain` | `docs/domain/<주제>.md` | PM |
| `decision` | ADR 또는 TDR (role이 경로를 결정) | PM·Dev |
| `spec` | `docs/specs/<기능>.md` + `[Epic]` Issue | PM |
| `slices` | `[Slice]` sub-issue들 (문서 없음) | Dev |
| `ui-spec` | `docs/ui/<화면>.md` | UI |
| `arch` | `docs/architecture/overview.md` | Dev |

각 스킬은 자기 템플릿과 자기 절차만 담는다. 공통 규칙은 라우터가 이미 로드했으므로 반복하지 않는다.

**인터뷰는 `grilling` 스킬에 위임한다.** 문서 스킬이 자체 질문지를 갖지 않는다. 요구가 대화에도 저장소에도 없을 때만 `grilling`을 부르고, 그 외에는 이미 있는 것에서 합성한다. 중간에 "이대로 씁니다" 하고 멈추는 승인 지점은 두지 않았다 — 검수는 GitHub에서 한다.

## subagent 넷

| 이름 | model | 하는 일 |
|------|-------|---------|
| `docs-locator` | haiku | 문서 위치 탐색과 인용 |
| `docs-generator` | sonnet | 템플릿 + 수집한 내용으로 영어 문서 작성 |
| `gh-issue-generator` | haiku | 한국어 Issue 발행, 라벨 3축, 보드 등록 |
| `gh-pr-generator` | sonnet | diff를 읽고 한국어 PR 본문 작성, PR 열기, 카드 이동 |

model 배분의 근거는 판단량이다. 라벨 붙이고 카드 올리는 일은 기계적이라 haiku로 충분하고, diff를 읽어 영향 범위를 서술하는 일은 sonnet이 필요하다.

`docs-locator`의 계약이 이 PR에서 가장 중요한 부분이다. 출력은 `path:line` 표에 줄당 1줄 인용, 최대 12행, 도구 호출 6회 상한이고, Read는 인용할 구간에만 `offset`·`limit`으로 쓴다. 메인 세션이 직접 grep하면 문서 서너 개가 통째로 컨텍스트에 얹혀 세션이 끝날 때까지 매 턴 다시 실려 가는데, locator에 맡기면 그 비용이 haiku 쪽에서 타고 메인에는 인용 몇 줄만 남는다.

**`status`를 항상 함께 반환하게 했다.** grep 결과만 보면 `superseded`된 결정과 살아 있는 결정이 똑같이 생겼고, 죽은 결정을 근거로 작업한 건 리뷰에 가서야 드러난다. 2단계에서 front matter에 `status`를 넣은 값이 여기서 나온다.

`gh-pr-generator`는 caller의 요약이 아니라 **diff를 직접 읽고** 본문을 쓴다. 요약을 그대로 옮기면 caller가 언급하지 않은 변경이 본문에서 빠지는데, 그게 리뷰가 늦게 잡는 바로 그 항목이다. 커밋 전에 소유권과 `.env`·하드코딩 자격증명을 확인하고, 걸리면 멈추고 보고한다.

## 규칙 변경

`matchers/writing-docs.md`에 한 줄 추가했다 — "`/doc` 스킬이 이 절차를 처음부터 끝까지 수행한다. 손으로 단계를 재현하지 말고 스킬을 써라." **새 조항이다.**

## Impact

- Domain: 없음
- Spec: 없음
- Arch: 문서 작성 경로가 스킬로 통일된다. 기존 `pr-reviewer`는 그대로 두고 별도 문서 auditor는 두지 않았다 — 규격 검사는 4단계의 `docs-check.mjs`가 기계로 맡을 예정이라 사람·에이전트 검사를 하나 더 늘리지 않는다.

관련 #69 (3단계 중 3단계)