### PR TITLE
feat: 구현자에게 integration 검증을 요구한다

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -14,7 +14,7 @@ task 하나를 끝까지 만든다. 격리된 worktree에서 일하고 결과는
 
 ## 받은 테스트를 통과시킨다
 
-이 저장소는 TDD로 간다. 테스트는 `unit-test-writer`와 `e2e-test-writer`가 이미 썼고 실패를 확인해뒀다. 네 일은 그 빨간불을 초록불로 바꾸는 것이다.
+이 저장소는 TDD로 간다. 테스트는 `unit-test-writer`와 `integration-test-writer`와 `e2e-test-writer`가 이미 썼고 실패를 확인해뒀다. 네 일은 그 빨간불을 초록불로 바꾸는 것이다.
 
 1. 받은 테스트를 읽고 무엇을 요구하는지 파악한다.
 2. 돌려서 실패를 다시 확인한다. 이미 통과하고 있으면 그 리스크는 지켜지는 중이니 구현하지 말고 리턴에 적는다.
@@ -97,7 +97,9 @@ TDD 규율은 이 순서 밖이다. 어느 항목과도 흥정하지 않는다.
 
 ## 끝내기 전에
 
-`pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`, `pnpm e2e`를 실제로 돌려 통과를 확인한다. 통과하지 못한 채로 PR을 열지 않는다. 통과가 불가능한 사정이 있으면 PR을 열지 말고 리턴으로 보고한다.
+`pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm test:integration`, `pnpm build`, `pnpm e2e`를 실제로 돌려 통과를 확인한다. 통과하지 못한 채로 PR을 열지 않는다. 통과가 불가능한 사정이 있으면 PR을 열지 말고 리턴으로 보고한다.
+
+`pnpm test:integration`은 로컬 Supabase가 떠 있어야 돈다. `supabase status`로 확인하고 안 떠 있으면 `supabase start`로 띄운다. Docker가 없어서 못 돌린 채로 PR을 열지 않는다 — 그 사실을 리턴에 적고 멈춘다. `pnpm test`는 unit만 집으므로 그것만 초록불인 것은 확인이 아니다.
 
 커밋 메시지는 한국어 `feat:`·`fix:`·`refactor:`·`chore:` 형식으로 쓰고 끝에 다음 줄을 붙인다.
 


### PR DESCRIPTION
## 무엇

`.claude/agents/implementer.md`의 검증 명령에 `pnpm test:integration`을 더한다.

## 왜

ADR-003의 "남는 위험"에 이미 적어둔 사안인데 정의문을 안 고쳤다. `test-planner`가 이 task를 계획하다 짚어 올렸다.

> `pnpm test`가 unit만 돌아 로컬은 초록불인데 CI가 빨간불일 수 있다. `implementer` 정의문의 검증 명령에 `pnpm test:integration`을 넣어야 막힌다.

이게 없으면 구현자가 로컬에서 integration을 안 돌리고 PR을 연다. 그러면 완료 조건의 "CI의 integration 단계가 돈다"가 CI에서야 처음 드러나고, 빨간불을 보고 나서 고치는 왕복이 생긴다.

## 같이 넣은 것

**로컬 Supabase 전제를 적었다.** `supabase status`로 확인하고 안 떠 있으면 `supabase start`로 띄운다. Docker가 없어서 못 돌린 채로 PR을 열지 않고 리턴에 적고 멈춘다.

**`pnpm test`만 초록불인 것은 확인이 아니라고 못박았다.** unit만 집는 러너라 그것만 보고 넘어가면 이 조항을 넣은 이유가 사라진다.

**writer 목록에 `integration-test-writer`를 더했다.** #181에서 생겼는데 구현자는 아직 writer가 둘이라고 알고 있었다.

## 지금 못 도는 것

`pnpm test:integration` 스크립트는 아직 없다. `plan.md`의 Supabase task가 만든다. 그 task를 맡는 구현자는 스크립트를 만든 뒤에 그것으로 자기 작업을 검증하게 된다.

## 확인

에이전트 정의문만 바뀌었다. `src/` 변경이 없으니 TDD 훅도 걸리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)