### PR TITLE
feat(rules): 추적되는 진입점 CLAUDE.md와 유휴 상태 규칙

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,27 +4,19 @@ Every session in this repository works as one role. Load your rules before you t
 
 ## Bootstrap
 
-1. Read `.agent-role` at the worktree root. Its value is your role key — `pm`, `dev`, or `ui`. No such file means you are the orchestrator, working in the `main` checkout.
+1. Read `.agent-role` at the worktree root. Its value is your role key — `pm`, `dev`, or `ui`.
 2. Read `docs/rules/common.md`. It is the constitution, and it carries the module map that governs steps 3 and 4.
 3. Read `docs/rules/roles/<role>.md` for your role.
 4. Read a file from `docs/rules/matchers/` only when its situation arrives. The map in `common.md` names each one and the moment it applies.
 
 Do this at the start of every session, before the first edit, branch, or Issue.
 
+The orchestrator is the exception in step 1: it works in the `main` checkout and carries no `.agent-role`, and it reads `docs/rules/roles/orchestrator.md`. A worktree that has no `.agent-role` and is not that checkout holds no role in this system. Ask which role you are; do not assume one, and do not assume you are the orchestrator.
+
 ## This file and `CLAUDE.local.md`
 
 This file is tracked, so a review and the hooks can see it. It holds the load order and nothing else.
 
-`CLAUDE.local.md` is untracked and personal — local paths, tools, and preferences for one machine. It carries no rules. When it disagrees with `docs/rules/`, the rules set wins.
-
-## Where things live
-
-| What | Where |
-|------|-------|
-| Rules | `docs/rules/` |
-| Path ownership | `config/ownership.json` |
-| Document templates | `docs/templates/` |
-| Skills and subagents | `.claude/skills/`, `.claude/agents/` |
-| Guards | `.claude/hooks/`, `.githooks/pre-commit` |
+`CLAUDE.local.md` is untracked and personal — local paths, tools, and preferences for one machine. It carries no rules.
 
 Nothing else belongs here. A rule written into this file is a second copy of a rule in `docs/rules/`, and the copy is the one that drifts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# La Bie Belle
+
+Every session in this repository works as one role. Load your rules before you touch anything.
+
+## Bootstrap
+
+1. Read `.agent-role` at the worktree root. Its value is your role key — `pm`, `dev`, or `ui`. No such file means you are the orchestrator, working in the `main` checkout.
+2. Read `docs/rules/common.md`. It is the constitution, and it carries the module map that governs steps 3 and 4.
+3. Read `docs/rules/roles/<role>.md` for your role.
+4. Read a file from `docs/rules/matchers/` only when its situation arrives. The map in `common.md` names each one and the moment it applies.
+
+Do this at the start of every session, before the first edit, branch, or Issue.
+
+## This file and `CLAUDE.local.md`
+
+This file is tracked, so a review and the hooks can see it. It holds the load order and nothing else.
+
+`CLAUDE.local.md` is untracked and personal — local paths, tools, and preferences for one machine. It carries no rules. When it disagrees with `docs/rules/`, the rules set wins.
+
+## Where things live
+
+| What | Where |
+|------|-------|
+| Rules | `docs/rules/` |
+| Path ownership | `config/ownership.json` |
+| Document templates | `docs/templates/` |
+| Skills and subagents | `.claude/skills/`, `.claude/agents/` |
+| Guards | `.claude/hooks/`, `.githooks/pre-commit` |
+
+Nothing else belongs here. A rule written into this file is a second copy of a rule in `docs/rules/`, and the copy is the one that drifts.

--- a/docs/rules/common.md
+++ b/docs/rules/common.md
@@ -2,7 +2,7 @@
 owner: "@orchestrator"
 status: "active"
 related_adr: ""
-related_issue: "#69"
+related_issue: "#69, #91"
 ---
 
 # Common Rules
@@ -53,15 +53,20 @@ Coding standards and conventions live in `docs/architecture/overview.md`, owned 
 
 Branches are short-lived and scoped to one task. At the start of every task, run `git fetch origin` and cut a fresh `<role>/<task-name>` branch from `origin/main` — `pm/…`, `dev/…`, `ui/…`, `orch/…`. Long-lived branches are forbidden.
 
-Between tasks a worktree parks on no branch at all:
+Between tasks a role worktree parks on no branch at all:
 
 ```
-git checkout --detach origin/main      # idle
-git checkout -b pm/<task> origin/main  # work starts
-git branch -d pm/<task>                # after the merge, back to detached
+git checkout --detach origin/main        # idle
+git checkout -b pm/<task> origin/main    # work starts
+                                         # the orchestrator squash-merges the PR
+git fetch origin --prune
+git checkout --detach origin/main        # leave the branch before deleting it
+git branch -D pm/<task>                  # -D, not -d: a squash merge rewrites the commit
 ```
 
-A parked branch becomes a long-lived branch, which is exactly what the rule above forbids. Detached, there is no name to violate the prefix rule and no branch to fall behind. `main` is not an option for parking: git refuses to check out one branch in two worktrees, and the `main` checkout belongs to the orchestrator.
+Delete the branch only after the merge lands. `git branch -d` refuses here — the squashed commit on `main` is not the branch's own commit, so git still calls the branch unmerged. The work is already on `main`; `-D` is the correct verb, not a shortcut around a warning.
+
+A parked branch becomes a long-lived branch, which is exactly what the rule above forbids. Detached, there is no name to violate the prefix rule and no branch to fall behind. `main` is not an option for parking: git refuses to check out one branch in two worktrees, and that checkout belongs to the orchestrator, who stays on `main` between tasks and works from `orch/` branches like everyone else.
 
 Never commit directly to `main`. Every change, the orchestrator's included, lands through a PR.
 

--- a/docs/rules/common.md
+++ b/docs/rules/common.md
@@ -45,13 +45,23 @@ The `orchestrator` key holds `["*"]`, because coordination reaches every path. T
 
 Never edit a path you do not own. Open a `[Request]` Issue for the owning agent instead.
 
-Each worktree carries its identity in two untracked files: `CLAUDE.local.md` holds the instructions, `.agent-role` holds the role marker the enforcement hooks read.
+A worktree declares its identity in one untracked file, `.agent-role`, which holds the role key the enforcement hooks read. The instructions themselves are tracked: `CLAUDE.md` at the repository root sends every session here at start-up. `CLAUDE.local.md`, where a worktree has one, is personal machine setup and carries no rules.
 
 Coding standards and conventions live in `docs/architecture/overview.md`, owned by Dev and written during the first design pass.
 
 ## Branches, PRs, and merges
 
 Branches are short-lived and scoped to one task. At the start of every task, run `git fetch origin` and cut a fresh `<role>/<task-name>` branch from `origin/main` — `pm/…`, `dev/…`, `ui/…`, `orch/…`. Long-lived branches are forbidden.
+
+Between tasks a worktree parks on no branch at all:
+
+```
+git checkout --detach origin/main      # idle
+git checkout -b pm/<task> origin/main  # work starts
+git branch -d pm/<task>                # after the merge, back to detached
+```
+
+A parked branch becomes a long-lived branch, which is exactly what the rule above forbids. Detached, there is no name to violate the prefix rule and no branch to fall behind. `main` is not an option for parking: git refuses to check out one branch in two worktrees, and the `main` checkout belongs to the orchestrator.
 
 Never commit directly to `main`. Every change, the orchestrator's included, lands through a PR.
 


### PR DESCRIPTION
## 무엇이 바뀌었나

추적되는 `CLAUDE.md`를 저장소 루트에 세운다. 세션이 시작될 때 `.agent-role`을 읽고 `docs/rules/common.md`와 `roles/<role>.md`를 로드하라는 진입점이다. 규칙 본문은 담지 않는다 — 여기 적는 순간 `docs/rules/`의 사본이 된다.
`docs/rules/common.md`에서 정체성 서술을 고친다. 지시는 이제 추적되는 `CLAUDE.md`가 갖고, `.agent-role`만 추적되지 않는 표식으로 남으며, `CLAUDE.local.md`는 개인 설정 전용이 된다.
브랜치 절에 유휴 상태를 못박는다. task 사이에는 `git checkout --detach origin/main`으로 아무 브랜치에도 서 있지 않는다. 주차된 브랜치가 곧 장수 브랜치이고, `main`은 git이 두 worktree에 못 걸게 막는 데다 총괄 몫이다.

## Impact

- Domain: 없음
- Spec: 없음
- Arch: 세션 부트스트랩이 처음으로 추적 파일 하나로 모인다. 지금까지 role 세션 셋은 `CLAUDE.local.md`가 가리키는 `docs/rules.md`를 따라갔는데 그 파일은 저장소에 없다 — 규칙 세트가 로드되지 않은 채 세션이 돌았다. 이 PR이 merge되면 role 세션은 재시작해야 새 진입점을 읽는다. worktree 셋을 detached로 옮기고 `tkyoun0421/*` 주차 브랜치를 지우는 일, `CLAUDE.local.md` 셋에서 역할 서술을 걷는 일은 추적되지 않는 파일이라 이 PR 밖에서 한다

## 관련 Issue

관련 #91 (6단계 중 1단계)
관련 #71
