### PR TITLE
feat(skills): 결정 인터뷰 스킬을 저장소 안에 세운다

### DIFF
--- a/.claude/skills/decision/SKILL.md
+++ b/.claude/skills/decision/SKILL.md
@@ -23,6 +23,8 @@ The four sections need: what forced the decision, what was decided, which altern
 
 The alternatives section is the one that earns the record. "We considered other options" records nothing — name the library, the pattern, the service, and the specific reason it lost. Without that, the same alternative gets proposed again in six months.
 
+When the alternatives were never argued out with the user, call the `interview` skill first. Its options block is what this section is made of — each option a claim, with what it wins and what it loses.
+
 ## Write
 
 Dispatch `docs-generator`. New records start at `status: proposed` and move to `accepted` when the decision is actually in force.

--- a/.claude/skills/domain/SKILL.md
+++ b/.claude/skills/domain/SKILL.md
@@ -17,7 +17,7 @@ Then sharpen the language against what the user actually says.
 - When two words mean one thing, pick one and list the other under `_Avoid_` so it does not come back.
 - Test relationships with concrete scenarios rather than abstractions. "A party of six books a table for four and two people cancel — is that one booking or two?" An invariant that survives three such scenarios is worth writing down.
 
-If the vocabulary has not been discussed at all yet, call the `grilling` skill and let it drive. It is not vendored into this repository, so when it is unavailable, ask directly for what the template needs.
+If the vocabulary has not been discussed at all yet, call the `interview` skill and let it drive.
 
 ## Write
 

--- a/.claude/skills/interview/SKILL.md
+++ b/.claude/skills/interview/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: interview
+description: "Interviews the user until every decision behind a plan is settled — one round at a time, each question carrying its background, its options as competing claims, and what each option wins and loses. Use before writing a PRD, spec, domain document, ADR, or TDR, before amending the rules set, and whenever a plan needs stress-testing. Korean triggers: 인터뷰 해줘, 질문해줘, 뭘 정해야 하지, 이 계획 따져줘, 설계 검증, 결정 좀 하자."
+---
+
+# Interview
+
+Settle every decision behind a plan before anyone writes a document or touches code. You ask; the user decides.
+
+Model the plan as a tree. Each answer settles one decision and opens the ones hanging off it.
+
+## Rounds
+
+The frontier is every decision whose prerequisites are already settled — the questions answerable now, without guessing at an answer you have not heard.
+
+Ask the whole frontier in one round, numbered. Then stop and wait. A question that depends on another question still open belongs to the next round, not this one.
+
+Recompute the frontier from the answers. Repeat until it is empty.
+
+## Facts are yours, decisions are the user's
+
+Never ask the user for something the repository can answer. Dispatch `docs-locator` for anything under `docs/`; read the file yourself for anything else. Every claim in a question carries its `file:line`.
+
+A running search is an unsettled prerequisite. Ask the rest of the frontier now and hold only the questions downstream of it.
+
+## Question format
+
+Four blocks, in this order.
+
+**What the problem is.** Prose, never a list. Three beats: how it stands today, what that costs in one concrete situation, and why the question opens now. Citations sit inside the sentences.
+
+**Options.** Each option is a claim, not a menu item. Under its heading, two lines: why the claim holds, and what actually changes — which file, which situation. Three real options beat five padded ones.
+
+**What each option wins and loses.** A table, one row per option, a column for each. Short cells: this block is for comparison side by side, not for argument.
+
+**Recommendation.** One option, one line of why.
+
+Rendered — headings in the user's language, structure as below:
+
+```
+❓ **Q1 — <the decision, in one line>**
+
+### <what the problem is>
+<prose, three beats, citations inline>
+
+### <options>
+**A. <the claim>**
+<why it holds>
+<what changes>
+
+**B. <the claim>**
+…
+
+### <what each wins and loses>
+| | <wins> | <loses> |
+|---|---|---|
+| A | … | … |
+| B | … | … |
+
+### <recommendation>
+**B** — <one line>
+```
+
+## Language
+
+Ask in the language the user is writing in. Where that is Korean, choose the everyday word over the Sino-Korean compound, and keep every sentence short enough to read once.
+
+## Ending
+
+When the frontier is empty, list every settled decision, then ask for approval in as many words. An answer given during the interview is not approval — the summary is what gets approved, and nothing is acted on until it does.
+
+Hand the settled set to whatever comes next: the stage skill that writes the document, or the session's own work.
+
+## Not this
+
+Write no file. The decisions land in the document the caller writes, or in an ADR or TDR.
+
+Ask no question the repository already answers.

--- a/.claude/skills/prd/SKILL.md
+++ b/.claude/skills/prd/SKILL.md
@@ -11,7 +11,7 @@ One file, `docs/prd.md`, from `docs/templates/prd.md`.
 
 The PRD is the one document with no upstream source in the repository. Everything in it comes from the user.
 
-If the conversation does not already contain the answers, call the `grilling` skill first and let it do the interviewing. It is not vendored into this repository, so when it is unavailable, ask directly for what the template needs and keep the questions to that. Do not build your own question list — `grilling` is sharper at it, and duplicating it means the user gets asked twice.
+If the conversation does not already contain the answers, call the `interview` skill first and let it do the interviewing. Do not build your own question list — duplicating it means the user gets asked twice.
 
 What the template needs answered: who has the problem and what it costs them today, what counts as success in measurable terms, what is deliberately out of scope, and the two or three journeys a user actually walks.
 

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -11,7 +11,7 @@ description: "Writes docs/specs/<feature>.md — the single source of truth for 
 
 Unless the router already handed you citations, run `docs-locator` for the domain vocabulary this feature touches and any decision record that constrains it. A spec that renames a domain term or contradicts an accepted ADR is a defect, not a proposal.
 
-Synthesise from what the conversation and the repository already hold. If the feature has not been discussed at all, call the `grilling` skill first. It is not vendored into this repository, so when it is unavailable, ask directly for what the template needs.
+Synthesise from what the conversation and the repository already hold. If the feature has not been discussed at all, call the `interview` skill first.
 
 ## Acceptance criteria carry the weight
 


### PR DESCRIPTION
## 무엇을 왜

`.claude/skills/interview/SKILL.md`를 새로 세웠다. 계획 뒤에 깔린 결정을 사용자와 라운드로 주고받아 전부 확정하는 스킬로, 질문 한 개가 네 덩어리(지금 뭐가 문제인가·선택지·각 선택지의 득실·추천)로 고정된다. 지금 답할 수 있는 질문을 한 라운드에 다 내고, 답을 받아 다음 라운드를 다시 계산한다. 사실 확인은 `docs-locator`에 맡기고 저장소가 답할 수 있는 건 사용자에게 묻지 않는다. 파일은 쓰지 않는다.

`prd`·`domain`·`spec`에서 바깥 `grilling` 스킬을 부르던 자리를 `interview` 호출로 바꿨다. 세 파일에 똑같이 복제돼 있던 "이 저장소에 vendored 되지 않았으니 없으면 직접 물어봐라"는 대비책 문장도 함께 지웠다 — `interview`가 저장소 안에 있으니 그 대비책이 더 이상 필요 없다.

`decision`에는 `interview` 호출이 새로 붙었다. ADR·TDR의 "Alternatives considered" 칸이 인터뷰의 선택지 블록과 그대로 겹치는데, 지금까지 그 대안을 어디서 얻는지가 어디에도 적혀 있지 않았다.

## Impact

- Domain: 없음
- Spec: 없음
- Arch: 없음 (`.claude/skills/` 안에서만 움직인다. 문서 작성 흐름의 인터뷰 단계가 저장소 안으로 들어온다)

## 확인

- [x] 브랜치를 `origin/main`에서 새로 땄다
- [x] 변경한 경로가 전부 내 소유다 (`config/ownership.json`)
- [x] 문서를 고쳤다면 front matter를 함께 갱신했다
- [ ] 동작을 바꿨다면 그에 상응하는 테스트가 있다

Closes #75