### PR TITLE
chore(config): README 경로를 registry에 넣는다

### DIFF
--- a/config/ownership.json
+++ b/config/ownership.json
@@ -1,6 +1,7 @@
 {
   "orchestrator": [
     "CLAUDE.md",
+    "README.md",
     ".gitignore",
     ".env.example",
     ".claude/",


### PR DESCRIPTION
## 무엇이 바뀌었나

`config/ownership.json`의 `orchestrator` 목록에 `README.md`를 넣었다. 지금까지 네 키 어디에도 없어서 소유 가드가 README 생성을 막았다. 이 PR은 경로만 연다 — 본문은 다음 작업이다.

## Impact

- Domain: 없음
- Spec: 없음
- Arch: 없음

## 관련 Issue

Closes #127
