### PR TITLE
chore(ci): 소유·secrets 검사를 PR마다 돌린다

### DIFF
--- a/.github/workflows/ownership.yml
+++ b/.github/workflows/ownership.yml
@@ -33,14 +33,15 @@ jobs:
           git -c core.quotepath=false diff --name-status -M "$BASE_SHA"..."$HEAD_SHA" \
             | awk -F'\t' '{for (i = 2; i <= NF; i++) print $i}' > changed.txt
           git -c core.quotepath=false log --format= --name-status -M "$BASE_SHA".."$HEAD_SHA" \
-            | awk -F'\t' 'NF > 1 {for (i = 2; i <= NF; i++) print $i}' | sort -u > touched.txt
+            | awk -F'\t' 'NF > 1 {for (i = 2; i <= NF; i++) print $i}' > touched.txt
+          sort -u changed.txt touched.txt > scanned.txt
           echo "최종 diff:"; cat changed.txt
-          echo "브랜치의 모든 커밋:"; cat touched.txt
+          echo "secrets 검사 대상:"; cat scanned.txt
 
       - name: secrets 차단
         shell: bash
         run: |
-          if grep -E '(^|/)\.env(\..+)?$|(^|/)\.envrc$' touched.txt | grep -vE '(^|/)\.env\.example$'; then
+          if grep -E '(^|/)\.env(\..+)?$|(^|/)\.envrc$' scanned.txt | grep -vE '(^|/)\.env\.example$'; then
             echo "::error::.env·.envrc 파일은 트리 어디에도 커밋하지 않는다. 저장소가 공개라 지운 커밋도 남는다."
             exit 1
           fi

--- a/.github/workflows/ownership.yml
+++ b/.github/workflows/ownership.yml
@@ -15,24 +15,39 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: base 기준 판정 module과 registry 꺼내기
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          mkdir -p base/config base/scripts
+          git show "$BASE_SHA:config/ownership.json" > base/config/ownership.json
+          git show "$BASE_SHA:scripts/ownership-check.py" > base/scripts/ownership-check.py
+
       - name: 변경 경로 수집
+        shell: bash
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          git diff --name-status -M "$BASE_SHA"..."$HEAD_SHA" \
+          git -c core.quotepath=false diff --name-status -M "$BASE_SHA"..."$HEAD_SHA" \
             | awk -F'\t' '{for (i = 2; i <= NF; i++) print $i}' > changed.txt
-          cat changed.txt
+          git -c core.quotepath=false log --format= --name-status -M "$BASE_SHA".."$HEAD_SHA" \
+            | awk -F'\t' 'NF > 1 {for (i = 2; i <= NF; i++) print $i}' | sort -u > touched.txt
+          echo "최종 diff:"; cat changed.txt
+          echo "브랜치의 모든 커밋:"; cat touched.txt
 
       - name: secrets 차단
+        shell: bash
         run: |
-          if grep -E '(^|/)\.env(\..+)?$|(^|/)\.envrc$' changed.txt | grep -vE '(^|/)\.env\.example$'; then
-            echo "::error::.env·.envrc 파일은 트리 어디에도 커밋하지 않는다. 저장소가 공개다."
+          if grep -E '(^|/)\.env(\..+)?$|(^|/)\.envrc$' touched.txt | grep -vE '(^|/)\.env\.example$'; then
+            echo "::error::.env·.envrc 파일은 트리 어디에도 커밋하지 않는다. 저장소가 공개라 지운 커밋도 남는다."
             exit 1
           fi
 
       - name: 소유 검사
+        shell: bash
         env:
-          PROJECT_DIR: ${{ github.workspace }}
+          PROJECT_DIR: ${{ github.workspace }}/base
           HEAD_REF: ${{ github.head_ref }}
-        run: python3 scripts/ownership-check.py paths --branch "$HEAD_REF" < changed.txt
+        run: python3 base/scripts/ownership-check.py paths --branch "$HEAD_REF" < changed.txt

--- a/.github/workflows/ownership.yml
+++ b/.github/workflows/ownership.yml
@@ -1,0 +1,38 @@
+name: ownership
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 변경 경로 수집
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git diff --name-status -M "$BASE_SHA"..."$HEAD_SHA" \
+            | awk -F'\t' '{for (i = 2; i <= NF; i++) print $i}' > changed.txt
+          cat changed.txt
+
+      - name: secrets 차단
+        run: |
+          if grep -E '(^|/)\.env(\..+)?$|(^|/)\.envrc$' changed.txt | grep -vE '(^|/)\.env\.example$'; then
+            echo "::error::.env·.envrc 파일은 트리 어디에도 커밋하지 않는다. 저장소가 공개다."
+            exit 1
+          fi
+
+      - name: 소유 검사
+        env:
+          PROJECT_DIR: ${{ github.workspace }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: python3 scripts/ownership-check.py paths --branch "$HEAD_REF" < changed.txt

--- a/docs/rules/common.md
+++ b/docs/rules/common.md
@@ -2,7 +2,7 @@
 owner: "@orchestrator"
 status: "active"
 related_adr: ""
-related_issue: "#69, #88, #91, #101, #105"
+related_issue: "#69, #88, #91, #101, #105, #106"
 ---
 
 # 공통 규칙
@@ -111,14 +111,17 @@ merge 소식은 뿌리지 않는다. 총괄은 그 merge가 특정 역할에게 
 
 ## 집행
 
-판정은 한 자리에 있다. `scripts/ownership-check.py`가 "역할 R이 경로 P를 쓸 수 있나"에 답하고, 아래 훅 둘이 그것을 부른다. 둘 다 **fail closed**다 — `config/ownership.json`이 깨졌거나, worktree 이름이 역할 키가 아니거나, 브랜치 접두가 가리키는 역할이 worktree와 다르면 통과가 아니라 차단이다. 총괄도 예외가 아니다. `["*"]`가 총괄의 모든 경로를 통과시킬 뿐, 검사 자체는 똑같이 돈다.
+판정은 한 자리에 있다. `scripts/ownership-check.py`가 "역할 R이 경로 P를 쓸 수 있나"에 답하고, 아래 셋이 그것을 부른다. 셋 다 **fail closed**다 — `config/ownership.json`이 깨졌거나, worktree 이름이 역할 키가 아니거나, 브랜치 접두가 가리키는 역할이 worktree와 다르면 통과가 아니라 차단이다. 총괄도 예외가 아니다. `["*"]`가 총괄의 모든 경로를 통과시킬 뿐, 검사 자체는 똑같이 돈다.
 
 secrets 차단은 별개 축이다. `.githooks/pre-commit`은 역할을 가리기도 전에 `.env*`와 `.envrc`를 거절하므로 총괄도 여기에 걸린다.
 
 - **PreToolUse 훅** `.claude/hooks/ownership-guard.sh`가 판정 module을 불러, 편집 시점에 역할 소유 밖 경로의 `Edit`·`Write`·`NotebookEdit`를 거절한다. 자기 worktree 밖의 절대 경로도 거절한다 — 다른 worktree도 포함이고, 임시 디렉터리와 `~/.claude`만 예외다.
 - **pre-commit 훅** `.githooks/pre-commit`이 스테이지된 변경의 소유를 검사한다 — 추가·수정·삭제와 rename 양쪽이다. 그리고 트리 어디에 있든 `.env*`와 `.envrc`를 막는다. 유일한 예외는 `.env.example`이다. 저장소를 클론하거나 리셋한 뒤에는 `git config core.hooksPath .githooks`를 한 번 돌려라.
+- **CI** `.github/workflows/ownership.yml`이 PR마다 같은 판정을 다시 돌린다. worktree가 없는 자리라 역할은 브랜치 접두에서 온다 — `--branch`가 그 값을 나른다. `.env` 계열 차단도 같이 돈다. 이 검사는 required status check라 빨간불이면 merge가 거부된다.
 
-알려진 한계: 역할 에이전트는 `git commit --no-verify`로 두 훅을 함께 끌 수 있다. 그건 규칙 위반이고, 마지막 방어선은 독립 PR 리뷰다 — 리뷰어는 브랜치 접두와 바뀐 모든 경로의 소유를 매번 대조한다.
+로컬 훅 둘은 끌 수 있다. `git commit --no-verify`가 pre-commit 훅을 건너뛰고, PreToolUse 훅은 Claude Code 설정을 고치면 꺼진다. 둘 다 규칙 위반이고, 그래서 같은 판정이 CI에 한 번 더 있다. CI는 저장소 설정이 지키므로 에이전트가 끄지 못한다.
+
+CI가 잡지 못하는 축은 남는다. `orchestrator` 키가 `["*"]`라 총괄의 작성권은 registry가 검사하지 않고, 명세 부합과 정확성도 기계의 몫이 아니다. 그 자리의 방어선은 독립 PR 리뷰다 — 리뷰어는 브랜치 접두와 바뀐 모든 경로의 소유를 매번 대조한다.
 
 ## 기본 전제
 

--- a/docs/rules/common.md
+++ b/docs/rules/common.md
@@ -111,13 +111,17 @@ merge 소식은 뿌리지 않는다. 총괄은 그 merge가 특정 역할에게 
 
 ## 집행
 
-판정은 한 자리에 있다. `scripts/ownership-check.py`가 "역할 R이 경로 P를 쓸 수 있나"에 답하고, 아래 셋이 그것을 부른다. 셋 다 **fail closed**다 — `config/ownership.json`이 깨졌거나, worktree 이름이 역할 키가 아니거나, 브랜치 접두가 가리키는 역할이 worktree와 다르면 통과가 아니라 차단이다. 총괄도 예외가 아니다. `["*"]`가 총괄의 모든 경로를 통과시킬 뿐, 검사 자체는 똑같이 돈다.
+판정은 한 자리에 있다. `scripts/ownership-check.py`가 "역할 R이 경로 P를 쓸 수 있나"에 답하고, 아래 셋이 그것을 부른다.
+
+셋 다 **fail closed**다. `config/ownership.json`을 읽을 수 없으면 어디서든 차단이다. 훅 둘은 worktree 이름이 역할 키가 아니거나 브랜치 접두가 가리키는 역할과 다를 때 막고, CI는 worktree가 없는 자리라 접두가 등록된 넷이 아니거나 그 값이 비었을 때 막는다.
+
+총괄도 예외가 아니다. `["*"]`가 총괄의 모든 경로를 통과시킬 뿐, 검사 자체는 똑같이 돈다.
 
 secrets 차단은 별개 축이다. `.githooks/pre-commit`은 역할을 가리기도 전에 `.env*`와 `.envrc`를 거절하므로 총괄도 여기에 걸린다.
 
 - **PreToolUse 훅** `.claude/hooks/ownership-guard.sh`가 판정 module을 불러, 편집 시점에 역할 소유 밖 경로의 `Edit`·`Write`·`NotebookEdit`를 거절한다. 자기 worktree 밖의 절대 경로도 거절한다 — 다른 worktree도 포함이고, 임시 디렉터리와 `~/.claude`만 예외다.
 - **pre-commit 훅** `.githooks/pre-commit`이 스테이지된 변경의 소유를 검사한다 — 추가·수정·삭제와 rename 양쪽이다. 그리고 트리 어디에 있든 `.env*`와 `.envrc`를 막는다. 유일한 예외는 `.env.example`이다. 저장소를 클론하거나 리셋한 뒤에는 `git config core.hooksPath .githooks`를 한 번 돌려라.
-- **CI** `.github/workflows/ownership.yml`이 PR마다 같은 판정을 다시 돌린다. worktree가 없는 자리라 역할은 브랜치 접두에서 온다 — `--branch`가 그 값을 나른다. `.env` 계열 차단도 같이 돈다. 이 검사는 required status check라 빨간불이면 merge가 거부된다.
+- **CI** `.github/workflows/ownership.yml`이 PR마다 같은 판정을 다시 돌린다. worktree가 없는 자리라 역할은 브랜치 접두에서 온다 — `--branch`가 그 값을 나른다. 판정 module과 registry는 PR이 아니라 base 커밋에서 꺼내 읽는다. 그러지 않으면 PR이 registry에 자기 줄을 넣어 스스로를 통과시킨다. `.env` 계열 차단도 같이 도는데, 이쪽은 최종 diff가 아니라 브랜치의 모든 커밋을 훑는다 — 넣었다 지운 키도 공개 저장소의 이력에는 남기 때문이다. 이 검사는 required status check라 빨간불이면 merge가 거부된다.
 
 로컬 훅 둘은 끌 수 있다. `git commit --no-verify`가 pre-commit 훅을 건너뛰고, PreToolUse 훅은 Claude Code 설정을 고치면 꺼진다. 둘 다 규칙 위반이고, 그래서 같은 판정이 CI에 한 번 더 있다. CI는 저장소 설정이 지키므로 에이전트가 끄지 못한다.
 

--- a/docs/rules/common.md
+++ b/docs/rules/common.md
@@ -121,7 +121,7 @@ secrets 차단은 별개 축이다. `.githooks/pre-commit`은 역할을 가리�
 
 - **PreToolUse 훅** `.claude/hooks/ownership-guard.sh`가 판정 module을 불러, 편집 시점에 역할 소유 밖 경로의 `Edit`·`Write`·`NotebookEdit`를 거절한다. 자기 worktree 밖의 절대 경로도 거절한다 — 다른 worktree도 포함이고, 임시 디렉터리와 `~/.claude`만 예외다.
 - **pre-commit 훅** `.githooks/pre-commit`이 스테이지된 변경의 소유를 검사한다 — 추가·수정·삭제와 rename 양쪽이다. 그리고 트리 어디에 있든 `.env*`와 `.envrc`를 막는다. 유일한 예외는 `.env.example`이다. 저장소를 클론하거나 리셋한 뒤에는 `git config core.hooksPath .githooks`를 한 번 돌려라.
-- **CI** `.github/workflows/ownership.yml`이 PR마다 같은 판정을 다시 돌린다. worktree가 없는 자리라 역할은 브랜치 접두에서 온다 — `--branch`가 그 값을 나른다. 판정 module과 registry는 PR이 아니라 base 커밋에서 꺼내 읽는다. 그러지 않으면 PR이 registry에 자기 줄을 넣어 스스로를 통과시킨다. `.env` 계열 차단도 같이 도는데, 이쪽은 최종 diff가 아니라 브랜치의 모든 커밋을 훑는다 — 넣었다 지운 키도 공개 저장소의 이력에는 남기 때문이다. 이 검사는 required status check라 빨간불이면 merge가 거부된다.
+- **CI** `.github/workflows/ownership.yml`이 PR마다 같은 판정을 다시 돌린다. worktree가 없는 자리라 역할은 브랜치 접두에서 온다 — `--branch`가 그 값을 나른다. 판정 module과 registry는 PR이 아니라 base 커밋에서 꺼내 읽는다. 그러지 않으면 PR이 registry에 자기 줄을 넣어 스스로를 통과시킨다. `.env` 계열 차단도 같이 도는데, 이쪽은 최종 diff와 브랜치의 모든 커밋을 합쳐 훑는다 — 넣었다 지운 키도 공개 저장소의 이력에는 남고, merge 커밋에서 얹은 파일은 커밋 목록에 안 나오기 때문이다. 이 검사는 required status check라 빨간불이면 merge가 거부된다.
 
 로컬 훅 둘은 끌 수 있다. `git commit --no-verify`가 pre-commit 훅을 건너뛰고, PreToolUse 훅은 Claude Code 설정을 고치면 꺼진다. 둘 다 규칙 위반이고, 그래서 같은 판정이 CI에 한 번 더 있다. CI는 저장소 설정이 지키므로 에이전트가 끄지 못한다.
 

--- a/docs/rules/roles/orchestrator.md
+++ b/docs/rules/roles/orchestrator.md
@@ -2,7 +2,7 @@
 owner: "@orchestrator"
 status: "active"
 related_adr: ""
-related_issue: "#69, #101, #105"
+related_issue: "#69, #101, #105, #106"
 ---
 
 # 역할: 총괄 (`@orchestrator`)
@@ -25,8 +25,12 @@ PM·Dev·UI가 소유한 것은 문서든 소스든 절대 쓰지 않는다. 소
 
 1. 역할이 PR을 열고 이 세션에 벨을 울린다.
 2. `pr-reviewer` 에이전트를 붙인다. 작성자는 자기 PR을 리뷰하지 않는다.
-3. PASS면 squash merge한다. `normal` 발견은 merge 후 `[Ticket]` Issue가 된다.
+3. PASS면 auto-merge를 건다 — `gh pr merge <번호> --auto --squash --delete-branch`. CI가 초록이 되는 순간 GitHub이 merge한다. `normal` 발견은 merge 후 `[Ticket]` Issue가 된다.
 4. FAIL이면 멈춘다. `docs/rules/matchers/review-failed.md`를 따른다.
+
+auto-merge를 거는 시점이 곧 리뷰가 끝났다는 뜻이다. PR을 열 때 걸지 마라. GitHub이 볼 수 있는 조건은 CI 초록뿐이고 — 계정이 하나라 `pr-reviewer`의 PASS를 required approval로 태울 수 없다 — 리뷰 조건은 이 절차가 지킨다.
+
+CI가 빨간불이면 리뷰어를 붙이기 전에 작성한 역할이 고친다. 같은 브랜치에 push하면 검사가 다시 돈다.
 
 merge를 전하는 것은 그게 다음 일감을 만들 때뿐이다. SPEC이 merge되면 Dev에게 Epic 분해를, 기능이 merge되면 UI에게 검수를 보낸다. 나머지 merge는 조용히 지나간다.
 


### PR DESCRIPTION
## 무엇이 바뀌었나

PR마다 도는 workflow `.github/workflows/ownership.yml`을 세웠다. 바뀐 경로를 `scripts/ownership-check.py`에 그대로 흘려 넣어 소유를 검사하고, `.env*`와 `.envrc`가 들어왔는지 본다. 판정 로직은 한 줄도 복사하지 않았다 — 로컬 훅이 부르는 그 파일을 CI도 부른다.

CI에는 worktree가 없어 체크아웃이 언제나 main 작업 트리다. 그래서 역할은 브랜치 접두에서 오고, `--branch` 인자가 그 값을 나른다. 브랜치 이름은 셸에 직접 박지 않고 `env`로 넘긴다.

`docs/rules/common.md`의 집행 절에 CI 불릿을 더하고, 로컬 훅을 끄는 방법이 둘이라는 것과 CI가 그 자리를 메운다는 것을 적었다. `docs/rules/roles/orchestrator.md`의 merge 절차 3번을 auto-merge로 바꿨다.

## Impact

- Domain: 없음
- Spec: 없음
- Arch: 판정 module에 세 번째 adapter가 붙었다. 로컬 편집 훅, pre-commit, CI가 같은 `scripts/ownership-check.py`를 부른다

## 관련 Issue

Closes #106
관련 #103 (3단계 중 3단계)

---

merge 뒤에 GitHub 설정 다섯을 켠다. workflow가 `main`에 들어가 한 번 돌아야 required check 이름이 잡히므로 순서가 있다.

- `ownership / check`를 required status check로 걸고 우회 허용을 끈다
- auto-merge를 켠다 (`allow_auto_merge`가 지금 `false`다)
- squash만 남기고 merge commit과 rebase merge를 끈다
- squash 커밋 제목을 `PR_TITLE`, 본문을 `PR_BODY`로 바꾼다
- merge하면 원격 브랜치를 자동으로 지운다

이 PR 자체는 아직 검사를 받지 않는다. workflow가 `main`에 없기 때문이다. 다음 PR부터 돈다.
