### PR TITLE
fix(skills): 인터뷰를 한 번에 한 질문씩으로 바꾼다

### DIFF
--- a/.claude/skills/interview/SKILL.md
+++ b/.claude/skills/interview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: interview
-description: "Interviews the user until every decision behind a plan is settled — one round at a time, each question carrying its background, its options as competing claims, and what each option wins and loses. Use before writing a PRD, spec, domain document, ADR, or TDR, before amending the rules set, and whenever a plan needs stress-testing. Korean triggers: 인터뷰 해줘, 질문해줘, 뭘 정해야 하지, 이 계획 따져줘, 설계 검증, 결정 좀 하자."
+description: "Interviews the user until every decision behind a plan is settled — one question at a time, each carrying its background, its options as competing claims, and what each option wins and loses. Use before writing a PRD, spec, domain document, ADR, or TDR, before amending the rules set, and whenever a plan needs stress-testing. Korean triggers: 인터뷰 해줘, 질문해줘, 뭘 정해야 하지, 이 계획 따져줘, 설계 검증, 결정 좀 하자."
 ---
 
 # Interview
@@ -9,19 +9,23 @@ Settle every decision behind a plan before anyone writes a document or touches c
 
 Model the plan as a tree. Each answer settles one decision and opens the ones hanging off it.
 
-## Rounds
+## One question at a time
 
 The frontier is every decision whose prerequisites are already settled — the questions answerable now, without guessing at an answer you have not heard.
 
-Ask the whole frontier in one round, numbered. Then stop and wait. A question that depends on another question still open belongs to the next round, not this one.
+Ask one of them. One question, not the frontier. Then stop and wait. Several questions in one turn arrive as a wall of text and come back half answered.
 
-Recompute the frontier from the answers. Repeat until it is empty.
+Open the turn with the frontier as titles — one line each, no bodies — so the size and the order of what is left is visible without being asked to answer it. Then ask the first. Keep that list current as answers land.
+
+Order the frontier by what it unblocks. A decision that changes the shape of later questions goes first.
+
+After each answer, recompute the frontier and ask the next question. A question that depends on one still open is not on the frontier at all. Repeat until it is empty.
 
 ## Facts are yours, decisions are the user's
 
-Never ask the user for something the repository can answer. Dispatch `docs-locator` for anything under `docs/`; read the file yourself for anything else. Every claim in a question carries its `file:line`.
+Never ask the user for something the repository can answer. Unless the caller already handed you citations, dispatch `docs-locator` for anything under `docs/`; read the file yourself for anything else. Every claim in a question carries its `file:line`.
 
-A running search is an unsettled prerequisite. Ask the rest of the frontier now and hold only the questions downstream of it.
+A question whose facts you do not yet hold is not on the frontier. `docs-locator` answers in one shot — run it, read what it returns, then ask.
 
 ## Question format
 
@@ -38,6 +42,8 @@ Four blocks, in this order.
 Rendered — headings in the user's language, structure as below:
 
 ```
+<what is left: one line per decision still on the frontier, titles only, this one marked>
+
 ❓ **Q1 — <the decision, in one line>**
 
 ### <what the problem is>
@@ -69,7 +75,7 @@ Ask in the language the user is writing in. Where that is Korean, choose the eve
 
 When the frontier is empty, list every settled decision, then ask for approval in as many words. An answer given during the interview is not approval — the summary is what gets approved, and nothing is acted on until it does.
 
-Hand the settled set to whatever comes next: the stage skill that writes the document, or the session's own work.
+Hand the settled set to whatever comes next. When a document follows, go through the `/doc` router — it resolves ownership and cuts the branch, and an interview that reaches a stage skill directly skips both. When the session's own work follows, carry on with it.
 
 ## Not this
 

--- a/.claude/skills/interview/SKILL.md
+++ b/.claude/skills/interview/SKILL.md
@@ -15,6 +15,8 @@ The frontier is every decision whose prerequisites are already settled — the q
 
 Ask one of them. One question, not the frontier. Then stop and wait. Several questions in one turn arrive as a wall of text and come back half answered.
 
+Number the questions in the order you ask them, across the whole interview — Q1, then Q2, then Q3. The count never restarts at a new turn.
+
 Open the turn with the frontier as titles — one line each, no bodies — so the size and the order of what is left is visible without being asked to answer it. Then ask the first. Keep that list current as answers land.
 
 Order the frontier by what it unblocks. A decision that changes the shape of later questions goes first.
@@ -25,7 +27,7 @@ After each answer, recompute the frontier and ask the next question. A question 
 
 Never ask the user for something the repository can answer. Unless the caller already handed you citations, dispatch `docs-locator` for anything under `docs/`; read the file yourself for anything else. Every claim in a question carries its `file:line`.
 
-A question whose facts you do not yet hold is not on the frontier. `docs-locator` answers in one shot — run it, read what it returns, then ask.
+A question whose facts you do not yet hold is not ready to ask, but the decision stays on the frontier — finding those facts is your work, not a reason to drop it. `docs-locator` answers in one shot: run it, read what it returns, then ask.
 
 ## Question format
 
@@ -75,10 +77,14 @@ Ask in the language the user is writing in. Where that is Korean, choose the eve
 
 When the frontier is empty, list every settled decision, then ask for approval in as many words. An answer given during the interview is not approval — the summary is what gets approved, and nothing is acted on until it does.
 
-Hand the settled set to whatever comes next. When a document follows, go through the `/doc` router — it resolves ownership and cuts the branch, and an interview that reaches a stage skill directly skips both. When the session's own work follows, carry on with it.
+Hand the settled set back to whoever called you. A stage skill calls this skill from inside its own Gather, which means `/doc` has already resolved ownership and cut the branch — return to that skill and let it write. Never send it back through the router.
+
+Nobody calls you when the user reaches this skill directly. If a document follows from there, start it through `/doc`: the router is what resolves ownership and cuts the branch, and the settled decisions travel with you in the conversation. Walking into a stage skill from here skips both.
+
+When the session's own work follows instead, carry on with it.
 
 ## Not this
 
-Write no file. The decisions land in the document the caller writes, or in an ADR or TDR.
+Write no file. The decisions land in the document that follows — the one the calling stage skill writes, or the one `/doc` routes to.
 
 Ask no question the repository already answers.


### PR DESCRIPTION
## 무엇을 왜

인터뷰 스킬이 한 라운드에 프론티어(지금 답할 수 있는 질문 전부)를 한꺼번에 던지던 방식이었는데, 실제로 돌려보니 한 턴에 셋씩 나가면서 글 덩어리가 되고 답이 반만 돌아왔다. `## Rounds` 절을 `## One question at a time`으로 바꾸고, 이제 한 턴에 질문 하나만 낸다. 대신 턴 머리에 남은 결정을 제목 한 줄씩으로 먼저 보여 남은 양과 순서가 드러나게 한다. 순서는 뒤 질문의 모양을 바꾸는 결정부터 잡는다. 답을 받으면 frontier를 다시 계산해 다음 하나를 낸다. 렌더 예시에도 남은 결정 줄을 추가했고, 스킬 `description`의 "one round at a time"도 "one question at a time"으로 고쳤다. (#81)

이어서 세 가지를 함께 고쳤다.

- `docs-locator`를 조건 없이 다시 돌리던 것을, "이미 호출자가 인용을 넘겼다면 생략"이라는 단서로 좁혔다 (#77)
- "검색이 도는 동안 나머지 질문을 낸다"는 전제를 지웠다. `docs-locator`는 한 번 부르면 표 하나를 돌려주는 단발이라 그런 중간 상태가 없다. 사실을 아직 못 쥔 질문은 애초에 frontier가 아니라고 정리했다 (#78)
- 확정된 결정을 stage skill에 바로 넘기라고 적혀 있던 것을, 문서로 이어질 때는 `/doc` 라우터를 타도록 고쳤다. 라우터가 소유권 검사와 브랜치 컷을 하는데, 바로 넘기면 둘 다 건너뛴다 (#79)

변경 파일은 `.claude/skills/interview/SKILL.md` 하나뿐이다.

## Impact

- Domain: 없음
- Spec: 없음
- Arch: 없음 (`.claude/skills/interview/SKILL.md` 한 파일 안에서만 움직인다)

## 확인

- [x] 브랜치를 `origin/main`에서 새로 땄다
- [x] 변경한 경로가 전부 내 소유다 (`config/ownership.json`)
- [x] 문서를 고쳤다면 front matter를 함께 갱신했다
- [ ] 동작을 바꿨다면 그에 상응하는 테스트가 있다

Closes #81
Closes #77
Closes #78
Closes #79