### PR TITLE
chore: test-planner를 sonnet으로 내린다

### DIFF
--- a/.claude/agents/test-planner.md
+++ b/.claude/agents/test-planner.md
@@ -1,7 +1,7 @@
 ---
 name: test-planner
 description: 완료 조건을 받아 검증할 리스크와 테스트 층을 정하는 계획자. 테스트를 쓰지 않고 구현도 하지 않는다. test writer를 스폰하기 전에 부른다.
-model: opus
+model: sonnet
 tools: Read, Grep, Glob
 ---
 


### PR DESCRIPTION
## 무엇

`test-planner`의 모델을 opus에서 sonnet으로 내린다.

## 왜

planner는 task마다 한 번 돌고 코드를 쓰지 않아 출력이 짧다. 층 배정과 중복 판정에 판단이 들어가긴 하지만 opus를 쓸 만큼 무겁지는 않다.

writer 둘이 sonnet이니 계층도 맞는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)