### PR TITLE
훅 둘이 각자 쓰던 payload 해독을 guard 모듈로 뺀다

### DIFF
--- a/.claude/hooks/guard.py
+++ b/.claude/hooks/guard.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+
+ROOT = os.path.abspath(os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
+
+CONTENT_KEYS = ("content", "new_string")
+
+
+def exists(relative_path):
+    return os.path.exists(os.path.join(ROOT, relative_path))
+
+
+def _payload():
+    try:
+        return json.load(sys.stdin)
+    except Exception:
+        return None
+
+
+def _relative_path(raw_path):
+    try:
+        return os.path.relpath(os.path.abspath(raw_path), ROOT)
+    except ValueError:
+        return None
+
+
+def _content(tool_input, relative_path):
+    incoming = "\n".join(str(tool_input.get(key, "")) for key in CONTENT_KEYS)
+    if relative_path.startswith(".."):
+        return incoming
+    try:
+        with open(
+            os.path.join(ROOT, relative_path), encoding="utf-8", errors="ignore"
+        ) as handle:
+            return handle.read()
+    except OSError:
+        return incoming
+
+
+def guard(verdict):
+    """verdict(relative_path, content) -> 막는 이유 문자열 또는 None"""
+    payload = _payload()
+    if payload is None:
+        sys.exit(0)
+
+    tool_input = payload.get("tool_input") or {}
+    raw_path = tool_input.get("file_path")
+    if not raw_path:
+        sys.exit(0)
+
+    relative_path = _relative_path(raw_path)
+    if relative_path is None:
+        sys.exit(0)
+
+    reason = verdict(relative_path, _content(tool_input, relative_path))
+    if not reason:
+        sys.exit(0)
+
+    sys.stderr.write(reason)
+    sys.exit(2)

--- a/.claude/hooks/tdd-guard-e2e.py
+++ b/.claude/hooks/tdd-guard-e2e.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-import json
 import os
-import sys
+
+from guard import exists, guard
 
 ROUTE_FILES = ("page.tsx", "layout.tsx", "route.ts")
 
@@ -25,36 +25,19 @@ def spec_name(path):
     return None
 
 
-def main():
-    try:
-        payload = json.load(sys.stdin)
-    except Exception:
-        sys.exit(0)
-
-    tool_input = payload.get("tool_input") or {}
-    raw_path = tool_input.get("file_path")
-    if not raw_path:
-        sys.exit(0)
-
-    root = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
-    try:
-        path = os.path.relpath(os.path.abspath(raw_path), os.path.abspath(root))
-    except ValueError:
-        sys.exit(0)
-
+def verdict(path, _content):
     name = spec_name(path)
     if not name:
-        sys.exit(0)
+        return None
 
     expected = f"tests/e2e/{name}.spec.ts"
-    if os.path.exists(os.path.join(root, expected)):
-        sys.exit(0)
+    if exists(expected):
+        return None
 
-    sys.stderr.write(
+    return (
         f"TDD 차단: {path} 는 화면인데 e2e 테스트가 없다.\n"
         f"{expected} 를 먼저 쓰고, 그 테스트가 실패하는 것을 확인한 뒤 구현해라.\n"
     )
-    sys.exit(2)
 
 
-main()
+guard(verdict)

--- a/.claude/hooks/tdd-guard-unit.py
+++ b/.claude/hooks/tdd-guard-unit.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-import json
 import os
 import re
-import sys
+
+from guard import exists, guard
 
 EXECUTABLE_EXPORT = re.compile(
     r"^\s*export\s+(default\s+)?(async\s+)?(function|class)\b"
@@ -16,64 +16,33 @@ SKIP_PREFIXES = ("src/app/", "src/shared/ui/")
 PAIR_SUFFIXES = (".test.ts", ".integration.test.ts")
 
 
-def incoming_text(tool_input):
-    return "\n".join(
-        str(tool_input.get(key, ""))
-        for key in ("content", "new_string")
-    )
-
-
-def main():
-    try:
-        payload = json.load(sys.stdin)
-    except Exception:
-        sys.exit(0)
-
-    tool_input = payload.get("tool_input") or {}
-    raw_path = tool_input.get("file_path")
-    if not raw_path:
-        sys.exit(0)
-
-    root = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
-    try:
-        path = os.path.relpath(os.path.abspath(raw_path), os.path.abspath(root))
-    except ValueError:
-        sys.exit(0)
-
+def verdict(path, content):
     if not path.startswith("src/") or not path.endswith(".ts"):
-        sys.exit(0)
+        return None
     if path.endswith(".d.ts") or path.endswith(".test.ts") or "/__tests__/" in path:
-        sys.exit(0)
+        return None
     if path.startswith(SKIP_PREFIXES):
-        sys.exit(0)
+        return None
 
-    absolute = os.path.join(root, path)
-    if os.path.exists(absolute):
-        with open(absolute, encoding="utf-8", errors="ignore") as handle:
-            body = handle.read()
-    else:
-        body = incoming_text(tool_input)
-
-    if not EXECUTABLE_EXPORT.search(body):
-        sys.exit(0)
+    if not EXECUTABLE_EXPORT.search(content):
+        return None
 
     directory, filename = os.path.split(path)
     candidates = [
         os.path.join(directory, "__tests__", filename[:-3] + suffix)
         for suffix in PAIR_SUFFIXES
     ]
-    if any(os.path.exists(os.path.join(root, candidate)) for candidate in candidates):
-        sys.exit(0)
+    if any(exists(candidate) for candidate in candidates):
+        return None
 
     listed = "".join(f"  {candidate}\n" for candidate in candidates)
-    sys.stderr.write(
+    return (
         f"TDD 차단: {path} 는 실행 코드를 내보내는데 테스트가 없다.\n"
         "아래 둘 중 하나를 먼저 쓰고, 그 테스트가 실패하는 것을 확인한 뒤 구현해라.\n"
         f"{listed}"
         "DB에 붙는 코드는 integration 쪽이다.\n"
         "타입이나 상수만 담을 파일이면 실행 코드를 빼라.\n"
     )
-    sys.exit(2)
 
 
-main()
+guard(verdict)

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ blob-report/
 playwright/.cache/
 next-env.d.ts
 *.tsbuildinfo
+__pycache__/


### PR DESCRIPTION
## 왜 뺐나

`tdd-guard-unit.py`와 `tdd-guard-e2e.py`는 stdin에서 JSON을 읽고, `tool_input.file_path`를 꺼내고, `CLAUDE_PROJECT_DIR`나 cwd로 루트를 정하고, 절대 경로를 저장소 기준으로 바꾸고, 위반이면 stderr에 쓰고 2로 죽는 다섯 층을 각자 다시 썼다. 서로 다른 건 가운데 판정 한 덩어리뿐이었다. 세 번째 훅을 붙이는 날 이 다섯 층이 세 번째로 복사된다.

## 왜 이 interface인가

`guard(verdict)` 하나만 노출한다. verdict는 저장소 기준 상대 경로와 파일 본문을 받고, 막을 이유 문자열이나 `None`을 돌려준다. 훅은 마지막 줄에서 `guard(verdict)`를 부르고 끝난다.

이렇게 자른 이유는 셋이다.

프로세스 경계를 옮기지 않으려 했다. 훅의 실제 계약은 exit code고, 테스트도 `spawnSync`로 그것만 본다. verdict가 exit를 직접 부르면 판정 로직이 프로세스 종료 규약에 묶인다. 문자열이냐 `None`이냐로 돌려받으면 판정은 순수 함수가 되고, 죽는 방식은 guard 혼자 안다.

루트 경로를 verdict 시야에서 지웠다. 두 훅 다 짝 파일 존재 확인이 필요한데, 그때마다 `os.path.join(root, ...)`를 쓰면 root가 판정 로직에 새어든다. `guard.exists("tests/e2e/home.spec.ts")`로 감싸니 verdict는 저장소 상대 경로 하나로만 말한다. root 해석은 guard 안에 갇힌다.

`content`는 e2e 훅이 안 쓰지만 시그니처에 남겼다. unit 훅의 본문 결정 규칙(디스크에 파일이 있으면 그걸 읽고, 없으면 payload의 `content`와 `new_string`을 잇는다)이 payload 해독의 일부라 공통 층에 속한다. 안 쓰는 훅은 `_content`로 받고 무시한다.

## 조건은 한 줄도 안 바뀌었다

제외 경로(`src/app/`, `src/shared/ui/`, `.d.ts`, `.test.ts`, `__tests__/`), 실행 코드 판별 정규식, `dals` 경로에서 integration 짝만 있어도 통과시키는 규칙, 루트 화면이 `home.spec.ts`로 짝을 찾는 규칙 전부 그대로다. `.claude/hooks/__tests__/tdd-guard.test.ts`는 한 글자도 안 건드렸고 15개 케이스가 그대로 통과한다.

`_content`에 한 줄 추가한 건 있다. 상대 경로가 `..`로 시작하면 디스크를 읽지 않고 payload 텍스트를 쓴다. 저장소 밖 파일을 열지 않으려는 방어고, 판정 결과는 바뀌지 않는다. 어차피 `src/`로 시작하지 않는 경로는 unit 훅이 곧바로 통과시킨다.

## import 경로를 확인했다

`.claude/settings.json`이 훅을 `python3 "<절대경로>"`로 부른다. python은 스크립트가 있는 디렉터리를 `sys.path[0]`에 넣으므로 `from guard import exists, guard`가 cwd와 무관하게 붙는다. `/tmp`에서 절대 경로로 훅을 직접 실행해 확인했다. `settings.json`은 손대지 않았다.

바이트코드 캐시가 `.claude/hooks/__pycache__/`에 생겨 `.gitignore`에 한 줄 더했다.

## 훅이 살아 있는지 손으로 확인했다

이 worktree에서 Write 도구로 직접 찔러봤다.

- 짝 테스트 없는 `src/entities/probe/models/probe.ts` — unit 훅이 막았고, 후보 경로 둘을 안내하는 메시지까지 그대로 나왔다
- 짝 테스트 `src/entities/probe/models/__tests__/probe.test.ts` — 통과
- 그 짝이 생긴 뒤 같은 `probe.ts` — 통과
- spec 없는 `src/screens/probe/ui/ProbeScreen.tsx` — e2e 훅이 막고 `tests/e2e/probe.spec.ts`를 요구했다
- `tests/e2e/probe.spec.ts`를 만든 뒤 같은 화면 파일 — 통과

찔러본 파일은 전부 지웠다.

## 검증

`pnpm lint`, `pnpm format:check` 통과. `pnpm test`는 113개 전부 통과한다.

기본 5초 timeout으로 돌리면 `tests/lint/` 파일마다 첫 케이스가 timeout으로 죽는데, 이건 이 브랜치가 만든 게 아니다. 원본 훅으로 되돌린 상태에서 같은 명령을 돌려도 12건이 죽었다(이 브랜치는 7건). 실행할 때마다 개수가 흔들리고 `--testTimeout=60000`을 주면 양쪽 다 전부 통과한다. ESLint 인스턴스를 처음 띄우는 비용이 5초를 넘기는 문제로 보이고, worktree 넷이 동시에 도는 지금 상황이 CPU를 갉아먹는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011amZJzkPpgG4rjrPM5fSCc
