### PR TITLE
규칙 카탈로그를 코드가 알게 한다

### DIFF
--- a/tests/lint/rule-catalogue.test.ts
+++ b/tests/lint/rule-catalogue.test.ts
@@ -1,0 +1,117 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { ESLint } from "eslint";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  DOCUMENTED_LINT_RULE_COUNT,
+  RULES,
+  RULE_NUMBERS_NEVER_ASSIGNED,
+  type EnforcedRule,
+} from "@tests/lint/rules";
+
+const PROBE_FILE = "src/shared/ui/card.tsx";
+
+const LINT_MECHANISMS: EnforcedRule["mechanism"][] = [
+  "eslint",
+  "house",
+  "prettier",
+];
+
+async function resolveConfig() {
+  const eslint = new ESLint({ overrideConfigFile: "eslint.config.mjs" });
+  return eslint.calculateConfigForFile(path.join(process.cwd(), PROBE_FILE));
+}
+
+function isTurnedOn(entry: unknown) {
+  const severity = Array.isArray(entry) ? entry[0] : entry;
+  return (
+    severity === 2 ||
+    severity === "error" ||
+    severity === 1 ||
+    severity === "warn"
+  );
+}
+
+function ruleIdsOf(mechanisms: EnforcedRule["mechanism"][]) {
+  return RULES.filter(
+    (rule) => mechanisms.includes(rule.mechanism) && rule.ruleId !== null,
+  ).map((rule) => rule.ruleId as string);
+}
+
+describe("규칙 카탈로그", () => {
+  let config: Awaited<ReturnType<typeof resolveConfig>>;
+
+  beforeAll(async () => {
+    config = await resolveConfig();
+  }, 60_000);
+
+  it("카탈로그가 켜졌다고 적은 규칙은 실제 config에서 켜져 있다", () => {
+    const turnedOff = ruleIdsOf(["eslint", "house"]).filter(
+      (ruleId) => !isTurnedOn(config.rules?.[ruleId]),
+    );
+
+    expect(turnedOff).toEqual([]);
+  });
+
+  it("house 플러그인이 내보내는 규칙은 전부 카탈로그에 있다", () => {
+    const registered = Object.keys(config.plugins.house.rules)
+      .map((name) => `house/${name}`)
+      .sort();
+    const catalogued = [...new Set(ruleIdsOf(["house"]))].sort();
+
+    expect(catalogued).toEqual(registered);
+  });
+
+  it("카탈로그가 가리키는 테스트 파일은 디스크에 있다", () => {
+    const missing = RULES.map((rule) => rule.test)
+      .filter((file): file is string => file !== null)
+      .filter((file) => !existsSync(path.join(process.cwd(), file)));
+
+    expect([...new Set(missing)]).toEqual([]);
+  });
+});
+
+describe("규칙 번호", () => {
+  const numbers = [
+    ...new Set([
+      ...RULES.map((rule) => rule.no),
+      ...RULE_NUMBERS_NEVER_ASSIGNED,
+    ]),
+  ].sort((a, b) => a - b);
+
+  it("1부터 시작해 끊기지 않는다", () => {
+    const unbroken = Array.from({ length: numbers.length }, (_, i) => i + 1);
+
+    expect(numbers).toEqual(unbroken);
+  });
+
+  it("한 번호를 나눠 가진 규칙은 이름이 같고 ruleId가 서로 다르다", () => {
+    const conflicting = numbers.filter((no) => {
+      const shared = RULES.filter((rule) => rule.no === no);
+      const names = new Set(shared.map((rule) => rule.name));
+      const ruleIds = new Set(shared.map((rule) => rule.ruleId));
+      return names.size > 1 || ruleIds.size !== shared.length;
+    });
+
+    expect(conflicting).toEqual([]);
+  });
+
+  it("끝내 정체를 못 찾은 번호는 카탈로그가 쓰지 않는다", () => {
+    const claimed = RULES.filter((rule) =>
+      RULE_NUMBERS_NEVER_ASSIGNED.includes(rule.no),
+    );
+
+    expect(claimed).toEqual([]);
+  });
+
+  it("문서가 말하는 열넷은 lint가 집행하는 마지막 번호다", () => {
+    const lintNumbers = [
+      ...RULES.filter((rule) => LINT_MECHANISMS.includes(rule.mechanism)).map(
+        (rule) => rule.no,
+      ),
+      ...RULE_NUMBERS_NEVER_ASSIGNED,
+    ];
+
+    expect(Math.max(...lintNumbers)).toBe(DOCUMENTED_LINT_RULE_COUNT);
+  });
+});

--- a/tests/lint/rules.ts
+++ b/tests/lint/rules.ts
@@ -1,0 +1,126 @@
+export type EnforcedRule = {
+  no: number;
+  name: string;
+  mechanism: "eslint" | "house" | "prettier" | "hook" | "pre-commit";
+  ruleId: string | null;
+  test: string | null;
+};
+
+export const DOCUMENTED_LINT_RULE_COUNT = 14;
+
+export const RULE_NUMBERS_NEVER_ASSIGNED = [6, 7, 8];
+
+export const RULES: EnforcedRule[] = [
+  {
+    no: 1,
+    name: "상대 경로 import 금지",
+    mechanism: "eslint",
+    ruleId: "no-restricted-imports",
+    test: "tests/lint/relative-import.test.ts",
+  },
+  {
+    no: 2,
+    name: "FSD 역방향 import",
+    mechanism: "eslint",
+    ruleId: "no-restricted-imports",
+    test: "tests/lint/fsd-layer-order.test.ts",
+  },
+  {
+    no: 3,
+    name: "같은 층 다른 슬라이스 import",
+    mechanism: "house",
+    ruleId: "house/no-cross-slice-import",
+    test: "tests/lint/fsd-slice-boundary.test.ts",
+  },
+  {
+    no: 4,
+    name: "하드코딩한 색과 크기",
+    mechanism: "house",
+    ruleId: "house/no-arbitrary-class-values",
+    test: "tests/lint/design-token-values.test.ts",
+  },
+  {
+    no: 4,
+    name: "하드코딩한 색과 크기",
+    mechanism: "house",
+    ruleId: "house/no-color-literals",
+    test: "tests/lint/design-token-values.test.ts",
+  },
+  {
+    no: 5,
+    name: "Tailwind 기본 팔레트 유틸리티",
+    mechanism: "house",
+    ruleId: "house/no-default-palette-class",
+    test: "tests/lint/tailwind-default-palette.test.ts",
+  },
+  {
+    no: 9,
+    name: ".tsx는 더미 UI",
+    mechanism: "house",
+    ruleId: "house/dumb-ui",
+    test: "tests/lint/tsx-dumb-ui.test.ts",
+  },
+  {
+    no: 10,
+    name: "집중 실행 표시",
+    mechanism: "eslint",
+    ruleId: "no-restricted-syntax",
+    test: "tests/lint/no-focused-tests.test.ts",
+  },
+  {
+    no: 11,
+    name: "import 순서",
+    mechanism: "eslint",
+    ruleId: "import/order",
+    test: "tests/lint/import-order.test.ts",
+  },
+  {
+    no: 12,
+    name: "Tailwind 클래스 순서",
+    mechanism: "prettier",
+    ruleId: null,
+    test: "tests/lint/format-check.test.ts",
+  },
+  {
+    no: 13,
+    name: "console",
+    mechanism: "eslint",
+    ruleId: "no-console",
+    test: "tests/lint/no-console.test.ts",
+  },
+  {
+    no: 14,
+    name: "미사용 import와 import type",
+    mechanism: "eslint",
+    ruleId: "unused-imports/no-unused-imports",
+    test: "tests/lint/unused-imports.test.ts",
+  },
+  {
+    no: 14,
+    name: "미사용 import와 import type",
+    mechanism: "eslint",
+    ruleId: "@typescript-eslint/consistent-type-imports",
+    test: "tests/lint/unused-imports.test.ts",
+  },
+  {
+    no: 15,
+    name: "실행 코드를 쓰기 전에 짝 테스트가 있어야 한다",
+    mechanism: "hook",
+    ruleId: null,
+    test: ".claude/hooks/__tests__/tdd-guard.test.ts",
+  },
+  {
+    no: 16,
+    name: "화면과 라우트를 쓰기 전에 e2e 명세가 있어야 한다",
+    mechanism: "hook",
+    ruleId: null,
+    test: ".claude/hooks/__tests__/tdd-guard.test.ts",
+  },
+  {
+    no: 17,
+    name: "시크릿과 .env는 커밋할 수 없다",
+    mechanism: "pre-commit",
+    ruleId: null,
+    test: null,
+  },
+];


### PR DESCRIPTION
규칙이 어디서 도는지 코드가 모르고 있었다. `eslint.config.mjs`에서 규칙 하나를 빼도 초록이었다. 카탈로그를 만들고, 카탈로그와 실제 config를 양방향으로 맞대어 보게 했다.

---

## 6·7·8은 없다

문서는 규칙이 열넷이라고 적었는데(`docs/handoff.md:9`, `docs/log/2026-08-26-4.md:3`) 번호가 실제로 나오는 자리는 `tests/lint/*.test.ts`의 `describe` 제목뿐이고 거기는 1·2·3·4·5·9·10·11·12·13·14 열하나다.

찾아본 곳은 이렇다. `docs/plan.md`의 완료 조건 일곱 갈래, `docs/log/` 전부, `docs/design-system/`, `docs/handoff.md`, PR #197 본문. 그리고 `git rev-list --all`로 전체 커밋을 훑어 `규칙6`·`규칙7`·`규칙8`과 그 띄어쓰기 변형을 grep했다. 한 건도 안 나온다.

`docs/log/2026-08-26-4.md:25`가 "조건은 여덟에서 열넷으로 늘었다"고 적었지만 그 여덟은 완료 조건 갈래를 센 수지 규칙 번호가 아니다. plan.md의 갈래는 경계·디자인 값·`.tsx` 더미 UI·테스트 규율·정리·포매터·증명 일곱이고, 어느 갈래에도 6·7·8에 해당하는 규칙이 붙어 있지 않다. 번호를 매긴 손이 5에서 9로 건너뛰었다고 보는 게 지금 근거로 말할 수 있는 전부다.

그래서 지어내지 않고 구조로 남겼다.

```ts
export const RULE_NUMBERS_NEVER_ASSIGNED = [6, 7, 8];
```

번호 연속성 단언이 이 목록을 카탈로그 번호와 합쳐서 본다. 6·7·8이 나중에 정체를 찾으면 이 상수에서 빼고 `RULES`에 넣어야 테스트가 통과한다. 빈자리가 코드에서 안 보이게 메워지는 길은 없다.

---

## 왜 이렇게 짰나

**픽스처를 린트하지 않고 config를 읽는다.** 규칙이 실제로 발동하는지는 기존 테스트 열하나가 이미 위반 픽스처로 본다. 카탈로그가 볼 것은 그다음 질문이다 — 그 규칙이 대상 파일의 최종 config에 아직 켜져 있는가. `ESLint#calculateConfigForFile()`로 `src/shared/ui/card.tsx`의 병합된 config를 뽑아 severity를 확인한다. 이 파일 하나로 카탈로그가 적은 lint 규칙 전부가 덮인다. `.tsx`이면서 `src/**/__tests__/` 밖이라 `house/dumb-ui`와 디자인 값 규칙 셋까지 같이 걸린다.

**house 규칙 목록을 `eslint-rules/index.mjs`에서 직접 읽지 않는다.** 그 파일을 import하면 플러그인이 무엇을 내보내는지만 알게 된다. 정작 물어야 할 건 `eslint.config.mjs`가 그 플러그인을 실제로 물고 있느냐다. resolved config의 `plugins.house.rules`를 읽으면 등록까지 확인한 목록이 나온다. 덤으로 `tests/`에서 저장소 루트로 올라가는 상대 경로 import를 안 만들어도 된다 — 규칙1이 막는 자리다.

**한 번호를 규칙 둘이 나눠 가진다.** 규칙4는 `house/no-arbitrary-class-values`와 `house/no-color-literals` 둘로, 규칙14는 `unused-imports/no-unused-imports`와 `@typescript-eslint/consistent-type-imports` 둘로 집행된다. `EnforcedRule`의 `ruleId`가 하나뿐이라 타입을 고치거나 엔트리를 나누거나였고, 받은 타입을 그대로 두고 엔트리를 나눴다. 대신 같은 번호를 쓰는 엔트리끼리 이름이 같고 `ruleId`는 서로 달라야 한다는 단언을 얹었다. 실수로 번호를 겹쳐 쓰면 여기서 걸린다.

**15·16·17은 카탈로그가 붙인 번호다.** 문서는 lint가 집행하는 열넷까지만 번호를 매겼고 `.claude/hooks/`의 TDD 가드 둘과 `.githooks/pre-commit`의 시크릿 검사에는 번호가 없다. 강제 수단 다섯 갈래를 한 자리에 모으려면 번호가 필요해서 뒤에 이어 붙였다. 문서의 열넷과 섞이지 않게 "lint가 집행하는 마지막 번호는 열넷"이라는 단언을 따로 뒀다.

**config 로드를 `beforeAll`로 올렸다.** 첫 `calculateConfigForFile()` 호출이 14초 걸려서 vitest 기본 타임아웃 5초에 걸렸다. next config와 플러그인을 전부 물어오는 비용이라 한 번만 치르면 된다.

---

## 무는지 확인했다

카탈로그를 일부러 어긋내고 테스트가 실제로 빨간지 봤다.

| 어긋낸 것 | 결과 |
| --- | --- |
| `house/no-color-literals` 엔트리를 지웠다 | 실패 — house 플러그인 규칙 대조 |
| `no-console`을 켜지 않은 `no-magic-numbers`로 바꿨다 | 실패 — 켜짐 확인 |
| 테스트 경로를 없는 파일로 바꿨다 | 실패 — 디스크 실재 확인 |
| `RULE_NUMBERS_NEVER_ASSIGNED`를 비웠다 | 실패 — 번호 연속성 |

---

## 검증

| 명령 | 결과 |
| --- | --- |
| `pnpm lint` | 통과 |
| `pnpm format:check` | 통과 |
| `pnpm typecheck` | 통과 |
| `pnpm test` | 새 파일 `Tests 7 passed (7)` — 나머지는 아래 |

---

## 안 고치고 남긴 것

`tests/lint/`의 기존 테스트는 하나도 안 건드렸다. 다른 worktree가 하네스로 옮기는 중이다.

`pnpm test`가 지금 초록이 아니다. 이 브랜치의 파일을 얹기 전에 돌려도 그렇다 — 세 번 돌려 실패한 파일이 다섯·여덟·일곱으로 매번 달랐다. 실패 사유는 전부 `Test timed out in 5000ms`다. lint 테스트 열하나가 각자 `ESLint` 인스턴스를 세워 픽스처를 린트하는데 한 테스트가 10초에서 40초를 쓴다. 병렬로 돌면 기본 타임아웃 5초를 넘긴다.

새 파일은 `beforeAll`로 그 자리를 피했고 일곱 단언 전부 통과한다. 다만 워커가 하나 늘어 경합은 조금 더 세진다. 기존 테스트도 `vitest.config.ts`의 `testTimeout`도 안 건드렸다 — 앞엣것은 다른 worktree가 하네스로 옮기는 중이고, 뒤엣것은 그 하네스가 정할 값이다.

`unused-imports/no-unused-vars`가 warn으로 켜져 있는데 문서 어느 번호에도 안 붙어 있다. 규칙14의 이름은 "미사용 import와 `import type`"이라 미사용 변수까지 담기지 않는다. 번호를 새로 주는 건 결정이라 카탈로그에 안 넣었다.
