### PR TITLE
class-strings를 자기 interface에서 테스트한다

### DIFF
--- a/eslint-rules/__tests__/class-strings.test.ts
+++ b/eslint-rules/__tests__/class-strings.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  arbitraryValueOf,
+  classStringVisitor,
+  utilityOf,
+} from "../class-strings.mjs";
+
+type CollectedToken = { token: string; nodeType: string };
+
+function literal(value: unknown) {
+  return { type: "Literal", value };
+}
+
+function identifier(name: string) {
+  return { type: "Identifier", name };
+}
+
+function templateElement(cooked: string) {
+  return { type: "TemplateElement", value: { cooked, raw: cooked } };
+}
+
+function attribute(name: unknown, value: unknown) {
+  return { type: "JSXAttribute", name, value };
+}
+
+function jsxIdentifier(name: string) {
+  return { type: "JSXIdentifier", name };
+}
+
+function callOf(callee: unknown, args: unknown[]) {
+  return { type: "CallExpression", callee, arguments: args };
+}
+
+function objectOf(properties: unknown[]) {
+  return { type: "ObjectExpression", properties };
+}
+
+function property(key: unknown, value: unknown) {
+  return { type: "Property", key, value };
+}
+
+function collector(collected: CollectedToken[]) {
+  return (token: string, node: { type: string }) => {
+    collected.push({ token, nodeType: node.type });
+  };
+}
+
+function visitAttribute(node: unknown): CollectedToken[] {
+  const collected: CollectedToken[] = [];
+  classStringVisitor(collector(collected)).JSXAttribute(node);
+  return collected;
+}
+
+function visitCall(node: unknown): CollectedToken[] {
+  const collected: CollectedToken[] = [];
+  classStringVisitor(collector(collected)).CallExpression(node);
+  return collected;
+}
+
+function tokensOf(collected: CollectedToken[]) {
+  return collected.map((entry) => entry.token);
+}
+
+describe("utilityOf — 변형 접두사를 벗기고 마지막 유틸리티만 남긴다", () => {
+  it.each([
+    { token: "flex", utility: "flex" },
+    { token: "-mt-2", utility: "-mt-2" },
+    { token: "hover:focus:bg-primary", utility: "bg-primary" },
+    {
+      token: "in-data-[slot=button-group]:rounded-lg",
+      utility: "rounded-lg",
+    },
+    { token: "supports-[display:grid]:grid", utility: "grid" },
+    { token: "[&_svg:not([class*='size-'])]:size-4", utility: "size-4" },
+    { token: "*:[img:first-child]:rounded-t-xl", utility: "rounded-t-xl" },
+    {
+      token: "md:hover:[&>*]:text-[color:var(--fg)]",
+      utility: "text-[color:var(--fg)]",
+    },
+    {
+      token: "hover:bg-(color:--brand)",
+      utility: "bg-(color:--brand)",
+    },
+  ])("$token 은 $utility 를 남긴다", ({ token, utility }) => {
+    expect(utilityOf(token)).toBe(utility);
+  });
+});
+
+describe("utilityOf — 경계에서 무엇을 돌려주는지", () => {
+  it("변형 접두사만 있고 유틸리티가 비면 빈 문자열을 돌려준다", () => {
+    expect(utilityOf("hover:")).toBe("");
+  });
+
+  it("빈 토큰은 빈 문자열을 돌려준다", () => {
+    expect(utilityOf("")).toBe("");
+  });
+
+  it("맨 앞 콜론은 빈 접두사로 세고 뒤를 유틸리티로 본다", () => {
+    expect(utilityOf(":flex")).toBe("flex");
+  });
+
+  it("짝 없는 닫는 대괄호는 깊이를 0 아래로 못 내린다", () => {
+    expect(utilityOf("a]:b")).toBe("b");
+  });
+});
+
+describe("arbitraryValueOf — 첫 대괄호부터 짝이 맞는 곳까지 꺼낸다", () => {
+  it.each([
+    { utility: "flex", value: null },
+    {
+      utility: "bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)]",
+      value: "color-mix(in_oklch,var(--secondary),var(--foreground)_5%)",
+    },
+    {
+      utility: "rounded-[min(var(--radius-md),12px)]",
+      value: "min(var(--radius-md),12px)",
+    },
+    {
+      utility: "grid-cols-[repeat(2,minmax(0,1fr))]",
+      value: "repeat(2,minmax(0,1fr))",
+    },
+    {
+      utility: "[&_svg:not([class*='size-'])]",
+      value: "&_svg:not([class*='size-'])",
+    },
+    { utility: "w-[1px]-[2px]", value: "1px" },
+  ])("$utility 에서 $value 를 꺼낸다", ({ utility, value }) => {
+    expect(arbitraryValueOf(utility)).toBe(value);
+  });
+});
+
+describe("arbitraryValueOf — 경계에서 무엇을 돌려주는지", () => {
+  it("대괄호가 열리기만 하고 안 닫히면 null 을 돌려준다", () => {
+    expect(arbitraryValueOf("bg-[foo")).toBeNull();
+  });
+
+  it("빈 대괄호는 null 이 아니라 빈 문자열을 돌려준다", () => {
+    expect(arbitraryValueOf("w-[]")).toBe("");
+  });
+});
+
+describe("classStringVisitor — className 속성에서 토큰을 뽑는다", () => {
+  it("문자열 리터럴을 공백으로 쪼개고 빈 토큰은 버린다", () => {
+    const collected = visitAttribute(
+      attribute(jsxIdentifier("className"), literal("  flex   gap-2 ")),
+    );
+
+    expect(tokensOf(collected)).toEqual(["flex", "gap-2"]);
+  });
+
+  it("class 속성도 같이 본다", () => {
+    const collected = visitAttribute(
+      attribute(jsxIdentifier("class"), literal("grid")),
+    );
+
+    expect(tokensOf(collected)).toEqual(["grid"]);
+  });
+
+  it("className 이 아닌 속성은 보지 않는다", () => {
+    const collected = visitAttribute(
+      attribute(jsxIdentifier("id"), literal("flex")),
+    );
+
+    expect(collected).toEqual([]);
+  });
+
+  it("값이 없는 속성은 보지 않는다", () => {
+    const collected = visitAttribute(
+      attribute(jsxIdentifier("className"), null),
+    );
+
+    expect(collected).toEqual([]);
+  });
+
+  it("JSXIdentifier 가 아닌 이름은 보지 않는다", () => {
+    const collected = visitAttribute(
+      attribute(
+        { type: "JSXNamespacedName", name: jsxIdentifier("className") },
+        literal("flex"),
+      ),
+    );
+
+    expect(collected).toEqual([]);
+  });
+
+  it("템플릿 리터럴은 quasi 를 먼저 훑고 표현식 안 문자열을 뒤에 붙인다", () => {
+    const collected = visitAttribute(
+      attribute(jsxIdentifier("className"), {
+        type: "JSXExpressionContainer",
+        expression: {
+          type: "TemplateLiteral",
+          quasis: [templateElement("flex "), templateElement(" rounded-md")],
+          expressions: [literal("gap-2")],
+        },
+      }),
+    );
+
+    expect(collected).toEqual([
+      { token: "flex", nodeType: "TemplateElement" },
+      { token: "rounded-md", nodeType: "TemplateElement" },
+      { token: "gap-2", nodeType: "Literal" },
+    ]);
+  });
+});
+
+describe("classStringVisitor — 클래스 헬퍼 호출에서 토큰을 뽑는다", () => {
+  it("인자로 받은 문자열을 순서대로 쪼갠다", () => {
+    const collected = visitCall(
+      callOf(identifier("cn"), [literal("flex gap-2"), literal("rounded-md")]),
+    );
+
+    expect(tokensOf(collected)).toEqual(["flex", "gap-2", "rounded-md"]);
+  });
+
+  it("중첩 객체 안의 문자열까지 내려가 훑는다", () => {
+    const collected = visitCall(
+      callOf(identifier("cva"), [
+        literal("base-class"),
+        objectOf([
+          property(
+            identifier("variants"),
+            objectOf([property(identifier("size"), literal("text-sm"))]),
+          ),
+        ]),
+      ]),
+    );
+
+    expect(tokensOf(collected)).toEqual(["base-class", "text-sm"]);
+  });
+
+  it("목록에 없는 함수 이름은 보지 않는다", () => {
+    const collected = visitCall(
+      callOf(identifier("translate"), [literal("flex")]),
+    );
+
+    expect(collected).toEqual([]);
+  });
+
+  it("멤버 호출은 이름이 같아도 보지 않는다", () => {
+    const collected = visitCall(
+      callOf(
+        {
+          type: "MemberExpression",
+          object: identifier("styles"),
+          property: identifier("cn"),
+        },
+        [literal("flex")],
+      ),
+    );
+
+    expect(collected).toEqual([]);
+  });
+
+  it("문자열이 아닌 인자는 토큰을 내지 않는다", () => {
+    const collected = visitCall(
+      callOf(identifier("cn"), [literal(42), identifier("isActive")]),
+    );
+
+    expect(collected).toEqual([]);
+  });
+
+  it("인자 안에 다른 함수 호출이 끼어도 그 문자열까지 클래스로 센다", () => {
+    const collected = visitCall(
+      callOf(identifier("cn"), [
+        callOf(identifier("translate"), [literal("cart.empty.title")]),
+      ]),
+    );
+
+    expect(tokensOf(collected)).toEqual(["cart.empty.title"]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
           include: [
             "src/**/__tests__/**/*.test.{ts,tsx}",
             ".claude/hooks/__tests__/**/*.test.ts",
+            "eslint-rules/__tests__/**/*.test.ts",
             "tests/lint/**/*.test.ts",
           ],
           exclude: [...configDefaults.exclude, "**/*.integration.test.ts"],


### PR DESCRIPTION
## 왜 이 자리에 테스트를 두는가

`eslint-rules/class-strings.mjs`는 규칙 둘(`no-arbitrary-class-values`, `no-default-palette-class`)이 함께 쓰는 파싱 모듈이다. interface는 함수 셋인데 안에는 중첩 대괄호, 변형 접두사, 템플릿 리터럴, AST 재귀 순회가 다 들어 있다. 깊이 자체는 문제가 아니다. 지우면 그 복잡도가 규칙 둘로 흩어지니 모듈은 제 몫을 한다.

문제는 이 모듈이 자기 interface에서 한 번도 안 불렸다는 것이었다. `utilityOf("in-data-[slot=button-group]:rounded-lg")`가 뭘 돌려주는지 보려면 ESLint 인스턴스를 띄우고 `eslint.config.mjs`와 Next 프리셋을 파싱해 플러그인을 거쳐야 했다. 단언 하나에 홉이 여섯이라, 실패해도 파싱이 틀린 건지 배선이 틀린 건지 안 갈렸다.

자리는 `eslint-rules/__tests__/`로 잡았다. `.claude/hooks/__tests__/tdd-guard.test.ts`가 이미 같은 모양이다 — 인프라 코드는 그 옆 `__tests__/`에서 자기를 친다. `eslint.config.mjs`의 상대 경로 금지는 `src/**`와 `tests/**`만 걸므로 이 자리에서 `../class-strings.mjs`는 합법이다. alias를 새로 파지 않았다.

`vitest.config.ts`는 unit `include`에 한 줄만 더했다.

## 무엇을 못 박았는가

리팩터링이 아니라 **지금 동작을 고정하는** 테스트다. `class-strings.mjs`는 한 글자도 안 고쳤다.

`utilityOf` — `depth` 계산이 대괄호와 괄호 안 콜론을 건너뛰는지가 핵심이다. 여러 겹 변형, `in-data-[slot=...]:`, 중첩 대괄호 `[&_svg:not([class*='size-'])]:`, `*:[img:first-child]:`, 그리고 유틸리티 **자신이** 콜론을 품은 `md:hover:[&>*]:text-[color:var(--fg)]`까지 넣었다.

`arbitraryValueOf` — 첫 `[`부터 짝이 맞는 `]`까지. `color-mix(...)`와 `min(...)` 같은 중첩 괄호, 중첩 대괄호, 대괄호가 둘인 토큰을 담았다.

`classStringVisitor` — ESLint AST 노드를 손으로 짓되 필요한 필드만 채웠다. 노드 빌더 여섯 개면 문자열 리터럴·템플릿 quasi·`cn`/`cva` 인자·중첩 객체가 전부 커버된다. 브리프는 지저분해지면 빼도 된다고 했지만, 실제로 짜보니 리터럴 하나가 `{ type, value }` 두 필드였다. 뺄 이유가 없었다.

## 단언이 실제로 무는지 확인했다

표 테스트는 통과만 시키기 쉽다. 그래서 구현을 여섯 군데 일부러 망가뜨려 보고 원본으로 되돌렸다.

| 망가뜨린 곳 | 결과 |
| --- | --- |
| `utilityOf` 콜론 깊이 검사 제거 | 1건 실패 |
| `utilityOf` 괄호 깊이 무시 | 1건 실패 |
| `arbitraryValueOf` 첫 `]`에서 반환 | 1건 실패 |
| `collectStrings` 템플릿 표현식 무시 | 1건 실패 |
| 빈 토큰 거르기 제거 | 2건 실패 |
| `class` 속성 제외 | 1건 실패 |

괄호 깊이는 첫 판에 살아남았다. 대괄호 없이 괄호 안에만 콜론이 오는 경우를 안 넣어서였고, Tailwind 4의 `bg-(color:--brand)` 표기가 정확히 그 자리라 표에 더했다.

## 경계에서 뭘 돌려주는지도 적었다

버그로 보이는 자리는 **고치지 않고 못 박았다**. 브리프가 그렇게 정했고, 규칙 둘이 이 값에 이미 기대고 있어 조용히 바꾸면 리뷰 없이 동작이 움직인다.

- `arbitraryValueOf("w-[]")`는 `null`이 아니라 `""`를 돌려준다. `no-arbitrary-class-values`는 `value === null`로만 걸러내니 빈 문자열은 정규식까지 내려가지만 아무것도 안 걸린다. 지금은 무해하다.
- `utilityOf("hover:")`와 `utilityOf("")`는 빈 문자열이다.
- `utilityOf("a]:b")`는 `"b"`다. 짝 없는 닫는 대괄호가 깊이를 0 아래로 못 내리기 때문이다.
- `arbitraryValueOf("bg-[foo")`는 열리고 안 닫히면 `null`이다.

## 발견한 이슈 — 이번 PR에서 안 고친다

**`cn(...)` 인자 안의 아무 문자열이나 클래스로 센다.** `collectStrings`가 인자 하위를 통째로 훑으니 `cn(translate("cart.empty.title"))`의 `"cart.empty.title"`도 토큰이 된다. 지금은 그 문자열이 팔레트 정규식이나 임의 값 정규식에 안 걸려 조용하지만, `t("text-red-500")` 같은 게 들어오면 없는 위반이 잡힌다. 마지막 테스트가 이 동작을 못 박아뒀으니 나중에 좁힐 때 무엇이 바뀌는지 보인다.

**`tests/lint/*`가 기본 5초 타임아웃에서 자주 터진다.** 이번 변경과 무관하다 — `vitest.config.ts`를 원래대로 되돌리고 돌려도 같은 파일들이 같은 이유로 실패했다(내 변경 없이 10건, 있을 때 8~12건으로 매 회차 다르다). `--testTimeout=60000`을 주면 146건 전부 통과한다. 실패는 항상 각 파일의 **첫** 테스트고, ESLint를 처음 띄우는 비용이 여기 몰린다. 워크트리 다섯이 같이 도는 지금은 더 그렇다. `tests/lint/`는 다른 손이 잡고 있어 건드리지 않았다.

이 지연이 이번 task의 전제와 같은 뿌리라는 점은 적어둘 만하다. 규칙 하나를 확인하려고 ESLint를 통째로 띄우는 구조라서 느리다. 이 PR이 그 홉을 없앤 자리는 14ms에 끝난다.

## 돌린 것

- `pnpm lint` — 통과
- `pnpm format:check` — 통과
- `pnpm typecheck` — 통과
- `pnpm test` — 새 파일 33건 전부 통과. `tests/lint/*`는 위에 적은 타임아웃으로 흔들린다. `--testTimeout=60000`이면 146건 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S45cw7DGat24tuHVCBGNS4
