### PR TITLE
refactor(rules): 소유 정보를 registry 한 곳으로 모은다

### DIFF
--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -46,7 +46,7 @@ Compare the target path against `config/ownership.json` and your role.
 
 If you do not own it, **stop here**. Dispatch `gh-issue-generator` to open a `[Request]` Issue for the owning role, describing what you need and why, then report the Issue number. Do not write the file, and do not open a branch.
 
-The orchestrator owns none of the documents in the table above. From the `main` checkout the answer is always a `[Request]`, or an assignment to the owning role.
+One role does not read the registry that way. The `orchestrator` key is `["*"]`, which is access and not authorship — the orchestrator writes none of the documents in the table above. From the `main` checkout the answer is always a `[Request]`, or an assignment to the owning role.
 
 ## 4. Cut the branch
 

--- a/config/ownership.json
+++ b/config/ownership.json
@@ -1,4 +1,5 @@
 {
+  "orchestrator": ["*"],
   "pm": ["docs/prd.md", "docs/domain/", "docs/adr/", "docs/specs/"],
   "dev": [
     "docs/architecture/",

--- a/docs/rules/common.md
+++ b/docs/rules/common.md
@@ -32,14 +32,16 @@ Rules are split along three axes. Load `docs/rules/common.md` always, your own r
 
 ## Roles and workspaces
 
-| Worktree | Agent | Owns |
-|----------|-------|------|
-| `main` checkout | Orchestrator (`@orchestrator`) | `docs/rules/`, `docs/templates/`, `config/`, `.claude/`, `.githooks/`, `.github/` — with access to every path |
-| `pm` | PM (`@agent-pm`) | `docs/prd.md`, `docs/domain/`, `docs/adr/`, `docs/specs/` |
-| `dev` | Dev (`@agent-dev`) | `docs/architecture/` (technical decisions under `architecture/decisions/` as TDRs), `src/`, root development config |
-| `ui` | UI (`@agent-ui`) | `docs/ui/` — never code |
+| Worktree | Agent | Branch prefix | Registry key |
+|----------|-------|---------------|--------------|
+| `main` checkout | Orchestrator (`@orchestrator`) | `orch/` | `orchestrator` |
+| `pm` | PM (`@agent-pm`) | `pm/` | `pm` |
+| `dev` | Dev (`@agent-dev`) | `dev/` | `dev` |
+| `ui` | UI (`@agent-ui`) | `ui/` | `ui` |
 
-`config/ownership.json` is the machine-readable source of truth for ownership. Where it disagrees with the table above, the JSON wins.
+Which paths a key owns lives in `config/ownership.json`, and nowhere else. Read it rather than recalling it — the guards and the reviewer read that same file, and a second copy in prose is a copy that drifts.
+
+The `orchestrator` key holds `["*"]`. Coordination reaches every path, so it is not an exception to the rule; it is a role that owns everything.
 
 Never edit a path you do not own. Open a `[Request]` Issue for the owning agent instead.
 

--- a/docs/rules/common.md
+++ b/docs/rules/common.md
@@ -39,9 +39,9 @@ Rules are split along three axes. Load `docs/rules/common.md` always, your own r
 | `dev` | Dev (`@agent-dev`) | `dev/` | `dev` |
 | `ui` | UI (`@agent-ui`) | `ui/` | `ui` |
 
-Which paths a key owns lives in `config/ownership.json`, and nowhere else. Read it rather than recalling it — the guards and the reviewer read that same file, and a second copy in prose is a copy that drifts.
+Which paths a key owns lives in `config/ownership.json`. Read it rather than recalling it — the guards and the reviewer read that same file, and a second copy in prose is a copy that drifts.
 
-The `orchestrator` key holds `["*"]`. Coordination reaches every path, so it is not an exception to the rule; it is a role that owns everything.
+The `orchestrator` key holds `["*"]`, because coordination reaches every path. That is access, not authorship. The orchestrator may touch anything and still writes nothing another role owns — not a document, not a source file. It assigns the work instead. Separately from the registry, the guards never see the orchestrator at all; **Enforcement** below says why.
 
 Never edit a path you do not own. Open a `[Request]` Issue for the owning agent instead.
 

--- a/docs/rules/matchers/reviewing-a-pr.md
+++ b/docs/rules/matchers/reviewing-a-pr.md
@@ -28,7 +28,7 @@ Add newly discovered borderline cases to this table as they come up.
 ## What to check, in order
 
 1. **Secrets** (critical) — any `.env` family file or hardcoded key or token in the diff.
-2. **Ownership** (high) — every changed path belongs to the branch prefix's role per `config/ownership.json`. `orch/` is exempt. Check this even though the hooks exist: a role agent can bypass them, so the review is the last line of defence.
+2. **Ownership** (high) — every changed path belongs to the branch prefix's role per `config/ownership.json`. Three prefixes carry their own name; `orch/` is the key `orchestrator`. Check this even though the hooks exist: a role agent can bypass them, so the review is the last line of defence.
 3. **Spec conformance** (high) — the implementation matches the acceptance criteria in the SPEC file and the Issue, and adds no behaviour the spec never asked for.
 4. **Correctness** (high to critical) — clear bugs, broken edge cases, type and logic errors. Breaking `main` makes it critical.
 5. **Tests** (high) — behaviour changes carry tests, and existing tests were not weakened without reason.

--- a/docs/rules/roles/dev.md
+++ b/docs/rules/roles/dev.md
@@ -11,7 +11,7 @@ The `dev` worktree.
 
 ## Owns
 
-`docs/architecture/` — including `docs/architecture/decisions/` for TDRs — plus `src/` and the root development config listed in `config/ownership.json`.
+The codebase and the documents about it: the architecture overview, the TDRs, the source tree, the tests, and the root development config. The paths are the `dev` key in `config/ownership.json`.
 
 ## Flow
 

--- a/docs/rules/roles/orchestrator.md
+++ b/docs/rules/roles/orchestrator.md
@@ -11,13 +11,13 @@ The `main` checkout. No `.agent-role` file, so the ownership guards do not check
 
 ## Owns
 
-Every path — the `orchestrator` key in `config/ownership.json` is `["*"]`, because coordination reaches everywhere. Write access still goes through an `orch/<task-name>` branch and a PR. Never commit to `main` directly.
+Every path — the `orchestrator` key in `config/ownership.json` is `["*"]`, because coordination reaches everywhere. Reach is not authorship; see **Does**. Write access still goes through an `orch/<task-name>` branch and a PR. Never commit to `main` directly.
 
 ## Does
 
 Coordinates review and performs every merge. Manages worktrees and agent sessions. Maintains the rules set, the ownership config, and the hooks.
 
-Never writes a document that PM, Dev, or UI owns. Assign it to the owning role instead.
+Never writes anything PM, Dev, or UI owns — a document or a source file alike. Assign it to the owning role instead. The registry does not stop this; only this rule does.
 
 ## Merge procedure
 

--- a/docs/rules/roles/orchestrator.md
+++ b/docs/rules/roles/orchestrator.md
@@ -11,7 +11,7 @@ The `main` checkout. No `.agent-role` file, so the ownership guards do not check
 
 ## Owns
 
-`docs/rules/`, `docs/templates/`, `config/`, `.claude/`, `.githooks/`, `.github/`. Access extends to every path, but write access still goes through an `orch/<task-name>` branch and a PR. Never commit to `main` directly.
+Every path — the `orchestrator` key in `config/ownership.json` is `["*"]`, because coordination reaches everywhere. Write access still goes through an `orch/<task-name>` branch and a PR. Never commit to `main` directly.
 
 ## Does
 

--- a/docs/rules/roles/pm.md
+++ b/docs/rules/roles/pm.md
@@ -11,7 +11,7 @@ The `pm` worktree.
 
 ## Owns
 
-`docs/prd.md`, `docs/domain/`, `docs/adr/`, `docs/specs/`.
+The product documents: the PRD, the domain, the product and domain decision records, the specs. The paths are the `pm` key in `config/ownership.json`.
 
 ## Flow
 

--- a/docs/rules/roles/ui.md
+++ b/docs/rules/roles/ui.md
@@ -11,7 +11,7 @@ The `ui` worktree.
 
 ## Owns
 
-`docs/ui/`. Nothing else — **code is untouchable**.
+The UI specifications, and nothing else — **code is untouchable**. The paths are the `ui` key in `config/ownership.json`.
 
 ## Flow
 


### PR DESCRIPTION
## 무엇을 왜

지금까지 소유 정보는 `config/ownership.json`과 `docs/rules/common.md`의 표, 그리고 각 role 문서의 Owns 절 세 곳에 나눠 적혀 있었다. `common.md`는 이 JSON을 정본이라고 명시하면서도 표에 경로를 그대로 복제해 두고 있었고, 서로 어긋나면 JSON이 이긴다는 조항으로 봉합해 왔다. 이번 변경은 그 사본을 걷어내고 `config/ownership.json` 하나만 남긴다.

- `config/ownership.json`에 `"orchestrator": ["*"]`를 추가했다. 지금까지 이 파일에는 `pm`·`dev`·`ui` 세 키뿐이었다 — orchestrator는 이 registry의 예외가 아니라 전 경로를 소유하는 role이라서 명시적으로 `["*"]`를 넣는다.
- `common.md`의 표에서 `Owns`(경로) 열을 빼고 `Branch prefix`·`Registry key` 두 열로 바꿨다. 표 밑에 있던 "JSON과 표가 어긋나면 JSON이 이긴다"는 조항도 지웠다 — 경로 사본이 표에 더 이상 없으니 어길 상대가 없다.
- `docs/rules/roles/orchestrator.md`·`pm.md`·`dev.md`·`ui.md`의 Owns 절에서 경로 나열을 빼고, 무엇을 소유하는지 한 줄로 설명한 뒤 `config/ownership.json`의 해당 키를 가리키도록 고쳤다.
- `docs/rules/matchers/reviewing-a-pr.md`의 "`orch/` is exempt" 문구를 "세 prefix는 자기 이름 그대로, `orch/`는 키 `orchestrator`"로 바꿨다. orchestrator를 검사 예외로 두던 문장이 사라지고, 네 role이 같은 ownership 검사 로직으로 검증된다.

훅 코드(`.claude/hooks/`, `.githooks/`)는 건드리지 않았다. 소유 정보를 한 곳에 모으는 사실 정리이고, 판정 로직을 바꾸는 작업은 별도다.

## Impact

- Domain: 없음
- Spec: 없음
- Arch: 소유 정보의 원본이 `config/ownership.json` 하나로 좁혀졌다. 규칙 문서는 이제 경로를 복제하지 않고 registry 키를 가리킨다

## 확인

- [x] 브랜치를 `origin/main`에서 새로 땄다
- [x] 변경한 경로가 전부 내 소유다 (`config/ownership.json`)
- [x] 문서를 고쳤다면 front matter를 함께 갱신했다
- [ ] 동작을 바꿨다면 그에 상응하는 테스트가 있다

Closes #86