### PR TITLE
chore(ci): secrets 판정을 module로 빼고 하네스를 세운다

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,13 +2,13 @@
 set -u
 
 toplevel=$(git rev-parse --show-toplevel)
+records=$(mktemp)
+trap 'rm -f "$records"' EXIT
 
-paths=$(git -c core.quotepath=false diff --cached --name-status -M | awk -F'\t' '{for (i = 2; i <= NF; i++) print $i}')
+git diff --cached --name-status -z -M \
+  | python3 "$toplevel/scripts/secrets-check.py" paths > "$records"
 
-if printf '%s\n' "$paths" | grep -E '(^|/)\.env(\..+)?$|(^|/)\.envrc$' | grep -vE '(^|/)\.env\.example$' >/dev/null; then
-  echo "pre-commit: .env·.envrc 파일은 트리 어디에도 커밋하지 않는다. 저장소가 공개다." >&2
-  exit 1
-fi
+python3 "$toplevel/scripts/secrets-check.py" scan < "$records" || exit 1
 
 export PROJECT_DIR="$toplevel"
-printf '%s\n' "$paths" | python3 "$toplevel/scripts/ownership-check.py" paths
+tr '\0' '\n' < "$records" | python3 "$toplevel/scripts/ownership-check.py" paths

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,11 +1,11 @@
 #!/bin/bash
-set -u
+set -uo pipefail
 
 toplevel=$(git rev-parse --show-toplevel)
 records=$(mktemp)
 trap 'rm -f "$records"' EXIT
 
-if ! git diff --cached --name-status -z -M \
+if ! git diff --cached --name-status -z -M -C \
   | python3 "$toplevel/scripts/secrets-check.py" paths > "$records"; then
   exit 1
 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,8 +5,10 @@ toplevel=$(git rev-parse --show-toplevel)
 records=$(mktemp)
 trap 'rm -f "$records"' EXIT
 
-git diff --cached --name-status -z -M \
-  | python3 "$toplevel/scripts/secrets-check.py" paths > "$records"
+if ! git diff --cached --name-status -z -M \
+  | python3 "$toplevel/scripts/secrets-check.py" paths > "$records"; then
+  exit 1
+fi
 
 python3 "$toplevel/scripts/secrets-check.py" scan < "$records" || exit 1
 

--- a/.github/workflows/ownership.yml
+++ b/.github/workflows/ownership.yml
@@ -50,7 +50,8 @@ jobs:
                 | python3 base/scripts/secrets-check.py paths > dropped.zero
               echo "force-push 이전 head ${BEFORE_SHA}의 이력도 함께 훑는다"
             else
-              echo "::warning::force-push 이전 head ${BEFORE_SHA}를 가져오지 못했다. 그 이력은 이번 검사에서 빠진다"
+              echo "::error::force-push 이전 head ${BEFORE_SHA}를 가져오지 못해 그 이력을 훑을 수 없다. 통과가 아니라 차단이다 — 브랜치에 다시 push해서 검사를 새로 돌려라"
+              exit 1
             fi
           fi
 

--- a/.github/workflows/ownership.yml
+++ b/.github/workflows/ownership.yml
@@ -48,14 +48,14 @@ jobs:
               || git fetch --no-tags --quiet origin "$BEFORE_SHA" 2>/dev/null; then
               git log --format= --name-status -z -M -C "$BASE_SHA".."$BEFORE_SHA" \
                 | python3 base/scripts/secrets-check.py paths > dropped.zero
-              echo "force-push 이전 head ${BEFORE_SHA}의 이력도 함께 훑는다"
+              echo "직전 head ${BEFORE_SHA}까지의 이력도 함께 훑는다 — force-push로 밀려난 커밋이 있다면 여기서 걸린다"
             else
               echo "::error::force-push 이전 head ${BEFORE_SHA}를 가져오지 못해 그 이력을 훑을 수 없다. 통과가 아니라 차단이다 — 커밋을 하나 얹어 일반 push해라. 또 force-push하면 같은 자리에 다시 걸리고, job 재실행도 같은 payload를 쓴다"
               exit 1
             fi
           fi
 
-          cat changed.zero touched.zero dropped.zero > scanned.zero
+          cat changed.zero touched.zero dropped.zero | sort -z -u > scanned.zero
           echo "소유 검사 대상 — 최종 diff:"
           tr '\0' '\n' < changed.zero
           echo "secrets 검사 대상 — 최종 diff에 모든 커밋과 떨어져 나간 이력을 더한 것:"

--- a/.github/workflows/ownership.yml
+++ b/.github/workflows/ownership.yml
@@ -37,20 +37,20 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BEFORE_SHA: ${{ github.event.before }}
         run: |
-          git diff --name-status -z -M "$BASE_SHA"..."$HEAD_SHA" \
+          git diff --name-status -z -M -C "$BASE_SHA"..."$HEAD_SHA" \
             | python3 base/scripts/secrets-check.py paths > changed.zero
-          git log --format= --name-status -z -M "$BASE_SHA".."$HEAD_SHA" \
+          git log --format= --name-status -z -M -C "$BASE_SHA".."$HEAD_SHA" \
             | python3 base/scripts/secrets-check.py paths > touched.zero
           : > dropped.zero
 
           if [ -n "${BEFORE_SHA:-}" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
             if git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null \
               || git fetch --no-tags --quiet origin "$BEFORE_SHA" 2>/dev/null; then
-              git log --format= --name-status -z -M "$BASE_SHA".."$BEFORE_SHA" \
+              git log --format= --name-status -z -M -C "$BASE_SHA".."$BEFORE_SHA" \
                 | python3 base/scripts/secrets-check.py paths > dropped.zero
               echo "force-push 이전 head ${BEFORE_SHA}의 이력도 함께 훑는다"
             else
-              echo "::error::force-push 이전 head ${BEFORE_SHA}를 가져오지 못해 그 이력을 훑을 수 없다. 통과가 아니라 차단이다 — 브랜치에 다시 push해서 검사를 새로 돌려라"
+              echo "::error::force-push 이전 head ${BEFORE_SHA}를 가져오지 못해 그 이력을 훑을 수 없다. 통과가 아니라 차단이다 — 커밋을 하나 얹어 일반 push해라. 또 force-push하면 같은 자리에 다시 걸리고, job 재실행도 같은 payload를 쓴다"
               exit 1
             fi
           fi

--- a/.github/workflows/ownership.yml
+++ b/.github/workflows/ownership.yml
@@ -23,32 +23,54 @@ jobs:
           mkdir -p base/config base/scripts
           git show "$BASE_SHA:config/ownership.json" > base/config/ownership.json
           git show "$BASE_SHA:scripts/ownership-check.py" > base/scripts/ownership-check.py
+          if git show "$BASE_SHA:scripts/secrets-check.py" > base/scripts/secrets-check.py 2>/dev/null; then
+            echo "secrets 판정 module을 base 커밋에서 꺼냈다"
+          else
+            cp scripts/secrets-check.py base/scripts/secrets-check.py
+            echo "::warning::base 커밋에 scripts/secrets-check.py가 없어 이번만 PR의 것을 쓴다"
+          fi
 
       - name: 변경 경로 수집
         shell: bash
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
-          git -c core.quotepath=false diff --name-status -M "$BASE_SHA"..."$HEAD_SHA" \
-            | awk -F'\t' '{for (i = 2; i <= NF; i++) print $i}' > changed.txt
-          git -c core.quotepath=false log --format= --name-status -M "$BASE_SHA".."$HEAD_SHA" \
-            | awk -F'\t' 'NF > 1 {for (i = 2; i <= NF; i++) print $i}' > touched.txt
-          sort -u changed.txt touched.txt > scanned.txt
-          echo "최종 diff:"; cat changed.txt
-          echo "secrets 검사 대상:"; cat scanned.txt
+          git diff --name-status -z -M "$BASE_SHA"..."$HEAD_SHA" \
+            | python3 base/scripts/secrets-check.py paths > changed.zero
+          git log --format= --name-status -z -M "$BASE_SHA".."$HEAD_SHA" \
+            | python3 base/scripts/secrets-check.py paths > touched.zero
+          : > dropped.zero
+
+          if [ -n "${BEFORE_SHA:-}" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            if git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null \
+              || git fetch --no-tags --quiet origin "$BEFORE_SHA" 2>/dev/null; then
+              git log --format= --name-status -z -M "$BASE_SHA".."$BEFORE_SHA" \
+                | python3 base/scripts/secrets-check.py paths > dropped.zero
+              echo "force-push 이전 head ${BEFORE_SHA}의 이력도 함께 훑는다"
+            else
+              echo "::warning::force-push 이전 head ${BEFORE_SHA}를 가져오지 못했다. 그 이력은 이번 검사에서 빠진다"
+            fi
+          fi
+
+          cat changed.zero touched.zero dropped.zero > scanned.zero
+          echo "소유 검사 대상 — 최종 diff:"
+          tr '\0' '\n' < changed.zero
+          echo "secrets 검사 대상 — 최종 diff에 모든 커밋과 떨어져 나간 이력을 더한 것:"
+          tr '\0' '\n' < scanned.zero
 
       - name: secrets 차단
         shell: bash
-        run: |
-          if grep -E '(^|/)\.env(\..+)?$|(^|/)\.envrc$' scanned.txt | grep -vE '(^|/)\.env\.example$'; then
-            echo "::error::.env·.envrc 파일은 트리 어디에도 커밋하지 않는다. 저장소가 공개라 지운 커밋도 남는다."
-            exit 1
-          fi
+        run: python3 base/scripts/secrets-check.py scan < scanned.zero
 
       - name: 소유 검사
         shell: bash
         env:
           PROJECT_DIR: ${{ github.workspace }}/base
           HEAD_REF: ${{ github.head_ref }}
-        run: python3 base/scripts/ownership-check.py paths --branch "$HEAD_REF" < changed.txt
+        run: tr '\0' '\n' < changed.zero | python3 base/scripts/ownership-check.py paths --branch "$HEAD_REF"
+
+      - name: 가드 하네스
+        shell: bash
+        run: python3 scripts/test-ownership.py

--- a/docs/rules/common.md
+++ b/docs/rules/common.md
@@ -2,7 +2,7 @@
 owner: "@orchestrator"
 status: "active"
 related_adr: ""
-related_issue: "#69, #88, #91, #101, #105, #106, #114, #109"
+related_issue: "#69, #88, #91, #101, #105, #106, #114, #109, #63, #111, #112"
 ---
 
 # 공통 규칙
@@ -114,7 +114,9 @@ merge 소식은 뿌리지 않는다. 총괄은 그 merge가 특정 역할에게 
 
 ## 집행
 
-판정은 한 자리에 있다. `scripts/ownership-check.py`가 "역할 R이 경로 P를 쓸 수 있나"에 답하고, 아래 셋이 그것을 부른다.
+판정 module이 둘이다. `scripts/ownership-check.py`가 "역할 R이 경로 P를 쓸 수 있나"에 답하고, `scripts/secrets-check.py`가 "이 경로가 자격 증명 파일인가"에 답한다. 아래 셋이 그것들을 부른다.
+
+둘 다 git이 내놓는 NUL 구분 목록을 그대로 읽는다. 경로에 따옴표나 탭이 들어 있으면 git이 이름을 인용해 내놓는데, 줄 단위로 자르면 그 인용이 패턴을 깨뜨려 `"이상한 폴더/.env"`가 그냥 지나간다. `scripts/test-ownership.py`가 그 경우를 케이스로 잡아 둔다.
 
 셋 다 **fail closed**다. `config/ownership.json`을 읽을 수 없으면 어디서든 차단이다. 훅 둘은 worktree 이름이 역할 키가 아니거나 브랜치 접두가 가리키는 역할과 다를 때 막고, CI는 worktree가 없는 자리라 접두가 등록된 넷이 아니거나 그 값이 비었을 때 막는다.
 
@@ -124,7 +126,9 @@ secrets 차단은 별개 축이다. `.githooks/pre-commit`은 역할을 가리�
 
 - **PreToolUse 훅** `.claude/hooks/ownership-guard.sh`가 판정 module을 불러, 편집 시점에 역할 소유 밖 경로의 `Edit`·`Write`·`NotebookEdit`를 거절한다. 자기 worktree 밖의 절대 경로도 거절한다 — 다른 worktree도 포함이고, 임시 디렉터리와 `~/.claude`만 예외다.
 - **pre-commit 훅** `.githooks/pre-commit`이 스테이지된 변경의 소유를 검사한다 — 추가·수정·삭제와 rename 양쪽이다. 그리고 트리 어디에 있든 `.env*`와 `.envrc`를 막는다. 유일한 예외는 `.env.example`이다. 저장소를 클론하거나 리셋한 뒤에는 `git config core.hooksPath .githooks`를 한 번 돌려라.
-- **CI** `.github/workflows/ownership.yml`이 PR마다 같은 판정을 다시 돌린다. 역할은 브랜치 접두에서 오고 `--branch`가 그 값을 나른다. 판정 module과 registry는 PR이 아니라 base 커밋에서 꺼내 읽는다. 그러지 않으면 PR이 registry에 자기 줄을 넣어 스스로를 통과시킨다. 두 검사가 서로 다른 목록을 본다. 소유 검사는 base와 head를 견준 **최종 diff**만 본다 — 중간에 건드렸다가 되돌린 파일은 merge될 트리에 없으니 소유를 묻지 않는다. `.env` 계열 차단은 그 최종 diff에 **브랜치의 모든 커밋**을 더해 훑는다. 넣었다 지운 키가 공개 저장소의 이력에 남기 때문이고, merge 커밋에서 얹은 파일은 커밋 목록에 나오지 않기 때문이다. 이 검사는 required status check라 빨간불이면 merge가 거부된다.
+- **CI** `.github/workflows/ownership.yml`이 PR마다 같은 판정을 다시 돌린다. 역할은 브랜치 접두에서 오고 `--branch`가 그 값을 나른다. 판정 module과 registry는 PR이 아니라 base 커밋에서 꺼내 읽는다. 그러지 않으면 PR이 registry에 자기 줄을 넣어 스스로를 통과시킨다. 두 검사가 서로 다른 목록을 본다. 소유 검사는 base와 head를 견준 **최종 diff**만 본다 — 중간에 건드렸다가 되돌린 파일은 merge될 트리에 없으니 소유를 묻지 않는다. `.env` 계열 차단은 그 최종 diff에 **브랜치의 모든 커밋**과 **force-push로 떨어져 나간 이력**을 더해 훑는다. 넣었다 지운 키가 공개 저장소의 이력에 남기 때문이고, merge 커밋에서 얹은 파일은 커밋 목록에 나오지 않기 때문이다. 떨어져 나간 이력은 `synchronize` 이벤트가 나르는 갈아타기 전 head에서 온다 — 그 커밋을 가져오지 못하면 검사를 건너뛰지 않고 경고를 남긴다. 이 검사는 required status check라 빨간불이면 merge가 거부된다.
+
+CI는 마지막으로 돌린 검사 하나로 merge를 가른다. force-push 이력은 그것을 밀어낸 push의 검사가 잡으므로, 그 뒤에 또 force-push하면 앞 이력은 다시 훑지 않는다. 한 번 저장소에 닿은 키는 검사 결과와 무관하게 폐기하고 새로 발급해라.
 
 로컬 훅 둘은 끌 수 있다. `git commit --no-verify`가 pre-commit 훅을 건너뛰고, PreToolUse 훅은 Claude Code 설정을 고치면 꺼진다. 둘 다 규칙 위반이고, 그래서 같은 판정이 CI에 한 번 더 있다. CI는 저장소 설정이 지키므로 에이전트가 끄지 못한다.
 
@@ -140,4 +144,3 @@ CI가 잡지 못하는 축은 남는다. `orchestrator` 키가 `["*"]`라 총괄
 아래가 정해지면 이 규칙 세트를 고친다.
 
 - 문서 색인과 검색 스크립트 (tsx)
-- 소유권 가드 자동 테스트 하네스 (#63)

--- a/docs/rules/common.md
+++ b/docs/rules/common.md
@@ -116,7 +116,9 @@ merge 소식은 뿌리지 않는다. 총괄은 그 merge가 특정 역할에게 
 
 판정 module이 둘이다. `scripts/ownership-check.py`가 "역할 R이 경로 P를 쓸 수 있나"에 답하고, `scripts/secrets-check.py`가 "이 경로가 자격 증명 파일인가"에 답한다. 아래 셋이 그것들을 부른다.
 
-둘 다 git이 내놓는 NUL 구분 목록을 그대로 읽는다. 경로에 따옴표나 탭이 들어 있으면 git이 이름을 인용해 내놓는데, 줄 단위로 자르면 그 인용이 패턴을 깨뜨려 `"이상한 폴더/.env"`가 그냥 지나간다. `scripts/test-ownership.py`가 그 경우를 케이스로 잡아 둔다.
+경로 목록은 `scripts/secrets-check.py`가 git의 NUL 구분 출력에서 꺼낸다. 줄 단위로 자르면 git이 이름을 인용해 내놓는 경로 — 따옴표나 탭이 든 것 — 에서 그 인용이 패턴을 깨뜨려 `"이상한 폴더/.env"`가 그냥 지나간다.
+
+`scripts/ownership-check.py`는 줄 단위로 읽는다. 그래서 꺼내는 자리가 개행이 든 경로를 아예 거절한다. 그러지 않으면 경로 하나가 조각으로 갈려 각 조각이 소유를 통과할 수 있다. `scripts/test-ownership.py`가 두 경우를 케이스로 잡아 둔다.
 
 셋 다 **fail closed**다. `config/ownership.json`을 읽을 수 없으면 어디서든 차단이다. 훅 둘은 worktree 이름이 역할 키가 아니거나 브랜치 접두가 가리키는 역할과 다를 때 막고, CI는 worktree가 없는 자리라 접두가 등록된 넷이 아니거나 그 값이 비었을 때 막는다.
 
@@ -126,7 +128,7 @@ secrets 차단은 별개 축이다. `.githooks/pre-commit`은 역할을 가리�
 
 - **PreToolUse 훅** `.claude/hooks/ownership-guard.sh`가 판정 module을 불러, 편집 시점에 역할 소유 밖 경로의 `Edit`·`Write`·`NotebookEdit`를 거절한다. 자기 worktree 밖의 절대 경로도 거절한다 — 다른 worktree도 포함이고, 임시 디렉터리와 `~/.claude`만 예외다.
 - **pre-commit 훅** `.githooks/pre-commit`이 스테이지된 변경의 소유를 검사한다 — 추가·수정·삭제와 rename 양쪽이다. 그리고 트리 어디에 있든 `.env*`와 `.envrc`를 막는다. 유일한 예외는 `.env.example`이다. 저장소를 클론하거나 리셋한 뒤에는 `git config core.hooksPath .githooks`를 한 번 돌려라.
-- **CI** `.github/workflows/ownership.yml`이 PR마다 같은 판정을 다시 돌린다. 역할은 브랜치 접두에서 오고 `--branch`가 그 값을 나른다. 판정 module과 registry는 PR이 아니라 base 커밋에서 꺼내 읽는다. 그러지 않으면 PR이 registry에 자기 줄을 넣어 스스로를 통과시킨다. 두 검사가 서로 다른 목록을 본다. 소유 검사는 base와 head를 견준 **최종 diff**만 본다 — 중간에 건드렸다가 되돌린 파일은 merge될 트리에 없으니 소유를 묻지 않는다. `.env` 계열 차단은 그 최종 diff에 **브랜치의 모든 커밋**과 **force-push로 떨어져 나간 이력**을 더해 훑는다. 넣었다 지운 키가 공개 저장소의 이력에 남기 때문이고, merge 커밋에서 얹은 파일은 커밋 목록에 나오지 않기 때문이다. 떨어져 나간 이력은 `synchronize` 이벤트가 나르는 갈아타기 전 head에서 온다 — 그 커밋을 가져오지 못하면 검사를 건너뛰지 않고 경고를 남긴다. 이 검사는 required status check라 빨간불이면 merge가 거부된다.
+- **CI** `.github/workflows/ownership.yml`이 PR마다 같은 판정을 다시 돌린다. 역할은 브랜치 접두에서 오고 `--branch`가 그 값을 나른다. 판정 module과 registry는 PR이 아니라 base 커밋에서 꺼내 읽는다. 그러지 않으면 PR이 registry에 자기 줄을 넣어 스스로를 통과시킨다. 두 검사가 서로 다른 목록을 본다. 소유 검사는 base와 head를 견준 **최종 diff**만 본다 — 중간에 건드렸다가 되돌린 파일은 merge될 트리에 없으니 소유를 묻지 않는다. `.env` 계열 차단은 그 최종 diff에 **브랜치의 모든 커밋**과 **force-push로 떨어져 나간 이력**을 더해 훑는다. 넣었다 지운 키가 공개 저장소의 이력에 남기 때문이고, merge 커밋에서 얹은 파일은 커밋 목록에 나오지 않기 때문이다. 떨어져 나간 이력은 `synchronize` 이벤트가 나르는 갈아타기 전 head에서 온다. 그 커밋을 가져오지 못하면 통과가 아니라 차단이다. 이 검사는 required status check라 빨간불이면 merge가 거부된다.
 
 CI는 마지막으로 돌린 검사 하나로 merge를 가른다. force-push 이력은 그것을 밀어낸 push의 검사가 잡으므로, 그 뒤에 또 force-push하면 앞 이력은 다시 훑지 않는다. 한 번 저장소에 닿은 키는 검사 결과와 무관하게 폐기하고 새로 발급해라.
 

--- a/docs/rules/common.md
+++ b/docs/rules/common.md
@@ -114,11 +114,11 @@ merge 소식은 뿌리지 않는다. 총괄은 그 merge가 특정 역할에게 
 
 ## 집행
 
-판정 module이 둘이다. `scripts/ownership-check.py`가 "역할 R이 경로 P를 쓸 수 있나"에 답하고, `scripts/secrets-check.py`가 "이 경로가 자격 증명 파일인가"에 답한다. 아래 셋이 그것들을 부른다.
+판정 module이 둘이다. `scripts/ownership-check.py`는 "역할 R이 경로 P를 쓸 수 있나"에 답한다. `scripts/secrets-check.py`는 "이 경로가 자격 증명 파일인가"에 답한다. 아래 셋이 그것들을 부른다.
 
 경로 목록은 `scripts/secrets-check.py`가 git의 NUL 구분 출력에서 꺼낸다. 줄 단위로 자르면 git이 이름을 인용해 내놓는 경로 — 따옴표나 탭이 든 것 — 에서 그 인용이 패턴을 깨뜨려 `"이상한 폴더/.env"`가 그냥 지나간다.
 
-`scripts/ownership-check.py`는 줄 단위로 읽는다. 그래서 꺼내는 자리가 개행이 든 경로를 아예 거절한다. 그러지 않으면 경로 하나가 조각으로 갈려 각 조각이 소유를 통과할 수 있다. `scripts/test-ownership.py`가 두 경우를 케이스로 잡아 둔다.
+`scripts/ownership-check.py`는 줄 단위로 읽는다. 그래서 꺼내는 자리가 줄바꿈으로 읽히는 문자가 든 경로를 아예 거절한다. 개행만이 아니라 수직 탭이나 다음 줄 문자도 파이썬은 줄 경계로 본다. 거절하지 않으면 경로 하나가 조각으로 갈려 각 조각이 소유를 통과한다. `scripts/test-ownership.py`가 두 경우를 케이스로 잡아 둔다.
 
 셋 다 **fail closed**다. `config/ownership.json`을 읽을 수 없으면 어디서든 차단이다. 훅 둘은 worktree 이름이 역할 키가 아니거나 브랜치 접두가 가리키는 역할과 다를 때 막고, CI는 worktree가 없는 자리라 접두가 등록된 넷이 아니거나 그 값이 비었을 때 막는다.
 

--- a/docs/rules/matchers/handling-secrets.md
+++ b/docs/rules/matchers/handling-secrets.md
@@ -2,7 +2,7 @@
 owner: "@orchestrator"
 status: "active"
 related_adr: ""
-related_issue: "#69, #101"
+related_issue: "#69, #101, #111, #112"
 ---
 
 # Matcher: 비밀 정보를 다룰 때
@@ -13,6 +13,8 @@ related_issue: "#69, #101"
 
 비밀 정보는 `.env`와 `.env.local`에만 산다. `.env.example`은 자리표시자를 담는다 — 키 이름과 형태일 뿐 동작하는 값은 아니다.
 
-`.githooks/pre-commit`이 트리 어디에 있든 `.env*`와 `.envrc`를 막는다. 유일한 예외는 `.env.example`이다.
+`.githooks/pre-commit`과 CI가 트리 어디에 있든 `.env*`와 `.envrc`를 막는다. 유일한 예외는 `.env.example`이다. 판정은 `scripts/secrets-check.py` 한 자리에 있다.
+
+한 번이라도 저장소에 닿은 키는 폐기하고 새로 발급해라. 저장소가 공개라 지운 커밋도 SHA로 읽힌다. 검사가 잡았다는 것은 merge를 막았다는 뜻이지 그 값이 안전해졌다는 뜻이 아니다.
 
 리뷰에서 diff 안의 비밀 정보는 `critical` 발견이고 merge는 멈춘다.

--- a/scripts/secrets-check.py
+++ b/scripts/secrets-check.py
@@ -25,6 +25,13 @@ def paths_from(records):
 
 
 def emit(paths):
+    newlined = [p for p in paths if "\n" in p or "\r" in p]
+    if newlined:
+        print("secrets-check: 경로에 개행이 든 파일은 이 저장소에서 다루지 않는다. 차단한다 — "
+              "아래 경로를 개행 없는 이름으로 바꿔라.", file=sys.stderr)
+        for path in newlined:
+            print(f"  {path!r}", file=sys.stderr)
+        return 1
     stream = sys.stdout.buffer
     for path in paths:
         stream.write(path.encode("utf-8", "surrogateescape") + b"\0")

--- a/scripts/secrets-check.py
+++ b/scripts/secrets-check.py
@@ -24,12 +24,17 @@ def paths_from(records):
     return collected
 
 
+def splits_into_lines(path):
+    return path.splitlines() != [path]
+
+
 def emit(paths):
-    newlined = [p for p in paths if "\n" in p or "\r" in p]
-    if newlined:
-        print("secrets-check: 경로에 개행이 든 파일은 이 저장소에서 다루지 않는다. 차단한다 — "
-              "아래 경로를 개행 없는 이름으로 바꿔라.", file=sys.stderr)
-        for path in newlined:
+    breaking = [p for p in paths if splits_into_lines(p)]
+    if breaking:
+        print("secrets-check: 줄바꿈으로 읽히는 문자가 든 경로는 이 저장소에서 다루지 않는다. 차단한다 — "
+              "소유 검사가 줄 단위로 읽어서 경로 하나가 조각으로 갈린다. 아래 경로의 이름을 바꿔라.",
+              file=sys.stderr)
+        for path in breaking:
             print(f"  {path!r}", file=sys.stderr)
         return 1
     stream = sys.stdout.buffer

--- a/scripts/secrets-check.py
+++ b/scripts/secrets-check.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import re
+import sys
+
+RENAME = re.compile(r"^[RC][0-9]*$")
+SECRET = re.compile(r"(?:^|/)(?:\.env(?:\..+)?|\.envrc)$")
+ALLOWED = re.compile(r"(?:^|/)\.env\.example$")
+
+
+def read_records():
+    chunks = sys.stdin.buffer.read().split(b"\0")
+    if chunks and chunks[-1] == b"":
+        chunks.pop()
+    return [chunk.decode("utf-8", "surrogateescape") for chunk in chunks]
+
+
+def paths_from(records):
+    collected = []
+    index = 0
+    while index < len(records):
+        wanted = 2 if RENAME.match(records[index]) else 1
+        collected.extend(records[index + 1:index + 1 + wanted])
+        index += 1 + wanted
+    return collected
+
+
+def emit(paths):
+    stream = sys.stdout.buffer
+    for path in paths:
+        stream.write(path.encode("utf-8", "surrogateescape") + b"\0")
+    return 0
+
+
+def scan(paths):
+    caught = [p for p in paths if SECRET.search(p) and not ALLOWED.search(p)]
+    if not caught:
+        return 0
+    print("secrets-check: .env·.envrc 파일은 트리 어디에도 커밋하지 않는다. 저장소가 공개라 지운 커밋도 남는다.", file=sys.stderr)
+    for path in caught:
+        print(f"  {path}", file=sys.stderr)
+    return 1
+
+
+def main():
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+    if mode not in ("paths", "scan"):
+        print("secrets-check: mode가 paths도 scan도 아니다. 차단한다.", file=sys.stderr)
+        return 1
+    records = read_records()
+    return emit(paths_from(records)) if mode == "paths" else scan(records)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-ownership.py
+++ b/scripts/test-ownership.py
@@ -243,7 +243,7 @@ def precommit_blocks_secrets_and_foreign_paths(main, worktrees):
     git(main, "add", "-A")
     check("pre-commit: rename 레코드 뒤에 붙은 .env도 막는다",
           run(["git", "commit", "-q", "-m", "t"], cwd=main).returncode, DENY_COMMIT)
-    discard(main, "docs/rename/.env")
+    discard(main, "docs/rename")
 
     stage_and_commit(main, {"docs/copy/src.md": "alpha\nbeta\ngamma\ndelta\n"})
     check("pre-commit: copy 레코드 뒤에 붙은 .env도 막는다",
@@ -252,7 +252,7 @@ def precommit_blocks_secrets_and_foreign_paths(main, worktrees):
               "docs/copy/dst.md": "alpha\nbeta\ngamma\ndelta\n",
               "docs/zzz/.env": "K=v\n",
           }), DENY_COMMIT)
-    discard(main, "docs/zzz")
+    discard(main, "docs/zzz", "docs/copy")
 
     git(worktrees["pm"], "checkout", "-q", "pm/t")
     stage_and_commit(worktrees["pm"], {"docs/specs/moved.md": "x\n"})

--- a/scripts/test-ownership.py
+++ b/scripts/test-ownership.py
@@ -226,6 +226,16 @@ def precommit_blocks_secrets_and_foreign_paths(main, worktrees):
           stage_and_commit(main, {"nl\nhere/a.md": "x\n"}), DENY_COMMIT)
     discard(main, "nl\nhere")
 
+    git(worktrees["pm"], "checkout", "-q", "pm/t")
+    check("pre-commit: 수직 탭이 든 경로도 조각나기 전에 거절한다",
+          stage_and_commit(worktrees["pm"], {"docs/prd.md\vdocs/specs/x.md": "x\n"}), DENY_COMMIT)
+    discard(worktrees["pm"], "docs/prd.md\vdocs/specs/x.md")
+
+    check("pre-commit: 다음 줄 문자가 든 경로도 거절한다",
+          stage_and_commit(worktrees["pm"], {"docs/prd.md\u0085docs/specs/y.md": "x\n"}), DENY_COMMIT)
+    discard(worktrees["pm"], "docs/prd.md\u0085docs/specs/y.md")
+    git(main, "checkout", "-q", "orch/t")
+
     stage_and_commit(main, {"docs/rename/before.md": "x\n"})
     git(main, "mv", "docs/rename/before.md", "docs/rename/after.md")
     with open(os.path.join(main, "docs/rename/.env"), "w") as f:

--- a/scripts/test-ownership.py
+++ b/scripts/test-ownership.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+DENY_HOOK = 2
+DENY_COMMIT = 1
+
+results = []
+
+
+def repo_root():
+    return subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def run(cmd, cwd=None, env=None, stdin=""):
+    merged = dict(os.environ)
+    if env:
+        merged.update(env)
+    return subprocess.run(
+        cmd, cwd=cwd, env=merged, input=stdin, capture_output=True, text=True
+    )
+
+
+def git(cwd, *args):
+    result = run(["git", *args], cwd=cwd)
+    if result.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} 실패: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def check(name, got, want):
+    results.append((got == want, name))
+    suffix = "" if got == want else f"  (exit {got}, 기대 {want})"
+    print(f"{'PASS' if got == want else 'FAIL'}  {name}{suffix}")
+
+
+def build_sandbox(source, root):
+    main = os.path.join(root, "main")
+    for relative in ("config/ownership.json", "scripts/ownership-check.py",
+                     "scripts/secrets-check.py", "githooks/pre-commit"):
+        target = os.path.join(main, relative)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        shutil.copy(os.path.join(source, relative.replace("githooks/", ".githooks/")), target)
+    os.chmod(os.path.join(main, "githooks", "pre-commit"), 0o755)
+
+    git(main, "init", "-q", "-b", "main")
+    git(main, "add", "-A")
+    git(main, "commit", "-q", "-m", "init")
+
+    worktrees = {}
+    for name in ("pm", "dev", "nonsense"):
+        path = os.path.join(root, name)
+        git(main, "worktree", "add", "-q", "--detach", path, "HEAD")
+        worktrees[name] = path
+
+    for path in (main, *worktrees.values()):
+        git(path, "config", "core.hooksPath", os.path.join(main, "githooks"))
+        git(path, "config", "user.email", "test@example.com")
+        git(path, "config", "user.name", "test")
+    return main, worktrees
+
+
+def module_of(project_dir):
+    common = run(["git", "-C", project_dir, "rev-parse", "--git-common-dir"]).stdout.strip()
+    if not os.path.isabs(common):
+        common = os.path.join(project_dir, common)
+    main = os.path.dirname(os.path.realpath(common))
+    return os.path.join(main, "scripts", "ownership-check.py")
+
+
+def judge_paths(project_dir, lines, branch=None):
+    args = ["python3", module_of(project_dir), "paths"]
+    if branch is not None:
+        args += ["--branch", branch]
+    return run(args, env={"PROJECT_DIR": project_dir}, stdin="\n".join(lines) + "\n").returncode
+
+
+def judge_hook(project_dir, file_path):
+    payload = json.dumps({"tool_input": {"file_path": file_path}}) if file_path else "{}"
+    args = ["python3", module_of(project_dir), "hook"]
+    return run(args, env={"PROJECT_DIR": project_dir}, stdin=payload).returncode
+
+
+def stage_and_commit(worktree, files):
+    for relative, body in files.items():
+        target = os.path.join(worktree, relative)
+        os.makedirs(os.path.dirname(target) or worktree, exist_ok=True)
+        with open(target, "w") as f:
+            f.write(body)
+    git(worktree, "add", "-A")
+    return run(["git", "commit", "-q", "-m", "t"], cwd=worktree).returncode
+
+
+def discard(worktree, *paths):
+    run(["git", "reset", "-q", "HEAD"], cwd=worktree)
+    run(["git", "checkout", "-q", "--", "."], cwd=worktree)
+    for path in paths:
+        full = os.path.join(worktree, path)
+        shutil.rmtree(full, ignore_errors=True)
+        if os.path.isfile(full):
+            os.remove(full)
+
+
+def role_comes_from_worktree(main, worktrees):
+    git(main, "checkout", "-q", "-b", "orch/t")
+    check("main 작업 트리는 총괄이라 모든 경로를 지난다",
+          judge_paths(main, ["docs/rules/a.md", "src/a.ts", "docs/ui/a.md"]), 0)
+
+    git(worktrees["pm"], "checkout", "-q", "-b", "pm/t")
+    check("pm worktree는 자기 소유 경로를 지난다",
+          judge_paths(worktrees["pm"], ["docs/specs/a.md"]), 0)
+    check("pm worktree는 dev 소유 경로에서 막힌다",
+          judge_paths(worktrees["pm"], ["src/a.ts"]), DENY_COMMIT)
+
+    git(worktrees["pm"], "checkout", "-q", "-b", "dev/t")
+    check("worktree 이름과 브랜치 접두가 어긋나면 막는다",
+          judge_paths(worktrees["pm"], ["docs/specs/a.md"]), DENY_COMMIT)
+
+    git(worktrees["pm"], "checkout", "-q", "--detach", "HEAD")
+    check("유휴 detached worktree는 디렉터리 이름 하나로 판정한다",
+          judge_paths(worktrees["pm"], ["docs/specs/a.md"]), 0)
+
+    git(worktrees["nonsense"], "checkout", "-q", "-b", "pm/t2")
+    check("등록되지 않은 이름의 worktree는 막는다",
+          judge_paths(worktrees["nonsense"], ["docs/specs/a.md"]), DENY_COMMIT)
+
+
+def role_comes_from_branch_prefix(main):
+    check("--branch dev/… 는 dev로 판정한다",
+          judge_paths(main, ["src/a.ts"], branch="dev/t"), 0)
+    check("--branch pm/… 에 dev 경로를 주면 막는다",
+          judge_paths(main, ["src/a.ts"], branch="pm/t"), DENY_COMMIT)
+    check("--branch orch/… 는 총괄이라 모두 지난다",
+          judge_paths(main, ["src/a.ts"], branch="orch/t"), 0)
+    check("등록되지 않은 접두는 막는다",
+          judge_paths(main, ["docs/rules/a.md"], branch="feat/t"), DENY_COMMIT)
+    check("--branch 값이 비면 막는다",
+          judge_paths(main, ["docs/rules/a.md"], branch=""), DENY_COMMIT)
+    check("접두가 아예 없는 이름은 막는다",
+          judge_paths(main, ["docs/rules/a.md"], branch="main"), DENY_COMMIT)
+
+
+def hook_guards_edit_time(worktrees):
+    pm, dev = worktrees["pm"], worktrees["dev"]
+    git(pm, "checkout", "-q", "pm/t")
+    check("훅: 자기 소유 경로는 지난다",
+          judge_hook(pm, os.path.join(pm, "docs/specs/a.md")), 0)
+    check("훅: 소유 밖 경로는 막는다",
+          judge_hook(pm, os.path.join(pm, "src/a.ts")), DENY_HOOK)
+    check("훅: 다른 worktree의 절대 경로는 막는다",
+          judge_hook(pm, os.path.join(dev, "src/a.ts")), DENY_HOOK)
+    check("훅: 임시 디렉터리는 예외다",
+          judge_hook(pm, "/tmp/scratch.md"), 0)
+    check("훅: ~/.claude는 예외다",
+          judge_hook(pm, os.path.join(os.path.expanduser("~"), ".claude", "x.md")), 0)
+    check("훅: file_path가 없는 payload는 지난다",
+          judge_hook(pm, None), 0)
+
+
+def registry_failure_closes(main, worktrees):
+    copies = [os.path.join(tree, "config", "ownership.json")
+              for tree in (main, worktrees["pm"])]
+    saved = {}
+    for path in copies:
+        with open(path) as f:
+            saved[path] = f.read()
+        with open(path, "w") as f:
+            f.write("{ not json")
+    check("registry를 읽을 수 없으면 통과가 아니라 차단이다",
+          judge_paths(main, ["docs/rules/a.md"], branch="orch/t"), DENY_COMMIT)
+    check("registry가 깨지면 훅도 막는다",
+          judge_hook(worktrees["pm"], os.path.join(worktrees["pm"], "docs/specs/a.md")), DENY_HOOK)
+    for path, body in saved.items():
+        with open(path, "w") as f:
+            f.write(body)
+
+
+def precommit_blocks_secrets_and_foreign_paths(main, worktrees):
+    pm = worktrees["pm"]
+    git(pm, "checkout", "-q", "pm/t")
+    check("pre-commit: 소유 경로는 커밋된다",
+          stage_and_commit(pm, {"docs/specs/a.md": "x\n"}), 0)
+    check("pre-commit: 소유 밖 경로는 막는다",
+          stage_and_commit(pm, {"src/a.ts": "x\n"}), DENY_COMMIT)
+    discard(pm, "src")
+
+    git(main, "checkout", "-q", "orch/t")
+    check("pre-commit: .env는 총괄도 막는다",
+          stage_and_commit(main, {".env": "K=v\n"}), DENY_COMMIT)
+    discard(main, ".env")
+
+    check("pre-commit: 트리 깊은 곳의 .env도 막는다",
+          stage_and_commit(main, {"docs/notes/.env.local": "K=v\n"}), DENY_COMMIT)
+    discard(main, "docs")
+
+    check("pre-commit: .env.example만 예외다",
+          stage_and_commit(main, {".env.example": "K=\n"}), 0)
+
+    check("pre-commit: 탭이 든 디렉터리 안의 .env도 막는다",
+          stage_and_commit(main, {"tab\there/.env": "K=v\n"}), DENY_COMMIT)
+    discard(main, "tab\there")
+
+    check("pre-commit: 따옴표가 든 디렉터리 안의 .env도 막는다",
+          stage_and_commit(main, {'quote"here/.env': "K=v\n"}), DENY_COMMIT)
+    discard(main, 'quote"here')
+
+    check("pre-commit: 한글 디렉터리 안의 .env도 막는다",
+          stage_and_commit(main, {"문서 폴더/.env": "K=v\n"}), DENY_COMMIT)
+    discard(main, "문서 폴더")
+
+    check("pre-commit: 한글 문서는 secrets에 걸리지 않는다",
+          stage_and_commit(main, {"docs/ui/화면.md": "x\n"}), 0)
+
+    with open(os.path.join(main, ".env"), "w") as f:
+        f.write("K=v\n")
+    git(main, "add", "-A")
+    run(["git", "commit", "-q", "--no-verify", "-m", "seed"], cwd=main)
+    os.remove(os.path.join(main, ".env"))
+    git(main, "add", "-A")
+    check("pre-commit: 이미 커밋된 .env를 지우는 커밋도 막는다 — --no-verify가 필요하다",
+          run(["git", "commit", "-q", "-m", "drop"], cwd=main).returncode, DENY_COMMIT)
+
+
+def main():
+    source = repo_root()
+    root = tempfile.mkdtemp(prefix=".ownership-test-", dir=os.path.expanduser("~"))
+    try:
+        sandbox, worktrees = build_sandbox(source, root)
+        role_comes_from_worktree(sandbox, worktrees)
+        role_comes_from_branch_prefix(sandbox)
+        hook_guards_edit_time(worktrees)
+        registry_failure_closes(sandbox, worktrees)
+        precommit_blocks_secrets_and_foreign_paths(sandbox, worktrees)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    failed = [name for ok, name in results if not ok]
+    print(f"\n{len(results) - len(failed)}/{len(results)} 통과")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-ownership.py
+++ b/scripts/test-ownership.py
@@ -245,6 +245,15 @@ def precommit_blocks_secrets_and_foreign_paths(main, worktrees):
           run(["git", "commit", "-q", "-m", "t"], cwd=main).returncode, DENY_COMMIT)
     discard(main, "docs/rename/.env")
 
+    stage_and_commit(main, {"docs/copy/src.md": "alpha\nbeta\ngamma\ndelta\n"})
+    check("pre-commit: copy 레코드 뒤에 붙은 .env도 막는다",
+          stage_and_commit(main, {
+              "docs/copy/src.md": "alpha\nbeta\ngamma\ndelta\nEXTRA\n",
+              "docs/copy/dst.md": "alpha\nbeta\ngamma\ndelta\n",
+              "docs/zzz/.env": "K=v\n",
+          }), DENY_COMMIT)
+    discard(main, "docs/zzz")
+
     git(worktrees["pm"], "checkout", "-q", "pm/t")
     stage_and_commit(worktrees["pm"], {"docs/specs/moved.md": "x\n"})
     os.makedirs(os.path.join(worktrees["pm"], "src"), exist_ok=True)

--- a/scripts/test-ownership.py
+++ b/scripts/test-ownership.py
@@ -51,6 +51,9 @@ def build_sandbox(source, root):
     os.chmod(os.path.join(main, "githooks", "pre-commit"), 0o755)
 
     git(main, "init", "-q", "-b", "main")
+    git(main, "config", "user.email", "test@example.com")
+    git(main, "config", "user.name", "test")
+    git(main, "config", "commit.gpgsign", "false")
     git(main, "add", "-A")
     git(main, "commit", "-q", "-m", "init")
 
@@ -64,6 +67,7 @@ def build_sandbox(source, root):
         git(path, "config", "core.hooksPath", os.path.join(main, "githooks"))
         git(path, "config", "user.email", "test@example.com")
         git(path, "config", "user.name", "test")
+        git(path, "config", "commit.gpgsign", "false")
     return main, worktrees
 
 
@@ -217,6 +221,27 @@ def precommit_blocks_secrets_and_foreign_paths(main, worktrees):
 
     check("pre-commit: 한글 문서는 secrets에 걸리지 않는다",
           stage_and_commit(main, {"docs/ui/화면.md": "x\n"}), 0)
+
+    check("pre-commit: 개행이 든 경로는 소유를 묻기 전에 거절한다",
+          stage_and_commit(main, {"nl\nhere/a.md": "x\n"}), DENY_COMMIT)
+    discard(main, "nl\nhere")
+
+    stage_and_commit(main, {"docs/rename/before.md": "x\n"})
+    git(main, "mv", "docs/rename/before.md", "docs/rename/after.md")
+    with open(os.path.join(main, "docs/rename/.env"), "w") as f:
+        f.write("K=v\n")
+    git(main, "add", "-A")
+    check("pre-commit: rename 레코드 뒤에 붙은 .env도 막는다",
+          run(["git", "commit", "-q", "-m", "t"], cwd=main).returncode, DENY_COMMIT)
+    discard(main, "docs/rename/.env")
+
+    git(worktrees["pm"], "checkout", "-q", "pm/t")
+    stage_and_commit(worktrees["pm"], {"docs/specs/moved.md": "x\n"})
+    os.makedirs(os.path.join(worktrees["pm"], "src"), exist_ok=True)
+    git(worktrees["pm"], "mv", "docs/specs/moved.md", "src/moved.ts")
+    check("pre-commit: 소유 밖으로 rename하면 막는다",
+          run(["git", "commit", "-q", "-m", "t"], cwd=worktrees["pm"]).returncode, DENY_COMMIT)
+    discard(worktrees["pm"], "src")
 
     with open(os.path.join(main, ".env"), "w") as f:
         f.write("K=v\n")


### PR DESCRIPTION
## 무엇이 바뀌었나

secrets 판정을 `scripts/secrets-check.py`로 빼고 pre-commit과 CI가 같이 부르게 했다. git의 NUL 구분 출력을 그대로 읽는다. 따옴표·탭이 든 경로가 인용된 채 패턴을 빠져나가던 구멍이 막히고, 줄바꿈으로 읽히는 문자가 든 경로는 소유를 묻기 전에 거절한다.

CI의 secrets 범위에 force-push로 떨어져 나간 이력을 더했다. `synchronize` 이벤트가 나르는 갈아타기 전 head에서 온다. 그 커밋을 가져오지 못하면 차단한다.

`scripts/test-ownership.py`가 가드 동작 서른여섯을 케이스로 고정하고 CI의 같은 job에서 돈다.

## Impact

- Domain: 없음
- Spec: 없음
- Arch: 판정 module이 둘이 됐다. secrets 축의 구조가 소유 축과 같다

## 관련 Issue

Closes #63
Closes #111
Closes #112

---

CI가 base 커밋에서 판정 module을 꺼내는데 `scripts/secrets-check.py`가 아직 base에 없어, 이번 PR만 head의 것을 쓰는 fallback이 돈다. merge되면 발동 조건이 사라지므로 바로 다음 PR에서 그 fallback을 걷어낸다. #113의 대상 경로에 `.github/workflows/ownership.yml`을 더해 뒀다.
