### PR TITLE
feat: zustand와 TanStack Query를 들인다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 ## 스택과 명령어
 
-Next.js 16(App Router, TypeScript) + Tailwind CSS 4 + shadcn/ui(`@base-ui/react` 기반), 테스트는 vitest와 Playwright다. Node 22, 패키지 매니저는 pnpm 8.15.2 — 정확한 버전은 `package.json`이 정본이다.
+Next.js 16(App Router, TypeScript) + Tailwind CSS 4 + shadcn/ui(`@base-ui/react` 기반), 클라이언트 상태는 zustand, 서버 상태는 TanStack Query(`app/providers.tsx`에 provider가 있다), 테스트는 vitest와 Playwright다. Node 22, 패키지 매니저는 pnpm 8.15.2 — 정확한 버전은 `package.json`이 정본이다.
 
 - `pnpm dev` — 개발 서버
 - `pnpm build` — 프로덕션 빌드

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Providers } from "./providers";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -23,7 +24,9 @@ export default function RootLayout({ children }: LayoutProps<"/">) {
       lang="ko"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col">
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",
+    "@tanstack/react-query": "^5.102.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.34.0",
@@ -20,7 +21,8 @@
     "react-dom": "19.2.8",
     "shadcn": "^4.19.0",
     "tailwind-merge": "^3.6.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zustand": "^5.0.15"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@base-ui/react':
     specifier: ^1.7.0
     version: 1.7.0(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
+  '@tanstack/react-query':
+    specifier: ^5.102.3
+    version: 5.102.3(react@19.2.8)
   class-variance-authority:
     specifier: ^0.7.1
     version: 0.7.1
@@ -35,6 +38,9 @@ dependencies:
   tw-animate-css:
     specifier: ^1.4.0
     version: 1.4.0
+  zustand:
+    specifier: ^5.0.15
+    version: 5.0.15(@types/react@19.2.18)(react@19.2.8)
 
 devDependencies:
   '@playwright/test':
@@ -1366,6 +1372,19 @@ packages:
       postcss: 8.5.26
       tailwindcss: 4.3.3
     dev: true
+
+  /@tanstack/query-core@5.102.3:
+    resolution: {integrity: sha512-5O2VEceonqC4uaTLUGglb0hgPouWCJ4K1ykVWyeV8aThhdNCzwpwu01bYoaRNJ9mgFUXS7Kf9utJ46ysT8m+bw==}
+    dev: false
+
+  /@tanstack/react-query@5.102.3(react@19.2.8):
+    resolution: {integrity: sha512-nHazxUEUQSGJOswGgSL2DI77f2K75WRCowDgaiyEi0ACocZTFKewTv+A/rJfq6QkuE35rVPff1QUT3ClbaePGQ==}
+    peerDependencies:
+      react: ^18 || ^19
+    dependencies:
+      '@tanstack/query-core': 5.102.3
+      react: 19.2.8
+    dev: false
 
   /@ts-morph/common@0.27.0:
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
@@ -5923,3 +5942,25 @@ packages:
   /zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
     dev: true
+
+  /zustand@5.0.15(@types/react@19.2.18)(react@19.2.8):
+    resolution: {integrity: sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+    dependencies:
+      '@types/react': 19.2.18
+      react: 19.2.8
+    dev: false


### PR DESCRIPTION
## 무엇을

- zustand, @tanstack/react-query 설치
- app/providers.tsx — QueryClientProvider를 클라이언트 컴포넌트로 만들고 layout에서 감싼다
- CLAUDE.md 스택 절에 두 라이브러리를 적는다 (클라이언트 상태 zustand, 서버 상태 TanStack Query)

로컬 lint·test·build 통과 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)