### PR TITLE
lint 규칙 확인을 하나의 하네스로 모은다

### DIFF
--- a/tests/lint/design-token-values.test.ts
+++ b/tests/lint/design-token-values.test.ts
@@ -1,14 +1,18 @@
-import path from "node:path";
-import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { violationsOf } from "@tests/lint/rule-check";
 
-async function lintClassName(className: string) {
-  const eslint = new ESLint({ overrideConfigFile: "eslint.config.mjs" });
+const NO_ARBITRARY_CLASS_VALUES = "house/no-arbitrary-class-values";
+const NO_COLOR_LITERALS = "house/no-color-literals";
+const DESIGN_TOKEN_RULES = [NO_ARBITRARY_CLASS_VALUES, NO_COLOR_LITERALS];
+
+function designTokenRuleIds(ruleIds: string[]) {
+  return ruleIds.filter((ruleId) => DESIGN_TOKEN_RULES.includes(ruleId));
+}
+
+async function ruleIdsOfClassName(className: string) {
   const code = `export function Fixture() {\n  return <div className="${className}" />;\n}\n`;
-  const [result] = await eslint.lintText(code, {
-    filePath: path.join(process.cwd(), "src/shared/ui/fixture.tsx"),
-  });
-  return result;
+  const violations = await violationsOf(code, "src/shared/ui/fixture.tsx");
+  return violations.map((violation) => violation.ruleId);
 }
 
 describe("규칙4 — 하드코딩한 색과 크기", () => {
@@ -25,30 +29,48 @@ describe("규칙4 — 하드코딩한 색과 크기", () => {
       ["rounded-[min(var(--radius-md),12px)]", "var()를 감싼 min()"],
       ["grid-cols-[1fr_auto]", "그리드 트랙 크기"],
       ["grid-rows-[auto_auto]", "그리드 트랙 크기"],
-    ])("%s (%s)는 위반 0건이다", async (className) => {
-      const result = await lintClassName(`flex ${className} items-center`);
+    ])("%s (%s)는 규칙4의 어느 규칙도 안 걸린다", async (className) => {
+      const ruleIds = await ruleIdsOfClassName(
+        `flex ${className} items-center`,
+      );
 
-      expect(result.errorCount).toBe(0);
+      expect(designTokenRuleIds(ruleIds)).toEqual([]);
     });
   });
 
   describe("대괄호 안이 리터럴이면 걸린다", () => {
     it.each([
-      ["text-[0.8rem]", "rem 리터럴 크기"],
-      ["text-[13px]", "px 리터럴 크기"],
-      ["p-[7px]", "px 리터럴 스페이싱"],
-      ["bg-[#6E4F39]", "hex 리터럴 색"],
-      ["bg-[rgb(110,79,57)]", "rgb 리터럴 색"],
-      ["bg-[hsl(24,32%,33%)]", "hsl 리터럴 색"],
-    ])("%s (%s)는 위반 1건 이상이다", async (className) => {
-      const result = await lintClassName(`flex ${className} items-center`);
+      ["text-[0.8rem]", "rem 리터럴 크기", [NO_ARBITRARY_CLASS_VALUES]],
+      ["text-[13px]", "px 리터럴 크기", [NO_ARBITRARY_CLASS_VALUES]],
+      ["p-[7px]", "px 리터럴 스페이싱", [NO_ARBITRARY_CLASS_VALUES]],
+      [
+        "bg-[#6E4F39]",
+        "hex 리터럴 색",
+        [NO_ARBITRARY_CLASS_VALUES, NO_COLOR_LITERALS],
+      ],
+      [
+        "bg-[rgb(110,79,57)]",
+        "rgb 리터럴 색",
+        [NO_ARBITRARY_CLASS_VALUES, NO_COLOR_LITERALS],
+      ],
+      [
+        "bg-[hsl(24,32%,33%)]",
+        "hsl 리터럴 색",
+        [NO_ARBITRARY_CLASS_VALUES, NO_COLOR_LITERALS],
+      ],
+    ])(
+      "%s (%s)는 적어둔 규칙이 전부 걸린다",
+      async (className, _description, expectedRuleIds) => {
+        const ruleIds = await ruleIdsOfClassName(
+          `flex ${className} items-center`,
+        );
 
-      expect(result.errorCount).toBeGreaterThan(0);
-    });
+        expect(designTokenRuleIds(ruleIds)).toEqual(expectedRuleIds);
+      },
+    );
   });
 
-  it("회귀 — text-[0.8rem]이 토큰 유틸로 바뀐 button.tsx는 위반 0건이다", async () => {
-    const eslint = new ESLint({ overrideConfigFile: "eslint.config.mjs" });
+  it("회귀 — text-[0.8rem]이 토큰 유틸로 바뀐 button.tsx는 규칙4의 어느 규칙도 안 걸린다", async () => {
     const code = `import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -91,10 +113,9 @@ function Button({
 
 export { Button, buttonVariants }
 `;
-    const [result] = await eslint.lintText(code, {
-      filePath: path.join(process.cwd(), "src/shared/ui/button.tsx"),
-    });
+    const violations = await violationsOf(code, "src/shared/ui/button.tsx");
+    const ruleIds = violations.map((violation) => violation.ruleId);
 
-    expect(result.errorCount).toBe(0);
+    expect(designTokenRuleIds(ruleIds)).toEqual([]);
   });
 });

--- a/tests/lint/fsd-layer-order.test.ts
+++ b/tests/lint/fsd-layer-order.test.ts
@@ -1,89 +1,104 @@
-import path from "node:path";
-import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { violationsOf } from "@tests/lint/rule-check";
 
-async function lintFixture(code: string, filePath: string) {
-  const eslint = new ESLint({ overrideConfigFile: "eslint.config.mjs" });
-  const [result] = await eslint.lintText(code, {
-    filePath: path.join(process.cwd(), filePath),
-  });
-  return result;
-}
+const NO_RESTRICTED_IMPORTS = "no-restricted-imports";
 
 describe("규칙2 — FSD 역방향 import", () => {
   it("shared가 entities를 import하면 걸린다", async () => {
     const code = `import { Profile } from "@/entities/profile/model/profile";\n\nexport const value = Profile;\n`;
 
-    const result = await lintFixture(code, "src/shared/lib/fixture.ts");
+    const violations = await violationsOf(code, "src/shared/lib/fixture.ts");
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
   });
 
   it("entities가 features를 import하면 걸린다", async () => {
     const code = `import { trackAttendance } from "@/features/attendance/model/attendance";\n\nexport const value = trackAttendance;\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/fixture.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
   });
 
   it("features가 screens를 import하면 걸린다", async () => {
     const code = `import { Home } from "@/screens/home/ui/home";\n\nexport const value = Home;\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/features/attendance/model/fixture.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
   });
 
   it("screens가 app을 import하면 걸린다", async () => {
     const code = `import { Providers } from "@/app/providers";\n\nexport const value = Providers;\n`;
 
-    const result = await lintFixture(code, "src/screens/home/ui/fixture.tsx");
+    const violations = await violationsOf(
+      code,
+      "src/screens/home/ui/fixture.tsx",
+    );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
   });
 
   it("app이 screens를 import하면 통과한다", async () => {
     const code = `import { Home } from "@/screens/home/ui/home";\n\nexport const value = Home;\n`;
 
-    const result = await lintFixture(code, "src/app/fixture.ts");
+    const violations = await violationsOf(code, "src/app/fixture.ts");
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
   });
 
   it("screens가 features를 import하면 통과한다", async () => {
     const code = `import { trackAttendance } from "@/features/attendance/model/attendance";\n\nexport const value = trackAttendance;\n`;
 
-    const result = await lintFixture(code, "src/screens/home/ui/fixture2.tsx");
+    const violations = await violationsOf(
+      code,
+      "src/screens/home/ui/fixture2.tsx",
+    );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
   });
 
   it("features가 entities를 import하면 통과한다", async () => {
     const code = `import { Profile } from "@/entities/profile/model/profile";\n\nexport const value = Profile;\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/features/attendance/model/fixture2.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
   });
 
   it("entities가 shared를 import하면 통과한다", async () => {
     const code = `import { cn } from "@/shared/lib/utils";\n\nexport const value = cn;\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/fixture2.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
   });
 });

--- a/tests/lint/fsd-slice-boundary.test.ts
+++ b/tests/lint/fsd-slice-boundary.test.ts
@@ -1,35 +1,32 @@
-import path from "node:path";
-import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { violationsOf } from "@tests/lint/rule-check";
 
-async function lintFixture(code: string, filePath: string) {
-  const eslint = new ESLint({ overrideConfigFile: "eslint.config.mjs" });
-  const [result] = await eslint.lintText(code, {
-    filePath: path.join(process.cwd(), filePath),
-  });
-  return result;
-}
+const NO_CROSS_SLICE_IMPORT = "house/no-cross-slice-import";
 
 describe("규칙3 — 같은 층 다른 슬라이스 import", () => {
   it("entities/profile이 entities/schedule을 import하면 걸린다", async () => {
     const code = `import { Schedule } from "@/entities/schedule/model/schedule";\n\nexport const value = Schedule;\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/fixture.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_CROSS_SLICE_IMPORT,
+    );
   });
 
   it("같은 슬라이스 안 다른 세그먼트 import는 통과한다", async () => {
     const code = `import { Profile } from "@/entities/profile/model/profile";\n\nexport const value = Profile;\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/dals/fixture.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_CROSS_SLICE_IMPORT,
+    );
   });
 });

--- a/tests/lint/import-order.test.ts
+++ b/tests/lint/import-order.test.ts
@@ -1,14 +1,7 @@
-import path from "node:path";
-import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { fixedCode, violationsOf } from "@tests/lint/rule-check";
 
-async function lintFixture(code: string, filePath: string, fix = false) {
-  const eslint = new ESLint({ overrideConfigFile: "eslint.config.mjs", fix });
-  const [result] = await eslint.lintText(code, {
-    filePath: path.join(process.cwd(), filePath),
-  });
-  return result;
-}
+const IMPORT_ORDER = "import/order";
 
 function importSources(code: string) {
   return [...code.matchAll(/from\s+["']([^"']+)["']/g)].map(
@@ -17,61 +10,67 @@ function importSources(code: string) {
 }
 
 describe("규칙11 — import 순서", () => {
-  it("app 레이어를 shared보다 먼저 import하면 걸린다", async () => {
+  it("app 레이어를 shared보다 먼저 import하면 import/order가 걸린다", async () => {
     const code = `import { Home } from "@/screens/home/ui/home";\nimport { cn } from "@/shared/lib/utils";\n\nexport const value = { Home, cn };\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/features/attendance/model/fixture.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      IMPORT_ORDER,
+    );
   });
 
-  it("shared → entities → features → screens → app 순서는 위반 0건이다", async () => {
+  it("shared → entities → features → screens → app 순서는 import/order가 안 걸린다", async () => {
     const code = `import { cn } from "@/shared/lib/utils";\nimport { Profile } from "@/entities/profile/model/profile";\nimport { trackAttendance } from "@/features/attendance/model/attendance";\nimport { Home } from "@/screens/home/ui/home";\n\nexport const value = { cn, Profile, trackAttendance, Home };\n`;
 
-    const result = await lintFixture(code, "src/app/fixture.ts");
+    const violations = await violationsOf(code, "src/app/fixture.ts");
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      IMPORT_ORDER,
+    );
   });
 
-  it("외부 패키지가 먼저 오고 FSD 그룹이 순서대로면 위반 0건이다", async () => {
+  it("외부 패키지가 먼저 오고 FSD 그룹이 순서대로면 import/order가 안 걸린다", async () => {
     const code = `import { describe } from "vitest";\nimport { cn } from "@/shared/lib/utils";\nimport { Profile } from "@/entities/profile/model/profile";\n\nexport const value = { describe, cn, Profile };\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/__tests__/fixture.test.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      IMPORT_ORDER,
+    );
   });
 
   it("--fix를 적용하면 import 순서가 바로잡힌다", async () => {
     const code = `import { Home } from "@/screens/home/ui/home";\nimport { cn } from "@/shared/lib/utils";\n\nexport const value = { Home, cn };\n`;
 
-    const result = await lintFixture(
+    const output = await fixedCode(
       code,
       "src/features/attendance/model/fixture.ts",
-      true,
     );
-    const fixedCode = result.output ?? code;
 
-    expect(importSources(fixedCode)).toEqual([
+    expect(importSources(output)).toEqual([
       "@/shared/lib/utils",
       "@/screens/home/ui/home",
     ]);
   });
 
-  it("CSS side-effect import가 섞여도 크래시나 오탐 없이 판정된다", async () => {
+  it("CSS side-effect import가 섞여도 크래시나 오탐 없이 import/order가 안 걸린다", async () => {
     const code = `import "@/app/globals.css";\nimport { cn } from "@/shared/lib/utils";\nimport { Home } from "@/screens/home/ui/home";\n\nexport const value = { cn, Home };\n`;
 
-    const result = await lintFixture(code, "src/app/fixture.ts");
+    const violations = await violationsOf(code, "src/app/fixture.ts");
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      IMPORT_ORDER,
+    );
   });
 
-  it("회귀 — alias로 고친 layout.tsx는 위반 0건이다", async () => {
+  it("회귀 — alias로 고친 layout.tsx는 import/order가 안 걸린다", async () => {
     const code = `import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Providers } from "@/app/providers";
@@ -91,8 +90,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 `;
 
-    const result = await lintFixture(code, "src/app/layout.tsx");
+    const violations = await violationsOf(code, "src/app/layout.tsx");
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      IMPORT_ORDER,
+    );
   });
 });

--- a/tests/lint/no-console.test.ts
+++ b/tests/lint/no-console.test.ts
@@ -1,83 +1,88 @@
-import path from "node:path";
-import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { violationsOf } from "@tests/lint/rule-check";
 
-async function lintFixture(code: string, filePath: string) {
-  const eslint = new ESLint({ overrideConfigFile: "eslint.config.mjs" });
-  const [result] = await eslint.lintText(code, {
-    filePath: path.join(process.cwd(), filePath),
-  });
-  return result;
-}
+const NO_CONSOLE = "no-console";
 
 describe("규칙13 — console", () => {
   it("console.log는 걸린다", async () => {
     const code = `export function f() {\n  console.log("x");\n}\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/fixture.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_CONSOLE,
+    );
   });
 
-  it("console.error는 위반 0건이다", async () => {
+  it("console.error는 no-console이 안 걸린다", async () => {
     const code = `export function f() {\n  console.error("x");\n}\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/fixture.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_CONSOLE,
+    );
   });
 
-  it("console.warn은 위반 0건이다", async () => {
+  it("console.warn은 no-console이 안 걸린다", async () => {
     const code = `export function f() {\n  console.warn("x");\n}\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/fixture.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_CONSOLE,
+    );
   });
 
   it("console.info도 걸린다", async () => {
     const code = `export function f() {\n  console.info("x");\n}\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/fixture.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_CONSOLE,
+    );
   });
 
   it("console.debug도 걸린다", async () => {
     const code = `export function f() {\n  console.debug("x");\n}\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/fixture.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_CONSOLE,
+    );
   });
 
   it("console.table도 걸린다", async () => {
     const code = `export function f() {\n  console.table(["x"]);\n}\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/fixture.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_CONSOLE,
+    );
   });
 
-  it("회귀 — 지금 src/에는 console 호출이 없어 위반 0건이다", async () => {
+  it("회귀 — 지금 src/에는 console 호출이 없어 no-console이 안 걸린다", async () => {
     const code = `import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
@@ -86,8 +91,10 @@ export function cn(...inputs: ClassValue[]) {
 }
 `;
 
-    const result = await lintFixture(code, "src/shared/lib/utils.ts");
+    const violations = await violationsOf(code, "src/shared/lib/utils.ts");
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_CONSOLE,
+    );
   });
 });

--- a/tests/lint/no-focused-tests.test.ts
+++ b/tests/lint/no-focused-tests.test.ts
@@ -1,96 +1,105 @@
-import path from "node:path";
-import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { violationsOf } from "@tests/lint/rule-check";
 
-async function lintFixture(code: string, filePath: string) {
-  const eslint = new ESLint({ overrideConfigFile: "eslint.config.mjs" });
-  const [result] = await eslint.lintText(code, {
-    filePath: path.join(process.cwd(), filePath),
-  });
-  return result;
-}
+const NO_RESTRICTED_SYNTAX = "no-restricted-syntax";
 
 describe("규칙10 — 집중 실행 표시", () => {
   it("vitest describe.only가 걸린다", async () => {
     const code = `import { describe, it } from "vitest";\n\ndescribe.only("x", () => {\n  it("y", () => {});\n});\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/__tests__/fixture.test.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_SYNTAX,
+    );
   });
 
   it("vitest it.only가 걸린다", async () => {
     const code = `import { describe, it } from "vitest";\n\ndescribe("x", () => {\n  it.only("y", () => {});\n});\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/__tests__/fixture.test.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_SYNTAX,
+    );
   });
 
   it("vitest test.only가 걸린다", async () => {
     const code = `import { test } from "vitest";\n\ntest.only("x", () => {});\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/__tests__/fixture.test.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_SYNTAX,
+    );
   });
 
   it("playwright test.only가 걸린다", async () => {
     const code = `import { test } from "@playwright/test";\n\ntest.only("x", async () => {});\n`;
 
-    const result = await lintFixture(code, "tests/e2e/fixture.spec.ts");
+    const violations = await violationsOf(code, "tests/e2e/fixture.spec.ts");
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_SYNTAX,
+    );
   });
 
   it("playwright test.describe.only가 걸린다", async () => {
     const code = `import { test } from "@playwright/test";\n\ntest.describe.only("x", () => {\n  test("y", async () => {});\n});\n`;
 
-    const result = await lintFixture(code, "tests/e2e/fixture.spec.ts");
+    const violations = await violationsOf(code, "tests/e2e/fixture.spec.ts");
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_SYNTAX,
+    );
   });
 
-  it("vitest it.skip은 위반 0건이다", async () => {
+  it("vitest it.skip은 no-restricted-syntax가 안 걸린다", async () => {
     const code = `import { describe, it } from "vitest";\n\ndescribe("x", () => {\n  it.skip("y", () => {});\n});\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/__tests__/fixture.test.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_RESTRICTED_SYNTAX,
+    );
   });
 
-  it("playwright test.skip은 위반 0건이다", async () => {
+  it("playwright test.skip은 no-restricted-syntax가 안 걸린다", async () => {
     const code = `import { test } from "@playwright/test";\n\ntest.skip("x", async () => {});\n`;
 
-    const result = await lintFixture(code, "tests/e2e/fixture.spec.ts");
+    const violations = await violationsOf(code, "tests/e2e/fixture.spec.ts");
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_RESTRICTED_SYNTAX,
+    );
   });
 
-  it("평범한 describe/it/test는 위반 0건이다", async () => {
+  it("평범한 describe/it/test는 no-restricted-syntax가 안 걸린다", async () => {
     const code = `import { describe, it, test } from "vitest";\n\ndescribe("x", () => {\n  it("y", () => {});\n  test("z", () => {});\n});\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/__tests__/fixture.test.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_RESTRICTED_SYNTAX,
+    );
   });
 
-  it("회귀 — profile.integration.test.ts는 위반 0건이다", async () => {
+  it("회귀 — profile.integration.test.ts는 no-restricted-syntax가 안 걸린다", async () => {
     const code = `import { describe, expect, it } from "vitest";
 import {
   createGuestClient,
@@ -127,15 +136,17 @@ describe("프로필 접근 권한", () => {
 });
 `;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/dals/__tests__/profile.integration.test.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_RESTRICTED_SYNTAX,
+    );
   });
 
-  it("회귀 — utils.test.ts는 위반 0건이다", async () => {
+  it("회귀 — utils.test.ts는 no-restricted-syntax가 안 걸린다", async () => {
     const code = `import { describe, expect, it } from "vitest";
 import { cn } from "@/shared/lib/utils";
 
@@ -154,15 +165,17 @@ describe("cn", () => {
 });
 `;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/shared/lib/__tests__/utils.test.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_RESTRICTED_SYNTAX,
+    );
   });
 
-  it("회귀 — home.spec.ts는 위반 0건이다", async () => {
+  it("회귀 — home.spec.ts는 no-restricted-syntax가 안 걸린다", async () => {
     const code = `import { expect, test } from "@playwright/test";
 
 test("기본 페이지가 뜨고 핵심 텍스트가 보인다", async ({ page }) => {
@@ -173,8 +186,10 @@ test("기본 페이지가 뜨고 핵심 텍스트가 보인다", async ({ page }
 });
 `;
 
-    const result = await lintFixture(code, "tests/e2e/home.spec.ts");
+    const violations = await violationsOf(code, "tests/e2e/home.spec.ts");
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_RESTRICTED_SYNTAX,
+    );
   });
 });

--- a/tests/lint/relative-import.test.ts
+++ b/tests/lint/relative-import.test.ts
@@ -1,79 +1,82 @@
-import path from "node:path";
-import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { violationsOf } from "@tests/lint/rule-check";
 
-async function lintFixture(code: string, filePath: string) {
-  const eslint = new ESLint({ overrideConfigFile: "eslint.config.mjs" });
-  const [result] = await eslint.lintText(code, {
-    filePath: path.join(process.cwd(), filePath),
-  });
-  return result;
-}
+const NO_RESTRICTED_IMPORTS = "no-restricted-imports";
 
 describe("규칙1 — 상대 경로 import 금지", () => {
   it("@tests alias로 tests/ 를 가리키면 통과한다", async () => {
     const code = `import { createGuestClient } from "@tests/integration/supabase";\n\nexport const client = createGuestClient;\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/dals/__tests__/profile.integration.test.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
   });
 
   it("깊은 상대 경로로 tests/ 를 가리키면 걸린다", async () => {
     const code = `import { createGuestClient } from "../../../../../tests/integration/supabase";\n\nexport const client = createGuestClient;\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/dals/__tests__/profile.integration.test.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
   });
 
   it("같은 폴더를 가리키는 ./ 상대 import가 걸린다", async () => {
     const code = `import { x } from "./x";\n\nexport const value = x;\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/profile.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
   });
 
   it("상위 폴더를 가리키는 ../ 상대 import가 걸린다", async () => {
     const code = `import { y } from "../y";\n\nexport const value = y;\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/profile.ts",
     );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
   });
 
   it("layout.tsx의 ./providers 상대 import가 걸린다", async () => {
     const code = `import { Providers } from "./providers";\nimport "./globals.css";\n\nexport const value = Providers;\n`;
 
-    const result = await lintFixture(code, "src/app/layout.tsx");
-    const providersLineErrors = result.messages.filter(
-      (message) => message.severity === 2 && message.line === 1,
+    const violations = await violationsOf(code, "src/app/layout.tsx");
+    const providersLine = violations.filter(
+      (violation) =>
+        violation.ruleId === NO_RESTRICTED_IMPORTS && violation.line === 1,
     );
 
-    expect(providersLineErrors.length).toBeGreaterThan(0);
+    expect(providersLine.length).toBeGreaterThan(0);
   });
 
   it("layout.tsx의 ./globals.css 상대 import가 걸린다", async () => {
     const code = `import { Providers } from "./providers";\nimport "./globals.css";\n\nexport const value = Providers;\n`;
 
-    const result = await lintFixture(code, "src/app/layout.tsx");
-    const globalsCssLineErrors = result.messages.filter(
-      (message) => message.severity === 2 && message.line === 2,
+    const violations = await violationsOf(code, "src/app/layout.tsx");
+    const globalsCssLine = violations.filter(
+      (violation) =>
+        violation.ruleId === NO_RESTRICTED_IMPORTS && violation.line === 2,
     );
 
-    expect(globalsCssLineErrors.length).toBeGreaterThan(0);
+    expect(globalsCssLine.length).toBeGreaterThan(0);
   });
 });

--- a/tests/lint/rule-check.ts
+++ b/tests/lint/rule-check.ts
@@ -1,0 +1,41 @@
+import path from "node:path";
+import { ESLint } from "eslint";
+
+export type Violation = { ruleId: string; line: number; message: string };
+
+const overrideConfigFile = "eslint.config.mjs";
+
+const reporter = new ESLint({ overrideConfigFile });
+const fixer = new ESLint({ overrideConfigFile, fix: true });
+
+function resolveFixturePath(filePath: string) {
+  return path.join(process.cwd(), filePath);
+}
+
+await reporter.calculateConfigForFile(resolveFixturePath("src/warm-up.tsx"));
+
+export async function violationsOf(
+  code: string,
+  filePath: string,
+): Promise<Violation[]> {
+  const [result] = await reporter.lintText(code, {
+    filePath: resolveFixturePath(filePath),
+  });
+
+  return result.messages.map((message) => ({
+    ruleId: message.ruleId ?? "",
+    line: message.line,
+    message: message.message,
+  }));
+}
+
+export async function fixedCode(
+  code: string,
+  filePath: string,
+): Promise<string> {
+  const [result] = await fixer.lintText(code, {
+    filePath: resolveFixturePath(filePath),
+  });
+
+  return result.output ?? code;
+}

--- a/tests/lint/tailwind-default-palette.test.ts
+++ b/tests/lint/tailwind-default-palette.test.ts
@@ -1,44 +1,42 @@
-import path from "node:path";
-import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { violationsOf } from "@tests/lint/rule-check";
 
-async function lintClassName(className: string) {
-  const eslint = new ESLint({ overrideConfigFile: "eslint.config.mjs" });
+const NO_DEFAULT_PALETTE_CLASS = "house/no-default-palette-class";
+
+async function ruleIdsOfClassName(className: string) {
   const code = `export function Fixture() {\n  return <div className="${className}" />;\n}\n`;
-  const [result] = await eslint.lintText(code, {
-    filePath: path.join(process.cwd(), "src/shared/ui/fixture.tsx"),
-  });
-  return result;
+  const violations = await violationsOf(code, "src/shared/ui/fixture.tsx");
+  return violations.map((violation) => violation.ruleId);
 }
 
 describe("규칙5 — Tailwind 기본 팔레트 유틸리티", () => {
-  it("text-warning-500은 우리 팔레트 이름이라 통과한다", async () => {
-    const result = await lintClassName("text-warning-500");
+  it("text-warning-500은 우리 팔레트 이름이라 house/no-default-palette-class가 안 걸린다", async () => {
+    const ruleIds = await ruleIdsOfClassName("text-warning-500");
 
-    expect(result.errorCount).toBe(0);
+    expect(ruleIds).not.toContain(NO_DEFAULT_PALETTE_CLASS);
   });
 
-  it("bg-neutral-500은 우리 팔레트 이름이라 통과한다", async () => {
-    const result = await lintClassName("bg-neutral-500");
+  it("bg-neutral-500은 우리 팔레트 이름이라 house/no-default-palette-class가 안 걸린다", async () => {
+    const ruleIds = await ruleIdsOfClassName("bg-neutral-500");
 
-    expect(result.errorCount).toBe(0);
+    expect(ruleIds).not.toContain(NO_DEFAULT_PALETTE_CLASS);
   });
 
-  it("bg-red-500은 우리 팔레트에 없어 걸린다", async () => {
-    const result = await lintClassName("bg-red-500");
+  it("bg-red-500은 우리 팔레트에 없어 house/no-default-palette-class가 걸린다", async () => {
+    const ruleIds = await ruleIdsOfClassName("bg-red-500");
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(ruleIds).toContain(NO_DEFAULT_PALETTE_CLASS);
   });
 
-  it("text-gray-600은 우리 팔레트에 없어 걸린다", async () => {
-    const result = await lintClassName("text-gray-600");
+  it("text-gray-600은 우리 팔레트에 없어 house/no-default-palette-class가 걸린다", async () => {
+    const ruleIds = await ruleIdsOfClassName("text-gray-600");
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(ruleIds).toContain(NO_DEFAULT_PALETTE_CLASS);
   });
 
-  it("bg-slate-100은 우리 팔레트에 없어 걸린다", async () => {
-    const result = await lintClassName("bg-slate-100");
+  it("bg-slate-100은 우리 팔레트에 없어 house/no-default-palette-class가 걸린다", async () => {
+    const ruleIds = await ruleIdsOfClassName("bg-slate-100");
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(ruleIds).toContain(NO_DEFAULT_PALETTE_CLASS);
   });
 });

--- a/tests/lint/tsx-dumb-ui.test.ts
+++ b/tests/lint/tsx-dumb-ui.test.ts
@@ -1,114 +1,133 @@
-import path from "node:path";
-import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { violationsOf } from "@tests/lint/rule-check";
 
-async function lintFixture(code: string, filePath: string) {
-  const eslint = new ESLint({ overrideConfigFile: "eslint.config.mjs" });
-  const [result] = await eslint.lintText(code, {
-    filePath: path.join(process.cwd(), filePath),
-  });
-  return result;
-}
+const DUMB_UI = "house/dumb-ui";
 
 describe("규칙9 — .tsx는 더미 UI", () => {
   it(".tsx에서 @supabase/supabase-js를 import하면 걸린다", async () => {
     const code = `import { createClient } from "@supabase/supabase-js";\n\nexport function Fixture() {\n  createClient("url", "key");\n  return null;\n}\n`;
 
-    const result = await lintFixture(code, "src/screens/home/ui/fixture.tsx");
+    const violations = await violationsOf(
+      code,
+      "src/screens/home/ui/fixture.tsx",
+    );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(DUMB_UI);
   });
 
   it(".tsx에서 fetch(...)를 호출하면 걸린다", async () => {
     const code = `export function Fixture() {\n  fetch("/api/profile");\n  return null;\n}\n`;
 
-    const result = await lintFixture(code, "src/screens/home/ui/fixture.tsx");
+    const violations = await violationsOf(
+      code,
+      "src/screens/home/ui/fixture.tsx",
+    );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(DUMB_UI);
   });
 
   it(".tsx에서 useQuery를 호출하면 걸린다", async () => {
     const code = `import { useQuery } from "@tanstack/react-query";\n\nexport function Fixture() {\n  useQuery({ queryKey: ["x"], queryFn: async () => null });\n  return null;\n}\n`;
 
-    const result = await lintFixture(code, "src/screens/home/ui/fixture.tsx");
+    const violations = await violationsOf(
+      code,
+      "src/screens/home/ui/fixture.tsx",
+    );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(DUMB_UI);
   });
 
   it(".tsx에서 useMutation을 호출하면 걸린다", async () => {
     const code = `import { useMutation } from "@tanstack/react-query";\n\nexport function Fixture() {\n  useMutation({ mutationFn: async () => null });\n  return null;\n}\n`;
 
-    const result = await lintFixture(code, "src/screens/home/ui/fixture.tsx");
+    const violations = await violationsOf(
+      code,
+      "src/screens/home/ui/fixture.tsx",
+    );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(DUMB_UI);
   });
 
   it(".tsx에서 useSuspenseQuery를 호출하면 걸린다", async () => {
     const code = `import { useSuspenseQuery } from "@tanstack/react-query";\n\nexport function Fixture() {\n  useSuspenseQuery({ queryKey: ["x"], queryFn: async () => null });\n  return null;\n}\n`;
 
-    const result = await lintFixture(code, "src/screens/home/ui/fixture.tsx");
+    const violations = await violationsOf(
+      code,
+      "src/screens/home/ui/fixture.tsx",
+    );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(DUMB_UI);
   });
 
   it("alias로 이름을 바꿔 useQuery를 불러도 걸린다", async () => {
     const code = `import { useQuery as useProfileQuery } from "@tanstack/react-query";\n\nexport function Fixture() {\n  useProfileQuery({ queryKey: ["x"], queryFn: async () => null });\n  return null;\n}\n`;
 
-    const result = await lintFixture(code, "src/screens/home/ui/fixture.tsx");
+    const violations = await violationsOf(
+      code,
+      "src/screens/home/ui/fixture.tsx",
+    );
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(DUMB_UI);
   });
 
   it(".ts 파일의 @supabase/supabase-js import는 통과한다", async () => {
     const code = `import { createClient } from "@supabase/supabase-js";\n\nexport function load() {\n  return createClient("url", "key");\n}\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/dals/fixture.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      DUMB_UI,
+    );
   });
 
   it(".ts 파일의 fetch(...) 호출은 통과한다", async () => {
     const code = `export function load() {\n  return fetch("/api/profile");\n}\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/dals/fixture.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      DUMB_UI,
+    );
   });
 
   it(".ts 파일의 useQuery 호출은 통과한다", async () => {
     const code = `import { useQuery } from "@tanstack/react-query";\n\nexport function useLoad() {\n  return useQuery({ queryKey: ["x"], queryFn: async () => null });\n}\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/dals/fixture.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      DUMB_UI,
+    );
   });
 
   it("src/app/providers.tsx 경로의 @supabase/* import는 예외로 통과한다", async () => {
     const code = `import { createClient } from "@supabase/supabase-js";\n\nexport function Providers() {\n  createClient("url", "key");\n  return null;\n}\n`;
 
-    const result = await lintFixture(code, "src/app/providers.tsx");
+    const violations = await violationsOf(code, "src/app/providers.tsx");
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      DUMB_UI,
+    );
   });
 
   it("src/shared/ui/의 fetch(...) 호출은 예외가 아니라 걸린다", async () => {
     const code = `export function Fixture() {\n  fetch("/api/profile");\n  return null;\n}\n`;
 
-    const result = await lintFixture(code, "src/shared/ui/fixture.tsx");
+    const violations = await violationsOf(code, "src/shared/ui/fixture.tsx");
 
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(DUMB_UI);
   });
 
-  it("회귀 — page.tsx는 위반 0건이다", async () => {
+  it("회귀 — page.tsx는 house/dumb-ui가 안 걸린다", async () => {
     const code = `import { Button } from "@/shared/ui/button";
 import {
   Card,
@@ -135,12 +154,14 @@ export default function Home() {
 }
 `;
 
-    const result = await lintFixture(code, "src/app/page.tsx");
+    const violations = await violationsOf(code, "src/app/page.tsx");
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      DUMB_UI,
+    );
   });
 
-  it("회귀 — layout.tsx는 위반 0건이다", async () => {
+  it("회귀 — layout.tsx는 house/dumb-ui가 안 걸린다", async () => {
     const code = `import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Providers } from "@/app/providers";
@@ -175,12 +196,14 @@ export default function RootLayout({ children }: LayoutProps<"/">) {
 }
 `;
 
-    const result = await lintFixture(code, "src/app/layout.tsx");
+    const violations = await violationsOf(code, "src/app/layout.tsx");
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      DUMB_UI,
+    );
   });
 
-  it("회귀 — providers.tsx는 위반 0건이다", async () => {
+  it("회귀 — providers.tsx는 house/dumb-ui가 안 걸린다", async () => {
     const code = `"use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -195,12 +218,14 @@ export function Providers({ children }: { children: React.ReactNode }) {
 }
 `;
 
-    const result = await lintFixture(code, "src/app/providers.tsx");
+    const violations = await violationsOf(code, "src/app/providers.tsx");
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      DUMB_UI,
+    );
   });
 
-  it("회귀 — button.tsx는 위반 0건이다", async () => {
+  it("회귀 — button.tsx는 house/dumb-ui가 안 걸린다", async () => {
     const code = `import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -261,12 +286,14 @@ function Button({
 export { Button, buttonVariants }
 `;
 
-    const result = await lintFixture(code, "src/shared/ui/button.tsx");
+    const violations = await violationsOf(code, "src/shared/ui/button.tsx");
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      DUMB_UI,
+    );
   });
 
-  it("회귀 — card.tsx는 위반 0건이다", async () => {
+  it("회귀 — card.tsx는 house/dumb-ui가 안 걸린다", async () => {
     const code = `import * as React from "react"
 
 import { cn } from "@/shared/lib/utils"
@@ -372,8 +399,10 @@ export {
 }
 `;
 
-    const result = await lintFixture(code, "src/shared/ui/card.tsx");
+    const violations = await violationsOf(code, "src/shared/ui/card.tsx");
 
-    expect(result.errorCount).toBe(0);
+    expect(violations.map((violation) => violation.ruleId)).not.toContain(
+      DUMB_UI,
+    );
   });
 });

--- a/tests/lint/unused-imports.test.ts
+++ b/tests/lint/unused-imports.test.ts
@@ -1,45 +1,47 @@
-import path from "node:path";
-import { ESLint } from "eslint";
 import { describe, expect, it } from "vitest";
+import { fixedCode, violationsOf } from "@tests/lint/rule-check";
 
-async function lintFixture(code: string, filePath: string, fix = false) {
-  const eslint = new ESLint({ overrideConfigFile: "eslint.config.mjs", fix });
-  const [result] = await eslint.lintText(code, {
-    filePath: path.join(process.cwd(), filePath),
-  });
-  return result;
+const NO_UNUSED_IMPORTS = "unused-imports/no-unused-imports";
+const NO_UNUSED_VARS = "unused-imports/no-unused-vars";
+const CONSISTENT_TYPE_IMPORTS = "@typescript-eslint/consistent-type-imports";
+const UNUSED_IMPORT_RULES = [
+  NO_UNUSED_IMPORTS,
+  NO_UNUSED_VARS,
+  CONSISTENT_TYPE_IMPORTS,
+];
+
+function unusedImportRuleIds(ruleIds: string[]) {
+  return ruleIds.filter((ruleId) => UNUSED_IMPORT_RULES.includes(ruleId));
 }
 
 describe("규칙14 — 미사용 import와 import type", () => {
-  it("안 쓰는 named import가 걸리고, --fix 후 그 줄이 사라진다", async () => {
+  it("안 쓰는 named import에 unused-imports/no-unused-imports가 걸리고, --fix 후 그 줄이 사라진다", async () => {
     const code = `import { unused } from "react";\n\nexport const value = 1;\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/entities/profile/model/fixture.ts",
     );
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_UNUSED_IMPORTS,
+    );
 
-    const fixedResult = await lintFixture(
+    const output = await fixedCode(
       code,
       "src/entities/profile/model/fixture.ts",
-      true,
     );
-    const fixedCode = fixedResult.output ?? code;
 
-    expect(fixedCode).not.toContain("unused");
+    expect(output).not.toContain("unused");
   });
 
   it("일부만 안 쓰는 named import는 --fix 후 쓰는 것만 남는다", async () => {
     const code = `import { used, unused } from "react";\n\nexport const value = used;\n`;
 
-    const fixedResult = await lintFixture(
+    const output = await fixedCode(
       code,
       "src/entities/profile/model/fixture.ts",
-      true,
     );
-    const fixedCode = fixedResult.output ?? code;
-    const importLine = fixedCode.match(/import \{([^}]+)\} from "react";/);
+    const importLine = output.match(/import \{([^}]+)\} from "react";/);
 
     expect(importLine).not.toBeNull();
     const specifiers = (importLine?.[1] ?? "")
@@ -50,39 +52,41 @@ describe("규칙14 — 미사용 import와 import type", () => {
     expect(specifiers).toEqual(["used"]);
   });
 
-  it("값 자리에서 안 쓰이고 타입 자리에서만 쓰는 import는 --fix 후 import type으로 바뀐다", async () => {
+  it("값 자리에서 안 쓰이고 타입 자리에서만 쓰는 import는 @typescript-eslint/consistent-type-imports가 걸리고, --fix 후 import type으로 바뀐다", async () => {
     const code = `import { Profile } from "@/entities/profile/model/profile";\n\nexport function show(profile: Profile) {\n  return profile;\n}\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/features/attendance/model/fixture.ts",
     );
-    expect(result.errorCount).toBeGreaterThan(0);
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      CONSISTENT_TYPE_IMPORTS,
+    );
 
-    const fixedResult = await lintFixture(
+    const output = await fixedCode(
       code,
       "src/features/attendance/model/fixture.ts",
-      true,
     );
-    const fixedCode = fixedResult.output ?? code;
 
-    expect(fixedCode).toMatch(
+    expect(output).toMatch(
       /import\s+type\s+\{\s*Profile\s*\}|import\s+\{\s*type\s+Profile\s*\}/,
     );
   });
 
-  it("이미 올바른 import { x, type Y }는 위반 0건이다", async () => {
+  it("이미 올바른 import { x, type Y }는 규칙14의 어느 규칙도 안 걸린다", async () => {
     const code = `import { useState, type ReactNode } from "react";\n\nexport function useThing(): ReactNode {\n  const [value] = useState<ReactNode>(null);\n  return value;\n}\n`;
 
-    const result = await lintFixture(
+    const violations = await violationsOf(
       code,
       "src/features/attendance/model/fixture.ts",
     );
 
-    expect(result.errorCount).toBe(0);
+    expect(
+      unusedImportRuleIds(violations.map((violation) => violation.ruleId)),
+    ).toEqual([]);
   });
 
-  it("회귀 — utils.ts는 이미 inline type을 쓰고 있어 위반 0건이다", async () => {
+  it("회귀 — utils.ts는 이미 inline type을 쓰고 있어 규칙14의 어느 규칙도 안 걸린다", async () => {
     const code = `import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
@@ -91,12 +95,14 @@ export function cn(...inputs: ClassValue[]) {
 }
 `;
 
-    const result = await lintFixture(code, "src/shared/lib/utils.ts");
+    const violations = await violationsOf(code, "src/shared/lib/utils.ts");
 
-    expect(result.errorCount).toBe(0);
+    expect(
+      unusedImportRuleIds(violations.map((violation) => violation.ruleId)),
+    ).toEqual([]);
   });
 
-  it("회귀 — button.tsx는 이미 inline type을 쓰고 있어 위반 0건이다", async () => {
+  it("회귀 — button.tsx는 이미 inline type을 쓰고 있어 규칙14의 어느 규칙도 안 걸린다", async () => {
     const code = `import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -128,8 +134,10 @@ function Button({
 export { Button, buttonVariants }
 `;
 
-    const result = await lintFixture(code, "src/shared/ui/button.tsx");
+    const violations = await violationsOf(code, "src/shared/ui/button.tsx");
 
-    expect(result.errorCount).toBe(0);
+    expect(
+      unusedImportRuleIds(violations.map((violation) => violation.ruleId)),
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## 왜

`tests/lint/`의 테스트는 규칙이 규칙대로 걸리는지 증명하지 못했다. `errorCount`를 보는 단언이 66개, `ruleId`를 보는 단언이 0개였다. 어느 규칙이 걸렸는지 테스트가 모르니, 규칙 하나를 설정에서 빼도 다른 규칙이 대신 걸려주면 초록불이 켜졌다.

`bg-[#6E4F39]`가 그 자리다. 이 클래스는 `house/no-arbitrary-class-values`와 `house/no-color-literals` 둘 다 걸리는데 단언은 `errorCount > 0` 하나뿐이었다.

여기에 같은 8줄짜리 helper가 10개 파일에 복사돼 있었고, `new ESLint(...)`를 만드는 자리가 11곳이라 단언마다 인스턴스가 새로 태어났다.

## 무엇을 정했나

**하네스 interface는 둘로 끝낸다.** `violationsOf(code, filePath)`와 `fixedCode(code, filePath)`. 나머지는 모듈 안에 숨긴다. `filePath`는 저장소 기준 상대 경로를 받아 모듈이 `process.cwd()`와 합치니, 호출자가 `path.join`을 다시 쓸 일이 없다.

**warning도 돌려준다.** `severity === 2`만 걸러낼 수도 있었지만 그러면 지금 warn으로 잡힌 `unused-imports/no-unused-vars`가 하네스 눈에 안 보인다. 규칙이 안 보이는 상태가 바로 이번에 없애려던 것이라 severity로 자르지 않았다. `Violation`에 severity 필드가 없으니, 자르는 순간 그 사실이 호출자에게 안 보이는 것도 이유다. 통과 케이스는 어차피 ruleId로 거르므로 다른 규칙의 warning이 섞여도 판정이 흔들리지 않는다.

**ESLint 인스턴스는 모듈 스코프에 둘만 둔다.** 평범한 것 하나, `fix: true` 하나. 여기에 모듈 import 시점에 `calculateConfigForFile`을 한 번 부른다. `eslint.config.mjs` 로드가 이 저장소에서 6초쯤 걸리는데, 이 비용은 프로세스당 한 번이면 된다. 첫 테스트가 그 6초를 자기 시계로 떠안으면 vitest 기본 타임아웃 5초에 걸려 첫 테스트만 실패한다. import 단계로 옮기면 어느 테스트도 이 값을 물지 않는다.

**단언은 케이스별 ruleId로 좁혔다.** 걸리는 케이스는 「이 규칙이 걸린다」, 통과 케이스는 「그 규칙이 안 걸린다」다. 규칙 둘이 함께 걸리는 규칙4와 규칙14는 해당 규칙만 추려 집합으로 비교한다. `relative-import`의 줄 단위 케이스는 `severity === 2` 대신 `ruleId`와 `Violation.line`으로 짚고, `--fix`를 보던 두 케이스는 `fixedCode()`가 받았다.

케이스는 늘리지도 줄이지도 않았다. 제목만 손봤다 — 「위반 0건이다」가 이제 사실이 아니라서 「해당 규칙이 안 걸린다」로 고쳤다.

## 하네스가 진짜로 지키는지

`eslint.config.mjs`에서 `house/no-color-literals`를 임시로 빼고 `design-token-values.test.ts`를 돌렸다.

- 기존 테스트: 15개 전부 통과. 규칙이 사라졌는데 초록불이다.
- 새 테스트: 3개 실패. `bg-[#6E4F39]`, `bg-[rgb(110,79,57)]`, `bg-[hsl(24,32%,33%)]`가 `['house/no-arbitrary-class-values']`만 받고 기대한 둘과 다르다고 잡는다.

확인 뒤 `eslint.config.mjs`는 원래대로 되돌렸고 이 PR의 diff에 남아있지 않다.

## 검증

`pnpm lint`, `pnpm format:check`, `pnpm test`(113개 전부 통과), `pnpm typecheck`까지 로컬에서 통과했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwBg5h3WAwARuPrdyK71gg
