### PR TITLE
chore(ci): front matter 검사를 CI에 세운다

### DIFF
--- a/.github/workflows/ownership.yml
+++ b/.github/workflows/ownership.yml
@@ -71,6 +71,14 @@ jobs:
         shell: bash
         run: python3 scripts/registry-check.py
 
+      - name: front matter 검사
+        shell: bash
+        run: python3 scripts/docs-check.py
+
       - name: 가드 하네스
         shell: bash
         run: python3 scripts/test-ownership.py
+
+      - name: front matter 하네스
+        shell: bash
+        run: python3 scripts/test-docs-check.py

--- a/docs/rules/common.md
+++ b/docs/rules/common.md
@@ -2,7 +2,7 @@
 owner: "@orchestrator"
 status: "active"
 related_adr: ""
-related_issue: "#69, #88, #91, #101, #105, #106, #114, #109, #63, #111, #112, #113"
+related_issue: "#69, #88, #91, #101, #105, #106, #114, #109, #63, #111, #112, #113, #126"
 ---
 
 # 공통 규칙
@@ -140,7 +140,9 @@ CI는 마지막으로 돌린 검사 하나로 merge를 가른다. force-push 이
 
 registry 둘의 대조는 CI에만 있다. `scripts/registry-check.py`가 `config/documents.json`의 모든 `path`를 `config/ownership.json`에 대서 소유 역할이 정확히 하나 나오는지 본다. 문서 종류를 새로 만들면서 소유를 정하지 않으면 여기서 걸린다. 같은 판정을 쓰려고 소유 module의 `owns()`를 그대로 불러 쓴다. 대조 규칙의 두 번째 사본을 만들지 않으려는 것이다.
 
-이 검사만 base가 아니라 PR의 트리를 읽는다. 묻는 것이 merge될 registry 둘의 정합이라 base를 읽으면 검사할 대상이 없다. 소유 검사의 base 고정은 PR이 registry에 자기 줄을 넣어 스스로를 통과시키는 것을 막는 장치인데, 이 대조는 통과를 주는 검사가 아니라 요구하는 검사라 그 위험이 없다.
+front matter 검사도 CI에만 있다. `scripts/docs-check.py`가 `docs/` 아래 모든 문서를 훑어 필드 넷이 다 있는지, `status`가 그 종류의 어휘에 드는지, `related_issue`와 `related_adr`이 규격대로인지 본다. 어느 어휘를 쓸지는 `config/documents.json`의 `adr`·`tdr` 항목이 가리키는 자리로 가른다. `scripts/test-docs-check.py`가 이 판정을 케이스 스물로 잡아 둔다. 규격 자체는 `docs/rules/matchers/writing-docs.md`가 갖는다.
+
+이 둘만 base가 아니라 PR의 트리를 읽는다. 묻는 것이 merge될 트리의 정합이라 base를 읽으면 검사할 대상이 없다. 소유 검사의 base 고정은 PR이 registry에 자기 줄을 넣어 스스로를 통과시키는 것을 막는 장치인데, 이 둘은 통과를 주는 검사가 아니라 요구하는 검사라 그 위험이 없다.
 
 CI가 잡지 못하는 축은 남는다. 명세 부합과 정확성은 기계의 몫이 아니다. 그 자리의 방어선은 독립 PR 리뷰다 — 리뷰어는 브랜치 접두와 바뀐 모든 경로의 소유를 매번 대조한다.
 

--- a/docs/rules/matchers/reviewing-a-pr.md
+++ b/docs/rules/matchers/reviewing-a-pr.md
@@ -2,7 +2,7 @@
 owner: "@orchestrator"
 status: "active"
 related_adr: ""
-related_issue: "#69, #89, #101, #114, #113, #91"
+related_issue: "#69, #89, #101, #114, #113, #91, #126"
 ---
 
 # Matcher: PR을 리뷰할 때
@@ -32,7 +32,7 @@ diff와 저장소 상태를 판단하지, 작성자가 그것에 대해 한 말�
 3. **명세 부합** (high) — 구현이 SPEC 파일과 Issue의 인수 조건과 맞는가, 명세가 요구하지 않은 동작을 덧붙이지 않았는가.
 4. **정확성** (high~critical) — 명백한 버그, 깨진 경계 사례, 타입·로직 오류. `main`을 깨뜨리면 critical이다.
 5. **테스트** (high) — 동작 변경에 테스트가 붙었는가, 기존 테스트를 이유 없이 약화시키지 않았는가.
-6. **관례** (normal) — 제목 형식, Issue 번호, Impact 줄, 문서 변경 시 갱신된 front matter.
+6. **관례** (normal) — 제목 형식, Issue 번호, Impact 줄, 문서 변경 시 갱신된 front matter. front matter의 형태는 CI의 `scripts/docs-check.py`가 이미 본다. 여기서 볼 것은 형태가 아니라 값이다 — 이 작업의 Issue 번호가 `related_issue`에 붙었는가, `status`가 실제 상태와 맞는가.
 7. **문체** (normal) — 새로 쓴 한국어 산문에 `docs/rules/matchers/writing-korean.md`가 세운 S1 대상 열여덟이 남았는가. PR 본문과 코멘트도 대상이다. `docs/rules/` 아래의 규칙 문서는 다음 세션이 본으로 삼는 글이라 더 엄하게 본다.
 
 6번과 7번은 기계로 옮기지 않는다. 그 둘의 절반을 CI로 내리자는 안이 #91에 있었는데, 세어 보니 남는 절반이 더 컸다. 제목 형식과 front matter는 정규식이 잡지만 Impact 줄이 실제로 무엇이 달라지는지 말하는가는 못 잡는다. 문체 항목은 인용문과 코드 블록 안에서도 똑같이 걸려 오탐이 merge를 막는다. 축을 반으로 갈라 절반만 CI에 두면 리뷰어는 나머지 절반을 보러 같은 파일을 다시 연다.

--- a/scripts/docs-check.py
+++ b/scripts/docs-check.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+
+FIELDS = ("owner", "status", "related_adr", "related_issue")
+DECISION_STATUSES = ("proposed", "accepted", "superseded")
+DOCUMENT_STATUSES = ("draft", "active", "superseded")
+
+RELATED_ISSUE = re.compile(r"^#\d+(, #\d+)*$")
+RELATED_ADR = re.compile(r"^(ADR|TDR)-\d+(, (ADR|TDR)-\d+)*$")
+FRONT_MATTER_LINE = re.compile(r'^([a-z_]+):\s*(?:"(.*)"|(.*))$')
+
+
+def load(name):
+    with open(os.path.join(ROOT, "config", name)) as f:
+        return json.load(f)
+
+
+def handle_for_role(role):
+    return "@orchestrator" if role == "orchestrator" else f"@agent-{role}"
+
+
+def decision_places(documents):
+    dirs = []
+    templates = []
+    for kind in ("adr", "tdr"):
+        entry = documents.get(kind)
+        if not entry:
+            continue
+        if entry.get("path"):
+            dirs.append(os.path.dirname(entry["path"]).rstrip("/") + "/")
+        if entry.get("template"):
+            templates.append(entry["template"])
+    return dirs, templates
+
+
+def markdown_files(docs_dir):
+    found = []
+    for current, _, names in os.walk(docs_dir):
+        for name in sorted(names):
+            if name.endswith(".md"):
+                found.append(os.path.join(current, name))
+    return sorted(found)
+
+
+def parse_front_matter(text):
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return None, "front matter가 없다. 첫 줄이 `---`여야 한다"
+
+    for index in range(1, len(lines)):
+        if lines[index].strip() == "---":
+            body = lines[1:index]
+            break
+    else:
+        return None, "front matter가 닫히지 않았다. 닫는 `---`가 없다"
+
+    fields = {}
+    for line in body:
+        if not line.strip():
+            continue
+        match = FRONT_MATTER_LINE.match(line)
+        if not match:
+            return None, f"front matter의 줄을 읽을 수 없다: {line.strip()}"
+        key, quoted, bare = match.groups()
+        fields[key] = quoted if quoted is not None else bare.strip()
+    return fields, None
+
+
+def check(path, decision, handles):
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+
+    fields, error = parse_front_matter(text)
+    if error:
+        return [error]
+
+    problems = []
+
+    missing = [field for field in FIELDS if field not in fields]
+    if missing:
+        problems.append(f"필드가 없다: {', '.join(missing)}")
+
+    unknown = [key for key in fields if key not in FIELDS]
+    if unknown:
+        problems.append(f"모르는 필드가 있다: {', '.join(sorted(unknown))}")
+
+    owner = fields.get("owner")
+    if owner is not None and owner not in handles:
+        problems.append(f"owner '{owner}'는 역할 이름이 아니다. 쓸 수 있는 것: {', '.join(handles)}")
+
+    status = fields.get("status")
+    allowed = DECISION_STATUSES if decision else DOCUMENT_STATUSES
+    if status is not None and status not in allowed:
+        kind = "결정 기록" if decision else "문서"
+        problems.append(f"status '{status}'는 {kind}의 어휘가 아니다. 쓸 수 있는 것: {', '.join(allowed)}")
+
+    related_issue = fields.get("related_issue")
+    if related_issue and not RELATED_ISSUE.match(related_issue):
+        problems.append(
+            f"related_issue '{related_issue}'의 형태가 아니다. `#42` 또는 `#42, #69`이고 없으면 빈 문자열이다"
+        )
+
+    related_adr = fields.get("related_adr")
+    if related_adr and not RELATED_ADR.match(related_adr):
+        problems.append(
+            f"related_adr '{related_adr}'의 형태가 아니다. `ADR-001` 또는 `TDR-001`이고 없으면 빈 문자열이다"
+        )
+
+    return problems
+
+
+def main():
+    try:
+        documents = load("documents.json")
+        ownership = load("ownership.json")
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"docs-check: registry를 읽을 수 없다 ({e}). 통과가 아니라 차단이다.", file=sys.stderr)
+        return 1
+
+    handles = [handle_for_role(role) for role in ownership]
+    dirs, templates = decision_places(documents)
+    docs_dir = os.path.join(ROOT, "docs")
+
+    if not os.path.isdir(docs_dir):
+        return 0
+
+    failures = []
+    for path in markdown_files(docs_dir):
+        rel = os.path.relpath(path, ROOT)
+        decision = rel in templates or any(rel.startswith(d) for d in dirs)
+        try:
+            problems = check(path, decision, handles)
+        except OSError as e:
+            failures.append((rel, [f"파일을 읽을 수 없다 ({e})"]))
+            continue
+        if problems:
+            failures.append((rel, problems))
+
+    if not failures:
+        return 0
+
+    print(
+        "docs-check: front matter가 규격과 어긋난다. 규격은 "
+        "docs/rules/matchers/writing-docs.md의 front matter 절에 있다.",
+        file=sys.stderr,
+    )
+    for rel, problems in failures:
+        print(f"  {rel}", file=sys.stderr)
+        for problem in problems:
+            print(f"    {problem}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-docs-check.py
+++ b/scripts/test-docs-check.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+results = []
+
+VALID = """---
+owner: "@agent-pm"
+status: "active"
+related_adr: ""
+related_issue: "#42"
+---
+
+# 문서
+"""
+
+
+def repo_root():
+    return subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def check(name, got, want):
+    results.append((got == want, name))
+    suffix = "" if got == want else f"  (exit {got}, 기대 {want})"
+    print(f"{'PASS' if got == want else 'FAIL'}  {name}{suffix}")
+
+
+def build_sandbox(source, root):
+    for relative in ("config/ownership.json", "config/documents.json",
+                     "scripts/docs-check.py"):
+        target = os.path.join(root, relative)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        shutil.copy(os.path.join(source, relative), target)
+    os.makedirs(os.path.join(root, "docs"), exist_ok=True)
+
+
+def write(root, relative, text):
+    target = os.path.join(root, relative)
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+    with open(target, "w", encoding="utf-8") as f:
+        f.write(text)
+    return target
+
+
+def run_check(root):
+    return subprocess.run(
+        [sys.executable, os.path.join(root, "scripts", "docs-check.py")],
+        capture_output=True, text=True,
+    ).returncode
+
+
+def case(root, name, relative, text, want):
+    target = write(root, relative, text)
+    try:
+        check(name, run_check(root), want)
+    finally:
+        os.remove(target)
+
+
+def decision_path(root, kind):
+    with open(os.path.join(root, "config", "documents.json")) as f:
+        documents = json.load(f)
+    directory = os.path.dirname(documents[kind]["path"])
+    return os.path.join(directory, f"{kind.upper()}-001-test.md")
+
+
+def main():
+    source = repo_root()
+    with tempfile.TemporaryDirectory() as root:
+        build_sandbox(source, root)
+
+        check("빈 docs 트리는 통과한다", run_check(root), 0)
+
+        case(root, "필드 넷을 갖춘 문서는 통과한다",
+             "docs/ok.md", VALID, 0)
+
+        case(root, "front matter가 없으면 막는다",
+             "docs/bare.md", "# 제목만 있다\n", 1)
+
+        case(root, "front matter가 닫히지 않으면 막는다",
+             "docs/unclosed.md", '---\nowner: "@agent-pm"\n\n# 본문\n', 1)
+
+        case(root, "필드가 빠지면 막는다",
+             "docs/missing.md",
+             '---\nowner: "@agent-pm"\nstatus: "active"\nrelated_adr: ""\n---\n', 1)
+
+        case(root, "모르는 필드가 있으면 막는다",
+             "docs/extra.md", VALID.replace('related_issue: "#42"',
+                                            'related_issue: "#42"\nupdated: "2026-08-24"'), 1)
+
+        case(root, "owner가 역할 이름이 아니면 막는다",
+             "docs/owner.md", VALID.replace('"@agent-pm"', '"@agent-qa"'), 1)
+
+        case(root, "총괄 handle은 통과한다",
+             "docs/orch.md", VALID.replace('"@agent-pm"', '"@orchestrator"'), 0)
+
+        case(root, "문서에 결정 기록 어휘를 쓰면 막는다",
+             "docs/status.md", VALID.replace('"active"', '"accepted"'), 1)
+
+        case(root, "모르는 status는 막는다",
+             "docs/unknown-status.md", VALID.replace('"active"', '"done"'), 1)
+
+        case(root, "결정 기록은 accepted를 받는다",
+             decision_path(root, "adr"), VALID.replace('"active"', '"accepted"'), 0)
+
+        case(root, "결정 기록에 문서 어휘를 쓰면 막는다",
+             decision_path(root, "adr"), VALID, 1)
+
+        case(root, "TDR도 결정 기록 어휘를 받는다",
+             decision_path(root, "tdr"), VALID.replace('"active"', '"proposed"'), 0)
+
+        case(root, "related_issue가 빈 문자열이면 통과한다",
+             "docs/no-issue.md", VALID.replace('"#42"', '""'), 0)
+
+        case(root, "related_issue 여럿은 쉼표로 나열한다",
+             "docs/many-issues.md", VALID.replace('"#42"', '"#42, #69"'), 0)
+
+        case(root, "related_issue에 번호가 아닌 값이 들면 막는다",
+             "docs/bad-issue.md", VALID.replace('"#42"', '"42"'), 1)
+
+        case(root, "related_issue의 구분자가 다르면 막는다",
+             "docs/bad-separator.md", VALID.replace('"#42"', '"#42 #69"'), 1)
+
+        case(root, "related_adr은 ADR-00N 형태를 받는다",
+             "docs/adr-ref.md", VALID.replace('related_adr: ""', 'related_adr: "ADR-001"'), 0)
+
+        case(root, "related_adr에 아무 문자열이나 들면 막는다",
+             "docs/bad-adr.md", VALID.replace('related_adr: ""', 'related_adr: "결제 결정"'), 1)
+
+        case(root, "하위 디렉터리도 훑는다",
+             "docs/deep/nested/thing.md", "# front matter가 없다\n", 1)
+
+    failed = [name for ok, name in results if not ok]
+    print()
+    if failed:
+        print(f"{len(results) - len(failed)}/{len(results)} 통과, {len(failed)}건 실패")
+        return 1
+    print(f"{len(results)}/{len(results)} 통과")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 무엇이 바뀌었나

`scripts/docs-check.py`가 `docs/` 아래 문서의 front matter를 검사한다 — 필드 넷, 종류별 `status` 어휘, `related_issue`와 `related_adr`의 형태다. 결정 기록인지는 `config/documents.json`의 `adr`·`tdr` 항목이 가리키는 자리로 가르므로 경로를 두 번 적지 않는다. `scripts/test-docs-check.py`가 케이스 스물로 판정을 잡고, 워크플로에 걸음 둘이 붙었다.

리뷰의 관례 축에서 형태 검사를 걷어 값 검사만 남겼다. 같은 것을 사람이 두 번 보지 않게 한다.

## Impact

- Domain: 없음
- Spec: 없음
- Arch: 없음

## 관련 Issue

Closes #126
