### PR TITLE
검증이 통과만 하던 자리를 실제로 막게 고친다

### DIFF
--- a/.claude/hooks/__tests__/tdd-guard.test.ts
+++ b/.claude/hooks/__tests__/tdd-guard.test.ts
@@ -16,6 +16,33 @@ function write(relative: string, body: string) {
   return absolute;
 }
 
+function spawn(
+  hook: string,
+  relative: string,
+  content: string,
+  options: { env?: NodeJS.ProcessEnv; timeout?: number } = {},
+) {
+  return spawnSync("python3", [join(hooksDir, hook)], {
+    input: JSON.stringify({
+      tool_name: "Write",
+      tool_input: { file_path: join(projectDir, relative), content },
+    }),
+    env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir, ...options.env },
+    encoding: "utf8",
+    timeout: options.timeout,
+  });
+}
+
+function fifo(relative: string) {
+  const absolute = join(projectDir, relative);
+  mkdirSync(dirname(absolute), { recursive: true });
+  const made = spawnSync("mkfifo", [absolute], { encoding: "utf8" });
+  if (made.status !== 0) {
+    throw new Error(`mkfifo 실패: ${made.stderr}`);
+  }
+  return relative;
+}
+
 function run(hook: string, relative: string, content: string) {
   const result = spawnSync("python3", [join(hooksDir, hook)], {
     input: JSON.stringify({
@@ -179,5 +206,37 @@ describe("e2e 훅", () => {
     expect(
       run("tdd-guard-e2e.py", "src/entities/cart/models/cart.ts", ""),
     ).toBe(allowed);
+  });
+});
+
+describe("훅이 서 있는 자리", () => {
+  it("모듈 탐색 경로가 잠겨도 판정이 살아 있다", () => {
+    const result = spawn(
+      "tdd-guard-unit.py",
+      "src/entities/locked/model/locked.ts",
+      "export function locked() {}",
+      { env: { PYTHONSAFEPATH: "1" } },
+    );
+
+    expect(result.status).toBe(blocked);
+  });
+
+  it("e2e 훅은 판정에 안 쓰는 파일을 읽지 않는다", () => {
+    const result = spawn("tdd-guard-e2e.py", fifo("src/app/page.tsx"), "", {
+      timeout: 5_000,
+    });
+
+    expect(result.status).toBe(allowed);
+  });
+
+  it("유닛 훅은 경로에서 이미 걸러낸 파일을 읽지 않는다", () => {
+    const result = spawn(
+      "tdd-guard-unit.py",
+      fifo("src/shared/ui/skipped.ts"),
+      "export function skipped() {}",
+      { timeout: 5_000 },
+    );
+
+    expect(result.status).toBe(allowed);
   });
 });

--- a/.claude/hooks/guard.py
+++ b/.claude/hooks/guard.py
@@ -26,21 +26,24 @@ def _relative_path(raw_path):
         return None
 
 
-def _content(tool_input, relative_path):
-    incoming = "\n".join(str(tool_input.get(key, "")) for key in CONTENT_KEYS)
-    if relative_path.startswith(".."):
-        return incoming
-    try:
-        with open(
-            os.path.join(ROOT, relative_path), encoding="utf-8", errors="ignore"
-        ) as handle:
-            return handle.read()
-    except OSError:
-        return incoming
+def _reader(tool_input, relative_path):
+    def read():
+        incoming = "\n".join(str(tool_input.get(key, "")) for key in CONTENT_KEYS)
+        if relative_path.startswith(".."):
+            return incoming
+        try:
+            with open(
+                os.path.join(ROOT, relative_path), encoding="utf-8", errors="ignore"
+            ) as handle:
+                return handle.read()
+        except OSError:
+            return incoming
+
+    return read
 
 
 def guard(verdict):
-    """verdict(relative_path, content) -> 막는 이유 문자열 또는 None"""
+    """verdict(relative_path, read) -> 막는 이유 문자열 또는 None"""
     payload = _payload()
     if payload is None:
         sys.exit(0)
@@ -54,7 +57,7 @@ def guard(verdict):
     if relative_path is None:
         sys.exit(0)
 
-    reason = verdict(relative_path, _content(tool_input, relative_path))
+    reason = verdict(relative_path, _reader(tool_input, relative_path))
     if not reason:
         sys.exit(0)
 

--- a/.claude/hooks/tdd-guard-e2e.py
+++ b/.claude/hooks/tdd-guard-e2e.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from guard import exists, guard
 
@@ -25,7 +28,7 @@ def spec_name(path):
     return None
 
 
-def verdict(path, _content):
+def verdict(path, _read):
     name = spec_name(path)
     if not name:
         return None

--- a/.claude/hooks/tdd-guard-unit.py
+++ b/.claude/hooks/tdd-guard-unit.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 import os
 import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from guard import exists, guard
 
@@ -16,7 +19,7 @@ SKIP_PREFIXES = ("src/app/", "src/shared/ui/")
 PAIR_SUFFIXES = (".test.ts", ".integration.test.ts")
 
 
-def verdict(path, content):
+def verdict(path, read):
     if not path.startswith("src/") or not path.endswith(".ts"):
         return None
     if path.endswith(".d.ts") or path.endswith(".test.ts") or "/__tests__/" in path:
@@ -24,7 +27,7 @@ def verdict(path, content):
     if path.startswith(SKIP_PREFIXES):
         return None
 
-    if not EXECUTABLE_EXPORT.search(content):
+    if not EXECUTABLE_EXPORT.search(read()):
         return None
 
     directory, filename = os.path.split(path)

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -6,7 +6,7 @@
 
 `docs/design-system/`이 섰다. `tokens.md`(팔레트 6계열 × 11단계, 역할 토큰 매핑, 타이포·스페이싱·라운딩·그림자·모션, Tailwind 4 `@theme` 전문)를 정본으로 두고, `foundation/`의 색·타이포·스페이싱과 형태·모션 넷과 `writing.md`·`components.md`·`README.md`가 그 정본을 이름으로만 부른다. 브랜드 색은 절제 규칙(버튼 한 자리) 아래 있고, warning은 brand와 밝기가 거의 같아 글자색으로는 안 쓴다. 라이트·다크 두 모드는 의미 매핑 표 하나로 같이 덮인다.
 
-규칙 열넷이 `eslint.config.mjs`와 Prettier로 CI에서 돈다. 경계(상대 경로·역방향 레이어·같은 층 다른 슬라이스 import), 디자인 값(하드코딩 색·크기, Tailwind 기본 팔레트), `.tsx` 더미 UI 강제, 테스트 `.only` 금지, import·Tailwind 클래스 순서, `console` 제한, 미사용 import 정리가 전부 잡힌다. `src/app/globals.css`는 `tokens.md` 8절 전문으로 교체됐고 대조 로직이 `src/shared/lib/token-css-parity.ts`에 있다. `@tests/*` alias가 생겨 `tests/`를 가리키는 상대 경로가 없어졌다. CI는 `lint → format:check → test → integration → build → e2e` 여섯 단계다.
+규칙 열넷이 `eslint.config.mjs`와 Prettier로 CI에서 돈다. 경계(상대 경로·역방향 레이어·같은 층 다른 슬라이스 import), 디자인 값(하드코딩 색·크기, Tailwind 기본 팔레트), `.tsx` 더미 UI 강제, 테스트 `.only` 금지, import·Tailwind 클래스 순서, `console` 제한, 미사용 import 정리가 전부 잡힌다. `src/app/globals.css`는 `tokens.md` 8절 전문으로 교체됐고 대조 로직이 `tests/lint/token-css-parity.ts`에 있다. `@tests/*` alias가 생겨 `tests/`를 가리키는 상대 경로가 없어졌다. CI는 `lint → format:check → test → integration → build → e2e` 여섯 단계다.
 
 생산 스폰이 같은 실패를 세 번째 만나면 손을 떼고 총괄이 `codex-rescue`(`--model gpt-5.6-sol`)로 넘기는 3회 규칙이 `CLAUDE.md`와 `.claude/agents/implementer.md`에 얹혔다. 셈은 구현자가 하고 넘기는 판정은 총괄이 한다.
 

--- a/tests/lint/design-token-values.test.ts
+++ b/tests/lint/design-token-values.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { violationsOf } from "@tests/lint/rule-check";
+import { errorsOf, violationsOf } from "@tests/lint/rule-check";
 
 const NO_ARBITRARY_CLASS_VALUES = "house/no-arbitrary-class-values";
 const NO_COLOR_LITERALS = "house/no-color-literals";
@@ -70,7 +70,7 @@ describe("규칙4 — 하드코딩한 색과 크기", () => {
     );
   });
 
-  it("회귀 — text-[0.8rem]이 토큰 유틸로 바뀐 button.tsx는 규칙4의 어느 규칙도 안 걸린다", async () => {
+  it("회귀 — text-[0.8rem]이 토큰 유틸로 바뀐 button.tsx는 어느 규칙도 안 걸린다", async () => {
     const code = `import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -113,9 +113,8 @@ function Button({
 
 export { Button, buttonVariants }
 `;
-    const violations = await violationsOf(code, "src/shared/ui/button.tsx");
-    const ruleIds = violations.map((violation) => violation.ruleId);
+    const errors = await errorsOf(code, "src/shared/ui/button.tsx");
 
-    expect(designTokenRuleIds(ruleIds)).toEqual([]);
+    expect(errors).toEqual([]);
   });
 });

--- a/tests/lint/import-order.test.ts
+++ b/tests/lint/import-order.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fixedCode, violationsOf } from "@tests/lint/rule-check";
+import { errorsOf, fixedCode, violationsOf } from "@tests/lint/rule-check";
 
 const IMPORT_ORDER = "import/order";
 
@@ -70,7 +70,7 @@ describe("규칙11 — import 순서", () => {
     );
   });
 
-  it("회귀 — alias로 고친 layout.tsx는 import/order가 안 걸린다", async () => {
+  it("회귀 — alias로 고친 layout.tsx는 어느 규칙도 안 걸린다", async () => {
     const code = `import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Providers } from "@/app/providers";
@@ -90,10 +90,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 `;
 
-    const violations = await violationsOf(code, "src/app/layout.tsx");
+    const errors = await errorsOf(code, "src/app/layout.tsx");
 
-    expect(violations.map((violation) => violation.ruleId)).not.toContain(
-      IMPORT_ORDER,
-    );
+    expect(errors).toEqual([]);
   });
 });

--- a/tests/lint/no-console.test.ts
+++ b/tests/lint/no-console.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { violationsOf } from "@tests/lint/rule-check";
+import { errorsOf, violationsOf } from "@tests/lint/rule-check";
 
 const NO_CONSOLE = "no-console";
 
@@ -82,7 +82,7 @@ describe("규칙13 — console", () => {
     );
   });
 
-  it("회귀 — 지금 src/에는 console 호출이 없어 no-console이 안 걸린다", async () => {
+  it("회귀 — 지금 src/의 utils.ts는 어느 규칙도 안 걸린다", async () => {
     const code = `import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
@@ -91,10 +91,8 @@ export function cn(...inputs: ClassValue[]) {
 }
 `;
 
-    const violations = await violationsOf(code, "src/shared/lib/utils.ts");
+    const errors = await errorsOf(code, "src/shared/lib/utils.ts");
 
-    expect(violations.map((violation) => violation.ruleId)).not.toContain(
-      NO_CONSOLE,
-    );
+    expect(errors).toEqual([]);
   });
 });

--- a/tests/lint/no-focused-tests.test.ts
+++ b/tests/lint/no-focused-tests.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { violationsOf } from "@tests/lint/rule-check";
+import { errorsOf, violationsOf } from "@tests/lint/rule-check";
 
 const NO_RESTRICTED_SYNTAX = "no-restricted-syntax";
 
@@ -99,7 +99,7 @@ describe("규칙10 — 집중 실행 표시", () => {
     );
   });
 
-  it("회귀 — profile.integration.test.ts는 no-restricted-syntax가 안 걸린다", async () => {
+  it("회귀 — profile.integration.test.ts는 어느 규칙도 안 걸린다", async () => {
     const code = `import { describe, expect, it } from "vitest";
 import {
   createGuestClient,
@@ -136,17 +136,15 @@ describe("프로필 접근 권한", () => {
 });
 `;
 
-    const violations = await violationsOf(
+    const errors = await errorsOf(
       code,
       "src/entities/profile/dals/__tests__/profile.integration.test.ts",
     );
 
-    expect(violations.map((violation) => violation.ruleId)).not.toContain(
-      NO_RESTRICTED_SYNTAX,
-    );
+    expect(errors).toEqual([]);
   });
 
-  it("회귀 — utils.test.ts는 no-restricted-syntax가 안 걸린다", async () => {
+  it("회귀 — utils.test.ts는 어느 규칙도 안 걸린다", async () => {
     const code = `import { describe, expect, it } from "vitest";
 import { cn } from "@/shared/lib/utils";
 
@@ -165,17 +163,15 @@ describe("cn", () => {
 });
 `;
 
-    const violations = await violationsOf(
+    const errors = await errorsOf(
       code,
       "src/shared/lib/__tests__/utils.test.ts",
     );
 
-    expect(violations.map((violation) => violation.ruleId)).not.toContain(
-      NO_RESTRICTED_SYNTAX,
-    );
+    expect(errors).toEqual([]);
   });
 
-  it("회귀 — home.spec.ts는 no-restricted-syntax가 안 걸린다", async () => {
+  it("회귀 — home.spec.ts는 어느 규칙도 안 걸린다", async () => {
     const code = `import { expect, test } from "@playwright/test";
 
 test("기본 페이지가 뜨고 핵심 텍스트가 보인다", async ({ page }) => {
@@ -186,10 +182,8 @@ test("기본 페이지가 뜨고 핵심 텍스트가 보인다", async ({ page }
 });
 `;
 
-    const violations = await violationsOf(code, "tests/e2e/home.spec.ts");
+    const errors = await errorsOf(code, "tests/e2e/home.spec.ts");
 
-    expect(violations.map((violation) => violation.ruleId)).not.toContain(
-      NO_RESTRICTED_SYNTAX,
-    );
+    expect(errors).toEqual([]);
   });
 });

--- a/tests/lint/pre-commit.test.ts
+++ b/tests/lint/pre-commit.test.ts
@@ -1,0 +1,111 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const hook = path.join(process.cwd(), ".githooks/pre-commit");
+
+const blocked = 1;
+const allowed = 0;
+
+const longSecret = "A".repeat(24);
+const fakeOpenAiKey = ["sk", "-", "B".repeat(24)].join("");
+const fakeAwsKey = ["AKIA", "C".repeat(16)].join("");
+
+let repo: string;
+
+function git(...args: string[]) {
+  const result = spawnSync("git", args, { cwd: repo, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} 실패: ${result.stderr}`);
+  }
+}
+
+function stage(name: string, body: string) {
+  const file = path.join(repo, name);
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, body, "utf8");
+  git("add", "--force", name);
+}
+
+function runHook() {
+  return spawnSync("sh", [hook], { cwd: repo, encoding: "utf8" }).status;
+}
+
+function reset() {
+  git("rm", "-r", "--cached", "--ignore-unmatch", "--quiet", ".");
+}
+
+beforeAll(() => {
+  repo = mkdtempSync(path.join(tmpdir(), "pre-commit-"));
+  git("init", "--quiet");
+});
+
+afterAll(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+describe("규칙17 — 시크릿과 .env", () => {
+  it("평범한 소스 파일만 staged면 통과시킨다", () => {
+    reset();
+    stage("src/shared/lib/utils.ts", "export const answer = 42;\n");
+
+    expect(runHook()).toBe(allowed);
+  });
+
+  it(".env가 staged면 막는다", () => {
+    reset();
+    stage(".env", "SUPABASE_URL=http://localhost\n");
+
+    expect(runHook()).toBe(blocked);
+  });
+
+  it(".env.local처럼 접미사가 붙어도 막는다", () => {
+    reset();
+    stage(".env.local", "SUPABASE_URL=http://localhost\n");
+
+    expect(runHook()).toBe(blocked);
+  });
+
+  it(".env.example은 통과시킨다", () => {
+    reset();
+    stage(".env.example", "SUPABASE_URL=\n");
+
+    expect(runHook()).toBe(allowed);
+  });
+
+  it("키=값 모양의 시크릿이 staged diff에 있으면 막는다", () => {
+    reset();
+    stage("src/shared/config/env.ts", `const apiKey = "${longSecret}";\n`);
+
+    expect(runHook()).toBe(blocked);
+  });
+
+  it("password와 token도 같은 그물에 걸린다", () => {
+    reset();
+    stage("src/shared/config/env.ts", `const password = "${longSecret}";\n`);
+    expect(runHook()).toBe(blocked);
+
+    reset();
+    stage("src/shared/config/env.ts", `const token = "${longSecret}";\n`);
+    expect(runHook()).toBe(blocked);
+  });
+
+  it("실키 형태의 문자열은 이름이 무해해도 막는다", () => {
+    reset();
+    stage("docs/scratch.md", `참고: ${fakeOpenAiKey}\n`);
+    expect(runHook()).toBe(blocked);
+
+    reset();
+    stage("docs/scratch.md", `참고: ${fakeAwsKey}\n`);
+    expect(runHook()).toBe(blocked);
+  });
+
+  it("짧은 값은 시크릿으로 세지 않는다", () => {
+    reset();
+    stage("src/shared/config/env.ts", `const apiKey = "short";\n`);
+
+    expect(runHook()).toBe(allowed);
+  });
+});

--- a/tests/lint/rule-catalogue.test.ts
+++ b/tests/lint/rule-catalogue.test.ts
@@ -1,9 +1,10 @@
-import { existsSync } from "node:fs";
+import { accessSync, constants, existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { ESLint } from "eslint";
 import { beforeAll, describe, expect, it } from "vitest";
 import {
   DOCUMENTED_LINT_RULE_COUNT,
+  ENFORCED_RULE_COUNT,
   RULES,
   RULE_NUMBERS_NEVER_ASSIGNED,
   type EnforcedRule,
@@ -24,12 +25,31 @@ async function resolveConfig() {
 
 function isTurnedOn(entry: unknown) {
   const severity = Array.isArray(entry) ? entry[0] : entry;
-  return (
-    severity === 2 ||
-    severity === "error" ||
-    severity === 1 ||
-    severity === "warn"
+  return severity === 2 || severity === "error";
+}
+
+function rulesEnforcedBy(mechanism: EnforcedRule["mechanism"]) {
+  return RULES.filter((rule) => rule.mechanism === mechanism);
+}
+
+function registeredHookCommands() {
+  const settings = JSON.parse(
+    readFileSync(path.join(process.cwd(), ".claude/settings.json"), "utf8"),
   );
+
+  return (settings.hooks?.PreToolUse ?? []).flatMap(
+    (matcher: { hooks?: { command?: string }[] }) =>
+      (matcher.hooks ?? []).map((hook) => hook.command ?? ""),
+  );
+}
+
+function isExecutable(file: string) {
+  try {
+    accessSync(path.join(process.cwd(), file), constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function ruleIdsOf(mechanisms: EnforcedRule["mechanism"][]) {
@@ -62,6 +82,31 @@ describe("규칙 카탈로그", () => {
     expect(catalogued).toEqual(registered);
   });
 
+  it("훅으로 집행한다고 적은 규칙은 실제로 settings.json에 등록돼 있다", () => {
+    const commands = registeredHookCommands().join("\n");
+    const unregistered = rulesEnforcedBy("hook")
+      .map((rule) => rule.enforcedBy as string)
+      .filter((script) => !commands.includes(script));
+
+    expect(unregistered).toEqual([]);
+  });
+
+  it("pre-commit으로 집행한다고 적은 규칙은 실행 가능한 파일을 가리킨다", () => {
+    const notExecutable = rulesEnforcedBy("pre-commit")
+      .map((rule) => rule.enforcedBy as string)
+      .filter((file) => !isExecutable(file));
+
+    expect(notExecutable).toEqual([]);
+  });
+
+  it("lint가 아닌 mechanism은 집행 파일을 반드시 적는다", () => {
+    const unnamed = RULES.filter(
+      (rule) => !LINT_MECHANISMS.includes(rule.mechanism),
+    ).filter((rule) => rule.enforcedBy === null);
+
+    expect(unnamed).toEqual([]);
+  });
+
   it("카탈로그가 가리키는 테스트 파일은 디스크에 있다", () => {
     const missing = RULES.map((rule) => rule.test)
       .filter((file): file is string => file !== null)
@@ -79,10 +124,17 @@ describe("규칙 번호", () => {
     ]),
   ].sort((a, b) => a - b);
 
-  it("1부터 시작해 끊기지 않는다", () => {
-    const unbroken = Array.from({ length: numbers.length }, (_, i) => i + 1);
+  it("1부터 열일곱까지 끊김 없이 이어진다", () => {
+    const unbroken = Array.from(
+      { length: ENFORCED_RULE_COUNT },
+      (_, index) => index + 1,
+    );
 
     expect(numbers).toEqual(unbroken);
+  });
+
+  it("정체를 못 찾은 번호는 여섯·일곱·여덟 셋뿐이다", () => {
+    expect(RULE_NUMBERS_NEVER_ASSIGNED).toEqual([6, 7, 8]);
   });
 
   it("한 번호를 나눠 가진 규칙은 이름이 같고 ruleId가 서로 다르다", () => {

--- a/tests/lint/rule-check.ts
+++ b/tests/lint/rule-check.ts
@@ -1,7 +1,12 @@
 import path from "node:path";
 import { ESLint } from "eslint";
 
-export type Violation = { ruleId: string; line: number; message: string };
+export type Violation = {
+  ruleId: string;
+  line: number;
+  message: string;
+  severity: 1 | 2;
+};
 
 const overrideConfigFile = "eslint.config.mjs";
 
@@ -26,7 +31,17 @@ export async function violationsOf(
     ruleId: message.ruleId ?? "",
     line: message.line,
     message: message.message,
+    severity: message.severity === 2 ? 2 : 1,
   }));
+}
+
+export async function errorsOf(
+  code: string,
+  filePath: string,
+): Promise<Violation[]> {
+  const violations = await violationsOf(code, filePath);
+
+  return violations.filter((violation) => violation.severity === 2);
 }
 
 export async function fixedCode(

--- a/tests/lint/rules.ts
+++ b/tests/lint/rules.ts
@@ -3,10 +3,13 @@ export type EnforcedRule = {
   name: string;
   mechanism: "eslint" | "house" | "prettier" | "hook" | "pre-commit";
   ruleId: string | null;
+  enforcedBy: string | null;
   test: string | null;
 };
 
 export const DOCUMENTED_LINT_RULE_COUNT = 14;
+
+export const ENFORCED_RULE_COUNT = 17;
 
 export const RULE_NUMBERS_NEVER_ASSIGNED = [6, 7, 8];
 
@@ -16,6 +19,7 @@ export const RULES: EnforcedRule[] = [
     name: "상대 경로 import 금지",
     mechanism: "eslint",
     ruleId: "no-restricted-imports",
+    enforcedBy: null,
     test: "tests/lint/relative-import.test.ts",
   },
   {
@@ -23,6 +27,7 @@ export const RULES: EnforcedRule[] = [
     name: "FSD 역방향 import",
     mechanism: "eslint",
     ruleId: "no-restricted-imports",
+    enforcedBy: null,
     test: "tests/lint/fsd-layer-order.test.ts",
   },
   {
@@ -30,6 +35,7 @@ export const RULES: EnforcedRule[] = [
     name: "같은 층 다른 슬라이스 import",
     mechanism: "house",
     ruleId: "house/no-cross-slice-import",
+    enforcedBy: null,
     test: "tests/lint/fsd-slice-boundary.test.ts",
   },
   {
@@ -37,6 +43,7 @@ export const RULES: EnforcedRule[] = [
     name: "하드코딩한 색과 크기",
     mechanism: "house",
     ruleId: "house/no-arbitrary-class-values",
+    enforcedBy: null,
     test: "tests/lint/design-token-values.test.ts",
   },
   {
@@ -44,6 +51,7 @@ export const RULES: EnforcedRule[] = [
     name: "하드코딩한 색과 크기",
     mechanism: "house",
     ruleId: "house/no-color-literals",
+    enforcedBy: null,
     test: "tests/lint/design-token-values.test.ts",
   },
   {
@@ -51,6 +59,7 @@ export const RULES: EnforcedRule[] = [
     name: "Tailwind 기본 팔레트 유틸리티",
     mechanism: "house",
     ruleId: "house/no-default-palette-class",
+    enforcedBy: null,
     test: "tests/lint/tailwind-default-palette.test.ts",
   },
   {
@@ -58,6 +67,7 @@ export const RULES: EnforcedRule[] = [
     name: ".tsx는 더미 UI",
     mechanism: "house",
     ruleId: "house/dumb-ui",
+    enforcedBy: null,
     test: "tests/lint/tsx-dumb-ui.test.ts",
   },
   {
@@ -65,6 +75,7 @@ export const RULES: EnforcedRule[] = [
     name: "집중 실행 표시",
     mechanism: "eslint",
     ruleId: "no-restricted-syntax",
+    enforcedBy: null,
     test: "tests/lint/no-focused-tests.test.ts",
   },
   {
@@ -72,6 +83,7 @@ export const RULES: EnforcedRule[] = [
     name: "import 순서",
     mechanism: "eslint",
     ruleId: "import/order",
+    enforcedBy: null,
     test: "tests/lint/import-order.test.ts",
   },
   {
@@ -79,6 +91,7 @@ export const RULES: EnforcedRule[] = [
     name: "Tailwind 클래스 순서",
     mechanism: "prettier",
     ruleId: null,
+    enforcedBy: "prettier.config.mjs",
     test: "tests/lint/format-check.test.ts",
   },
   {
@@ -86,6 +99,7 @@ export const RULES: EnforcedRule[] = [
     name: "console",
     mechanism: "eslint",
     ruleId: "no-console",
+    enforcedBy: null,
     test: "tests/lint/no-console.test.ts",
   },
   {
@@ -93,6 +107,7 @@ export const RULES: EnforcedRule[] = [
     name: "미사용 import와 import type",
     mechanism: "eslint",
     ruleId: "unused-imports/no-unused-imports",
+    enforcedBy: null,
     test: "tests/lint/unused-imports.test.ts",
   },
   {
@@ -100,6 +115,7 @@ export const RULES: EnforcedRule[] = [
     name: "미사용 import와 import type",
     mechanism: "eslint",
     ruleId: "@typescript-eslint/consistent-type-imports",
+    enforcedBy: null,
     test: "tests/lint/unused-imports.test.ts",
   },
   {
@@ -107,6 +123,7 @@ export const RULES: EnforcedRule[] = [
     name: "실행 코드를 쓰기 전에 짝 테스트가 있어야 한다",
     mechanism: "hook",
     ruleId: null,
+    enforcedBy: ".claude/hooks/tdd-guard-unit.py",
     test: ".claude/hooks/__tests__/tdd-guard.test.ts",
   },
   {
@@ -114,6 +131,7 @@ export const RULES: EnforcedRule[] = [
     name: "화면과 라우트를 쓰기 전에 e2e 명세가 있어야 한다",
     mechanism: "hook",
     ruleId: null,
+    enforcedBy: ".claude/hooks/tdd-guard-e2e.py",
     test: ".claude/hooks/__tests__/tdd-guard.test.ts",
   },
   {
@@ -121,6 +139,7 @@ export const RULES: EnforcedRule[] = [
     name: "시크릿과 .env는 커밋할 수 없다",
     mechanism: "pre-commit",
     ruleId: null,
-    test: null,
+    enforcedBy: ".githooks/pre-commit",
+    test: "tests/lint/pre-commit.test.ts",
   },
 ];

--- a/tests/lint/token-css-parity.test.ts
+++ b/tests/lint/token-css-parity.test.ts
@@ -58,6 +58,12 @@ ${options.darkAttribute ?? DARK_PALETTE}
 `;
 }
 
+function notMatching(diff: TokenDiffEntry[]) {
+  return diff.filter(
+    (entry) => entry.status !== "match" && entry.status !== "skipped",
+  );
+}
+
 function entryOf(diff: TokenDiffEntry[], token: string): TokenDiffEntry {
   const entry = diff.find((item) => item.token === token);
   if (!entry) {
@@ -93,14 +99,14 @@ describe("tokens.md 표 읽기", () => {
     expect(entry.status).toBe("match");
   });
 
-  it("팔레트 열이 빈 자리(—)인 행은 값 대조 없이 통과한다", () => {
+  it("팔레트 열이 빈 자리(—)인 행은 값 대조를 건너뛴 것으로 표시된다", () => {
     const entry = entryOf(
       tokenCssParity(TOKENS_MD, cssFixture({})),
       "stroke.surface",
     );
 
     expect(entry.variable).toBe("--role-stroke-surface");
-    expect(entry.status).toBe("match");
+    expect(entry.status).toBe("skipped");
   });
 
   it("Variant와 State가 붙은 토큰 이름을 하나의 항목으로 읽는다", () => {
@@ -136,7 +142,7 @@ describe("globals.css 세 블록 구분", () => {
   it("--role- 이 가리키는 --palette- 참조를 테마마다 다른 값으로 푼다", () => {
     const diff = tokenCssParity(TOKENS_MD, cssFixture({}));
 
-    expect(diff.filter((entry) => entry.status !== "match")).toEqual([]);
+    expect(notMatching(diff)).toEqual([]);
   });
 
   it("역할 변수를 리터럴로 박으면 다크 두 블록이 라이트 값을 물려받아 어긋난다", () => {
@@ -196,7 +202,7 @@ ${ROLES}`;
 
     const diff = tokenCssParity(TOKENS_MD, cssFixture({ root: paddedLight }));
 
-    expect(diff.filter((entry) => entry.status !== "match")).toEqual([]);
+    expect(notMatching(diff)).toEqual([]);
   });
 
   it("값이 실제로 다르면 불일치로 판정한다", () => {
@@ -246,21 +252,37 @@ describe("역할 변수 누락", () => {
   });
 });
 
+const ROLE_TOKEN_COUNT = 27;
+
+const PALETTE_LESS_TOKENS = ["stroke.surface"];
+
+function realEntries() {
+  const markdown = readFileSync(
+    path.join(process.cwd(), "docs/design-system/tokens.md"),
+    "utf8",
+  );
+  const css = readFileSync(
+    path.join(process.cwd(), "src/app/globals.css"),
+    "utf8",
+  );
+
+  return tokenCssParity(markdown, css);
+}
+
 describe("실제 tokens.md와 globals.css 대조", () => {
+  it("tokens.md의 역할 토큰 표에서 스물일곱 행을 읽는다", () => {
+    expect(realEntries()).toHaveLength(ROLE_TOKEN_COUNT);
+  });
+
+  it("팔레트를 가리키지 않아 값 대조를 건너뛰는 토큰은 stroke.surface 하나뿐이다", () => {
+    const skipped = realEntries()
+      .filter((entry) => entry.status === "skipped")
+      .map((entry) => entry.token);
+
+    expect(skipped).toEqual(PALETTE_LESS_TOKENS);
+  });
+
   it("globals.css가 tokens.md 8절과 oklch 문자열로 맞물린다", () => {
-    const markdown = readFileSync(
-      path.join(process.cwd(), "docs/design-system/tokens.md"),
-      "utf8",
-    );
-    const css = readFileSync(
-      path.join(process.cwd(), "src/app/globals.css"),
-      "utf8",
-    );
-
-    const notMatching = tokenCssParity(markdown, css).filter(
-      (entry) => entry.status !== "match",
-    );
-
-    expect(notMatching).toEqual([]);
+    expect(notMatching(realEntries())).toEqual([]);
   });
 });

--- a/tests/lint/token-css-parity.ts
+++ b/tests/lint/token-css-parity.ts
@@ -10,6 +10,7 @@ type ThemeName = keyof GlobalsCssBlocks;
 
 export type TokenDiffEntry =
   | { token: string; variable: string; status: "match" }
+  | { token: string; variable: string; status: "skipped" }
   | { token: string; variable: string; status: "missing"; themes: ThemeName[] }
   | {
       token: string;
@@ -381,7 +382,7 @@ export function tokenCssParity(
     }
 
     if (row.palette === null) {
-      return { token: row.token, variable, status: "match" };
+      return { token: row.token, variable, status: "skipped" };
     }
 
     const step = palette[row.palette];

--- a/tests/lint/tsx-dumb-ui.test.ts
+++ b/tests/lint/tsx-dumb-ui.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { violationsOf } from "@tests/lint/rule-check";
+import { errorsOf, violationsOf } from "@tests/lint/rule-check";
 
 const DUMB_UI = "house/dumb-ui";
 
@@ -127,7 +127,7 @@ describe("규칙9 — .tsx는 더미 UI", () => {
     expect(violations.map((violation) => violation.ruleId)).toContain(DUMB_UI);
   });
 
-  it("회귀 — page.tsx는 house/dumb-ui가 안 걸린다", async () => {
+  it("회귀 — page.tsx는 어느 규칙도 안 걸린다", async () => {
     const code = `import { Button } from "@/shared/ui/button";
 import {
   Card,
@@ -154,14 +154,12 @@ export default function Home() {
 }
 `;
 
-    const violations = await violationsOf(code, "src/app/page.tsx");
+    const errors = await errorsOf(code, "src/app/page.tsx");
 
-    expect(violations.map((violation) => violation.ruleId)).not.toContain(
-      DUMB_UI,
-    );
+    expect(errors).toEqual([]);
   });
 
-  it("회귀 — layout.tsx는 house/dumb-ui가 안 걸린다", async () => {
+  it("회귀 — layout.tsx는 어느 규칙도 안 걸린다", async () => {
     const code = `import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Providers } from "@/app/providers";
@@ -196,14 +194,12 @@ export default function RootLayout({ children }: LayoutProps<"/">) {
 }
 `;
 
-    const violations = await violationsOf(code, "src/app/layout.tsx");
+    const errors = await errorsOf(code, "src/app/layout.tsx");
 
-    expect(violations.map((violation) => violation.ruleId)).not.toContain(
-      DUMB_UI,
-    );
+    expect(errors).toEqual([]);
   });
 
-  it("회귀 — providers.tsx는 house/dumb-ui가 안 걸린다", async () => {
+  it("회귀 — providers.tsx는 어느 규칙도 안 걸린다", async () => {
     const code = `"use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -218,14 +214,12 @@ export function Providers({ children }: { children: React.ReactNode }) {
 }
 `;
 
-    const violations = await violationsOf(code, "src/app/providers.tsx");
+    const errors = await errorsOf(code, "src/app/providers.tsx");
 
-    expect(violations.map((violation) => violation.ruleId)).not.toContain(
-      DUMB_UI,
-    );
+    expect(errors).toEqual([]);
   });
 
-  it("회귀 — button.tsx는 house/dumb-ui가 안 걸린다", async () => {
+  it("회귀 — button.tsx는 어느 규칙도 안 걸린다", async () => {
     const code = `import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -286,14 +280,12 @@ function Button({
 export { Button, buttonVariants }
 `;
 
-    const violations = await violationsOf(code, "src/shared/ui/button.tsx");
+    const errors = await errorsOf(code, "src/shared/ui/button.tsx");
 
-    expect(violations.map((violation) => violation.ruleId)).not.toContain(
-      DUMB_UI,
-    );
+    expect(errors).toEqual([]);
   });
 
-  it("회귀 — card.tsx는 house/dumb-ui가 안 걸린다", async () => {
+  it("회귀 — card.tsx는 어느 규칙도 안 걸린다", async () => {
     const code = `import * as React from "react"
 
 import { cn } from "@/shared/lib/utils"
@@ -399,10 +391,8 @@ export {
 }
 `;
 
-    const violations = await violationsOf(code, "src/shared/ui/card.tsx");
+    const errors = await errorsOf(code, "src/shared/ui/card.tsx");
 
-    expect(violations.map((violation) => violation.ruleId)).not.toContain(
-      DUMB_UI,
-    );
+    expect(errors).toEqual([]);
   });
 });

--- a/tests/lint/unused-imports.test.ts
+++ b/tests/lint/unused-imports.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fixedCode, violationsOf } from "@tests/lint/rule-check";
+import { errorsOf, fixedCode, violationsOf } from "@tests/lint/rule-check";
 
 const NO_UNUSED_IMPORTS = "unused-imports/no-unused-imports";
 const NO_UNUSED_VARS = "unused-imports/no-unused-vars";
@@ -86,7 +86,7 @@ describe("규칙14 — 미사용 import와 import type", () => {
     ).toEqual([]);
   });
 
-  it("회귀 — utils.ts는 이미 inline type을 쓰고 있어 규칙14의 어느 규칙도 안 걸린다", async () => {
+  it("회귀 — utils.ts는 이미 inline type을 쓰고 있어 어느 규칙도 안 걸린다", async () => {
     const code = `import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
@@ -95,14 +95,12 @@ export function cn(...inputs: ClassValue[]) {
 }
 `;
 
-    const violations = await violationsOf(code, "src/shared/lib/utils.ts");
+    const errors = await errorsOf(code, "src/shared/lib/utils.ts");
 
-    expect(
-      unusedImportRuleIds(violations.map((violation) => violation.ruleId)),
-    ).toEqual([]);
+    expect(errors).toEqual([]);
   });
 
-  it("회귀 — button.tsx는 이미 inline type을 쓰고 있어 규칙14의 어느 규칙도 안 걸린다", async () => {
+  it("회귀 — button.tsx는 이미 inline type을 쓰고 있어 어느 규칙도 안 걸린다", async () => {
     const code = `import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -134,10 +132,8 @@ function Button({
 export { Button, buttonVariants }
 `;
 
-    const violations = await violationsOf(code, "src/shared/ui/button.tsx");
+    const errors = await errorsOf(code, "src/shared/ui/button.tsx");
 
-    expect(
-      unusedImportRuleIds(violations.map((violation) => violation.ruleId)),
-    ).toEqual([]);
+    expect(errors).toEqual([]);
   });
 });


### PR DESCRIPTION
PR #199~203을 한 브랜치에 합친 뒤 적대적 검증자와 codex(gpt-5.6)를 붙여 토론시켰다. 둘이 합의한 결론은 이랬다. 다섯이 만든 구조는 규칙이 **켜져 있는지**는 잘 증명하는데, **얼마나 세게 켜져 있는지**와 **볼 대상이 남아 있는지**는 증명하지 못한다.

말이 아니라 변이로 확인했다. 아래 아홉은 병합 직후에는 전부 초록불이었다.

| 조작 | 고치기 전 | 지금 |
| --- | --- | --- |
| `tokens.md` 표 헤더를 깨서 한 행도 파싱 안 되게 | 173 통과 | 2 실패 |
| `bg.neutral` 행 삭제 | 통과 | 1 실패 |
| `bg.neutral-weak-pressed` 팔레트를 `—`로 (값 대조 끄기) | 통과 | 1 실패 |
| house 규칙을 `error` → `warn` 강등 | 통과 | 1 실패 |
| `.claude/settings.json`을 `{}`로 (훅 둘 제거) | 통과 | 1 실패 |
| `.githooks/pre-commit`을 `exit 0`으로 | 통과 | 5 실패 |
| 마지막 번호(규칙17) 삭제 | 통과 | 1 실패 |
| 규칙13을 지우고 never-assigned로 세탁 | 통과 | 1 실패 |
| 회귀 픽스처에 무관한 규칙 위반 주입 | 통과 | 1 실패 |

## 토큰 대조가 공허하게 참이었다

`parseRoleTokenTable`이 헤더를 못 찾으면 빈 배열을 돌려주고, 실전 대조 테스트는 그 빈 배열을 "어긋난 게 없다"로 읽었다. 대조할 게 0건이어도 통과한다는 뜻이다.

뿌리는 하나 더 있었다. 팔레트 칸이 빈 행은 값 대조를 건너뛰는데, 그걸 "맞았다"와 같은 `status: "match"`로 뭉갰다. 그래서 팔레트 칸을 지워 대조를 꺼도 개수와 상태가 그대로였다.

`"skipped"`를 갈라 세고, 행 수와 건너뛴 토큰 이름을 단언한다. #201이 실제 `tokens.md`를 읽는 케이스를 넷에서 하나로 줄이며 잃었던 그물이 여기서 돌아온다.

## 회귀 픽스처가 그물이기를 그만뒀다

옛 테스트의 통과 단언 서른다섯은 `errorCount === 0`, 즉 **아무 오류도 없어야** 통과였다. #203이 하네스로 옮기며 "그 규칙만 안 걸리면 통과"로 좁아졌다. 실제 파일 전문을 픽스처로 쓰는 회귀 케이스 열셋이 그 손실을 그대로 맞았다 — `card.tsx`에 `bg-red-500`을 섞어도 아무도 안 알아챈다.

`Violation`에 `severity`를 얹고 `errorsOf`를 열어 그 열셋을 되돌린다. 단위 성격의 부정 단언은 겨냥된 채로 둔다. 전부 넓히면 규칙5 테스트가 규칙11 변경으로 깨지는 결합이 되살아나는데, #197 본문이 이미 그 자리에서 한 번 데었다고 적어뒀다.

## 카탈로그가 확인하지 않고 주장했다

`isTurnedOn`이 `warn`을 켜짐으로 인정했다. house 규칙 넷을 강등해도 전부 통과했고 카탈로그는 계속 집행 중이라고 말했다. 그리고 `hook`·`pre-commit` mechanism은 이름만 적어두고 아무것도 확인하지 않았다 — `settings.json`을 통째로 비워도 초록불이었다.

`enforcedBy`로 집행 파일을 적게 하고, 훅은 `settings.json` 등록 여부를 본다. pre-commit은 새 `tests/lint/pre-commit.test.ts`가 임시 저장소에 `.env`와 시크릿을 staged한 채 실제로 스크립트를 돌려 exit code를 확인한다. 규칙17이 `test: null`을 벗었다.

번호는 `ENFORCED_RULE_COUNT`까지 이어지는지 통째로 보고, never-assigned 목록을 `[6, 7, 8]`로 못 박는다. 규칙을 지우고 번호만 그 목록에 옮겨 적어 연속성을 메우는 길이 닫힌다.

## 훅에 새 실패 모드 둘이 있었다

#199가 공통 층을 `guard.py`로 뺀 판단은 맞다. 원본과 exit code를 서른 개 payload로 대조해 전부 일치하는 것도 확인했다. 다만 sibling import가 생기면서 `PYTHONSAFEPATH=1`이면 `ModuleNotFoundError`로 exit 1이 된다. PreToolUse에서 exit 1은 차단이 아니라 **통과**라, 환경 변수 하나로 TDD 규율이 조용히 사라진다. 스크립트 디렉터리를 `sys.path`에 직접 넣는다.

그리고 `guard`가 `verdict`를 부르기 전에 파일을 먼저 읽었다. 판정에 파일을 안 쓰는 e2e 훅도, 경로에서 이미 걸러낸 파일도 전부 읽는다는 뜻이다. `verdict`가 `content` 대신 `read`를 받아 필요할 때만 읽는다.

이 셋은 실패하는 테스트를 먼저 쓰고 실패를 확인한 뒤 고쳤다. FIFO를 물려 "안 읽는다"를 실제로 잰다.

## 이번에 안 고친 것

codex가 Tailwind 4.3.3으로 컴파일해 확인한 실제 lint 우회로가 남아 있다. `max-[600px]:hidden`, `bg-red-500/[0.5]`, `p-[calc(var(--gap)+13px)]` 셋이 유효 CSS를 만드는데 아무 규칙에도 안 걸린다. 뿌리는 `eslint-rules/class-strings.mjs:90-93`이 `(`와 `[`를 한 깊이 카운터에 섞어 세는 것이다.

`git diff`로 확인한 대로 규칙 구현 `.mjs`는 #200에서 한 줄도 안 바뀌었다. 즉 이건 새로 생긴 회귀가 아니라 원래 있던 구멍을 #200의 테스트가 처음 드러낸 것이다. 흠이 아니라 성과라 이번 PR의 범위에서 뺐다. 다만 `class-strings.test.ts:127`이 "두 번째 대괄호를 못 본다"를 알려진 한계가 아니라 정상 계약처럼 적어둔 건 나중에 고칠 때 같이 손봐야 할 테스트 부채다.

## 검증

`pnpm lint` · `pnpm format:check` · `pnpm typecheck` 통과. `pnpm test`는 17파일 173케이스 (병합 직후 16파일 156케이스).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vBoxavpXotgpxE6Xdx6xt