### PR TITLE
lint 규칙이 통과시키던 우회로 다섯을 막는다

### DIFF
--- a/eslint-rules/__tests__/class-strings.test.ts
+++ b/eslint-rules/__tests__/class-strings.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  arbitraryValueOf,
+  arbitraryValuesOf,
   classStringVisitor,
+  segmentsOf,
   utilityOf,
 } from "../class-strings.mjs";
 
@@ -87,6 +88,21 @@ describe("utilityOf — 변형 접두사를 벗기고 마지막 유틸리티만 
   });
 });
 
+describe("utilityOf — 대괄호 깊이와 소괄호 깊이를 따로 센다", () => {
+  it.each([
+    { token: "[&[title=(]]:bg-red-500", utility: "bg-red-500" },
+    {
+      token: "[&[data-x='((']]:text-red-600",
+      utility: "text-red-600",
+    },
+  ])(
+    "$token 은 대괄호 안 짝 없는 소괄호에 안 흔들리고 $utility 를 남긴다",
+    ({ token, utility }) => {
+      expect(utilityOf(token)).toBe(utility);
+    },
+  );
+});
+
 describe("utilityOf — 경계에서 무엇을 돌려주는지", () => {
   it("변형 접두사만 있고 유틸리티가 비면 빈 문자열을 돌려준다", () => {
     expect(utilityOf("hover:")).toBe("");
@@ -105,38 +121,53 @@ describe("utilityOf — 경계에서 무엇을 돌려주는지", () => {
   });
 });
 
-describe("arbitraryValueOf — 첫 대괄호부터 짝이 맞는 곳까지 꺼낸다", () => {
-  it.each([
-    { utility: "flex", value: null },
-    {
-      utility: "bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)]",
-      value: "color-mix(in_oklch,var(--secondary),var(--foreground)_5%)",
-    },
-    {
-      utility: "rounded-[min(var(--radius-md),12px)]",
-      value: "min(var(--radius-md),12px)",
-    },
-    {
-      utility: "grid-cols-[repeat(2,minmax(0,1fr))]",
-      value: "repeat(2,minmax(0,1fr))",
-    },
-    {
-      utility: "[&_svg:not([class*='size-'])]",
-      value: "&_svg:not([class*='size-'])",
-    },
-    { utility: "w-[1px]-[2px]", value: "1px" },
-  ])("$utility 에서 $value 를 꺼낸다", ({ utility, value }) => {
-    expect(arbitraryValueOf(utility)).toBe(value);
+describe("segmentsOf — 깊이 0의 콜론으로 세그먼트를 전부 쪼갠다", () => {
+  it("변형 셋과 유틸리티 하나로 네 세그먼트가 나온다", () => {
+    expect(segmentsOf("md:hover:[&>*]:text-[color:var(--fg)]")).toEqual([
+      "md",
+      "hover",
+      "[&>*]",
+      "text-[color:var(--fg)]",
+    ]);
+  });
+
+  it("변형이 없으면 원소 하나짜리 배열을 돌려준다", () => {
+    expect(segmentsOf("flex")).toEqual(["flex"]);
   });
 });
 
-describe("arbitraryValueOf — 경계에서 무엇을 돌려주는지", () => {
-  it("대괄호가 열리기만 하고 안 닫히면 null 을 돌려준다", () => {
-    expect(arbitraryValueOf("bg-[foo")).toBeNull();
+describe("arbitraryValuesOf — 유틸리티 안의 대괄호 그룹을 짝이 맞는 것만 순서대로 꺼낸다", () => {
+  it.each([
+    { utility: "flex", values: [] },
+    {
+      utility: "bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)]",
+      values: ["color-mix(in_oklch,var(--secondary),var(--foreground)_5%)"],
+    },
+    {
+      utility: "rounded-[min(var(--radius-md),12px)]",
+      values: ["min(var(--radius-md),12px)"],
+    },
+    {
+      utility: "grid-cols-[repeat(2,minmax(0,1fr))]",
+      values: ["repeat(2,minmax(0,1fr))"],
+    },
+    {
+      utility: "[&_svg:not([class*='size-'])]",
+      values: ["&_svg:not([class*='size-'])"],
+    },
+    { utility: "w-[1px]-[2px]", values: ["1px", "2px"] },
+  ])("$utility 에서 $values 를 꺼낸다", ({ utility, values }) => {
+    expect(arbitraryValuesOf(utility)).toEqual(values);
+  });
+});
+
+describe("arbitraryValuesOf — 경계에서 무엇을 돌려주는지", () => {
+  it("대괄호가 열리기만 하고 안 닫히면 빈 배열을 돌려준다", () => {
+    expect(arbitraryValuesOf("bg-[foo")).toEqual([]);
   });
 
-  it("빈 대괄호는 null 이 아니라 빈 문자열을 돌려준다", () => {
-    expect(arbitraryValueOf("w-[]")).toBe("");
+  it("빈 대괄호는 빈 문자열이 담긴 배열을 돌려준다", () => {
+    expect(arbitraryValuesOf("w-[]")).toEqual([""]);
   });
 });
 

--- a/eslint-rules/class-strings.mjs
+++ b/eslint-rules/class-strings.mjs
@@ -81,17 +81,22 @@ export function classStringVisitor(onClassToken) {
   };
 }
 
-export function utilityOf(classToken) {
+export function segmentsOf(classToken) {
   const segments = [];
-  let depth = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
   let current = "";
 
   for (const character of classToken) {
-    if (character === "[" || character === "(") {
-      depth += 1;
-    } else if (character === "]" || character === ")") {
-      depth = Math.max(0, depth - 1);
-    } else if (character === ":" && depth === 0) {
+    if (character === "[") {
+      bracketDepth += 1;
+    } else if (character === "]") {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+    } else if (bracketDepth === 0 && character === "(") {
+      parenDepth += 1;
+    } else if (bracketDepth === 0 && character === ")") {
+      parenDepth = Math.max(0, parenDepth - 1);
+    } else if (character === ":" && bracketDepth === 0 && parenDepth === 0) {
       segments.push(current);
       current = "";
       continue;
@@ -100,26 +105,33 @@ export function utilityOf(classToken) {
   }
 
   segments.push(current);
+  return segments;
+}
+
+export function utilityOf(classToken) {
+  const segments = segmentsOf(classToken);
   return segments[segments.length - 1];
 }
 
-export function arbitraryValueOf(utility) {
-  const start = utility.indexOf("[");
-  if (start === -1) {
-    return null;
-  }
-
+export function arbitraryValuesOf(utility) {
+  const values = [];
   let depth = 0;
-  for (let index = start; index < utility.length; index += 1) {
-    if (utility[index] === "[") {
+  let start = -1;
+
+  for (let index = 0; index < utility.length; index += 1) {
+    const character = utility[index];
+    if (character === "[") {
+      if (depth === 0) {
+        start = index;
+      }
       depth += 1;
-    } else if (utility[index] === "]") {
+    } else if (character === "]" && depth > 0) {
       depth -= 1;
       if (depth === 0) {
-        return utility.slice(start + 1, index);
+        values.push(utility.slice(start + 1, index));
       }
     }
   }
 
-  return null;
+  return values;
 }

--- a/eslint-rules/no-arbitrary-class-values.mjs
+++ b/eslint-rules/no-arbitrary-class-values.mjs
@@ -1,14 +1,29 @@
 import {
-  arbitraryValueOf,
+  arbitraryValuesOf,
   classStringVisitor,
-  utilityOf,
+  segmentsOf,
 } from "./class-strings.mjs";
 
-const THROUGH_TOKEN = /var\(|--spacing\(|--alpha\(|--value\(/;
+const CUSTOM_PROPERTY = /--[A-Za-z0-9_-]+/g;
 const COLOR_LITERAL =
-  /#[0-9a-f]{3,8}\b|\b(?:rgba?|hsla?|oklch|oklab|lch|lab)\(/i;
+  /#[0-9a-f]{3,8}(?![0-9a-f])|\b(?:rgba?|hsla?|oklch|oklab|lch|lab)\(/i;
 const SIZE_LITERAL =
-  /(?:^|[^a-z0-9_.-])\d*\.?\d+(?:px|rem|em|ch|ex|vh|vw|vmin|vmax|pt|pc|in|cm|mm|%)\b/i;
+  /(?:^|[^a-z0-9_.])\d*\.?\d+(?:px|rem|em|ch|ex|vh|vw|vmin|vmax|pt|pc|in|cm|mm|%)\b/i;
+
+function beyondTokens(value) {
+  return value.replace(CUSTOM_PROPERTY, "");
+}
+
+function hasLiteral(value) {
+  const remainder = beyondTokens(value);
+  return COLOR_LITERAL.test(remainder) || SIZE_LITERAL.test(remainder);
+}
+
+function literalIn(classToken) {
+  return segmentsOf(classToken)
+    .flatMap((segment) => arbitraryValuesOf(segment))
+    .some(hasLiteral);
+}
 
 const noArbitraryClassValues = {
   meta: {
@@ -25,11 +40,7 @@ const noArbitraryClassValues = {
   },
   create(context) {
     return classStringVisitor((classToken, node) => {
-      const value = arbitraryValueOf(utilityOf(classToken));
-      if (value === null || THROUGH_TOKEN.test(value)) {
-        return;
-      }
-      if (!COLOR_LITERAL.test(value) && !SIZE_LITERAL.test(value)) {
+      if (!literalIn(classToken)) {
         return;
       }
       context.report({

--- a/eslint-rules/no-color-literals.mjs
+++ b/eslint-rules/no-color-literals.mjs
@@ -1,4 +1,5 @@
-const HEX_COLOR = /(?:^|[^&\w])#[0-9a-f]{3}(?:[0-9a-f]{3}(?:[0-9a-f]{2})?)?\b/i;
+const HEX_COLOR =
+  /(?:^|[^&\w])#[0-9a-f]{3}(?:[0-9a-f]{3}(?:[0-9a-f]{2})?)?(?![0-9a-f])/i;
 const COLOR_FUNCTION = /\b(?:rgba?|hsla?|oklch|oklab|lch|lab)\(\s*[\d.]/i;
 
 const noColorLiterals = {

--- a/eslint-rules/no-default-palette-class.mjs
+++ b/eslint-rules/no-default-palette-class.mjs
@@ -25,9 +25,10 @@ const DEFAULT_PALETTES = [
 ];
 
 const STEPPED = new RegExp(
-  `^-?[a-z]+(?:-[a-z]+)*-(?:${DEFAULT_PALETTES.join("|")})-(?:50|\\d{3})(?:\\/\\d+)?$`,
+  `^-?[a-z]+(?:-[a-z]+)*-(?:${DEFAULT_PALETTES.join("|")})-(?:50|\\d{3})(?:\\/(?:\\d+|\\[[^\\]]*\\]))?$`,
 );
-const ACHROMATIC = /^-?[a-z]+(?:-[a-z]+)*-(?:white|black)(?:\/\d+)?$/;
+const ACHROMATIC =
+  /^-?[a-z]+(?:-[a-z]+)*-(?:white|black)(?:\/(?:\d+|\[[^\]]*\]))?$/;
 
 const noDefaultPaletteClass = {
   meta: {

--- a/src/shared/ui/__tests__/button.test.ts
+++ b/src/shared/ui/__tests__/button.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { buttonVariants } from "@/shared/ui/button";
+
+const SIZES = [
+  "default",
+  "xs",
+  "sm",
+  "lg",
+  "icon",
+  "icon-xs",
+  "icon-sm",
+  "icon-lg",
+] as const;
+
+describe("buttonVariants — 모양은 크기와 무관하게 rounded-full 이다", () => {
+  it.each(SIZES)(
+    "%s 크기는 rounded-full 을 담고 rounded-lg 와 rounded-[ 는 안 담는다",
+    (size) => {
+      const className = buttonVariants({ size });
+
+      expect(className).toContain("rounded-full");
+      expect(className).not.toContain("rounded-lg");
+      expect(className).not.toContain("rounded-[");
+    },
+  );
+});

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/shared/lib/utils";
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-full border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -22,14 +22,12 @@ const buttonVariants = cva(
       size: {
         default:
           "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        xs: "h-6 gap-1 px-2 text-xs has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 px-2.5 text-xs has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
         lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         icon: "size-8",
-        "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-xs": "size-6 [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-7",
         "icon-lg": "size-9",
       },
     },

--- a/tests/lint/design-token-values.test.ts
+++ b/tests/lint/design-token-values.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { errorsOf, violationsOf } from "@tests/lint/rule-check";
 
@@ -19,14 +21,21 @@ describe("규칙4 — 하드코딩한 색과 크기", () => {
   describe("대괄호 안이 토큰을 거치면 통과한다", () => {
     it.each([
       ["[&_svg]:pointer-events-none", "선택자 변형"],
+      ["[&_svg:not([class*='size-'])]:size-4", "not 선택자 안 크기 클래스"],
       ["in-data-[slot=button-group]:rounded-lg", "속성 선택자 변형"],
       ["*:[img:first-child]:rounded-t-xl", "자식 선택자 변형"],
+      [
+        "data-[size=sm]:[--card-spacing:--spacing(3)]",
+        "data 변형 안 커스텀 프로퍼티",
+      ],
       ["[--card-spacing:--spacing(3)]", "커스텀 프로퍼티에 스페이싱 함수"],
+      ["has-data-[icon=inline-end]:pr-2", "has-data 변형"],
+      ["active:not-aria-[haspopup]:translate-y-px", "not-aria 변형"],
+      ["supports-[display:grid]:grid", "supports 변형"],
       [
         "bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)]",
         "var()를 감싼 color-mix",
       ],
-      ["rounded-[min(var(--radius-md),12px)]", "var()를 감싼 min()"],
       ["grid-cols-[1fr_auto]", "그리드 트랙 크기"],
       ["grid-rows-[auto_auto]", "그리드 트랙 크기"],
     ])("%s (%s)는 규칙4의 어느 규칙도 안 걸린다", async (className) => {
@@ -70,49 +79,79 @@ describe("규칙4 — 하드코딩한 색과 크기", () => {
     );
   });
 
-  it("회귀 — text-[0.8rem]이 토큰 유틸로 바뀐 button.tsx는 어느 규칙도 안 걸린다", async () => {
-    const code = `import { Button as ButtonPrimitive } from "@base-ui/react/button"
-import { cva, type VariantProps } from "class-variance-authority"
+  describe("변형 접두사 자리에 박힌 임의 값도 걸린다", () => {
+    it.each([
+      [
+        "max-[600px]:hidden",
+        "변형 자리 px 리터럴",
+        [NO_ARBITRARY_CLASS_VALUES],
+      ],
+      [
+        "min-[48rem]:grid-cols-2",
+        "변형 자리 rem 리터럴",
+        [NO_ARBITRARY_CLASS_VALUES],
+      ],
+    ])(
+      "%s (%s)는 마지막 세그먼트가 아니어도 걸린다",
+      async (className, _description, expectedRuleIds) => {
+        const ruleIds = await ruleIdsOfClassName(
+          `flex ${className} items-center`,
+        );
 
-import { cn } from "@/shared/lib/utils"
-
-const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        expect(designTokenRuleIds(ruleIds)).toEqual(expectedRuleIds);
       },
-      size: {
-        default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+    );
+  });
+
+  describe("두 번째 이후 대괄호 그룹도 걸린다", () => {
+    it("w-[var(--w)]-[13px]의 두 번째 그룹 13px가 걸린다", async () => {
+      const ruleIds = await ruleIdsOfClassName(
+        "flex w-[var(--w)]-[13px] items-center",
+      );
+
+      expect(designTokenRuleIds(ruleIds)).toEqual([NO_ARBITRARY_CLASS_VALUES]);
+    });
+  });
+
+  describe("토큰 함수를 걷어내고 남는 리터럴은 걸린다", () => {
+    it.each([
+      [
+        "p-[calc(var(--gap)+13px)]",
+        "calc 안에 남는 px",
+        [NO_ARBITRARY_CLASS_VALUES],
+      ],
+      [
+        "w-[calc(var(--w)-2rem)]",
+        "calc 안에 남는 rem",
+        [NO_ARBITRARY_CLASS_VALUES],
+      ],
+      [
+        "rounded-[min(var(--radius-md),12px)]",
+        "min() 안에 남는 px",
+        [NO_ARBITRARY_CLASS_VALUES],
+      ],
+      [
+        "bg-[color-mix(in_oklch,var(--primary),#6E4F39_10%)]",
+        "color-mix 안에 남는 hex",
+        [NO_ARBITRARY_CLASS_VALUES, NO_COLOR_LITERALS],
+      ],
+    ])(
+      "%s (%s)는 var()를 걷어낸 나머지에서 걸린다",
+      async (className, _description, expectedRuleIds) => {
+        const ruleIds = await ruleIdsOfClassName(
+          `flex ${className} items-center`,
+        );
+
+        expect(designTokenRuleIds(ruleIds)).toEqual(expectedRuleIds);
       },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+    );
+  });
 
-function Button({
-  className,
-  variant = "default",
-  size = "default",
-  ...props
-}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
-  return (
-    <ButtonPrimitive
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props}
-    />
-  )
-}
-
-export { Button, buttonVariants }
-`;
+  it("회귀 — 실제 button.tsx 파일은 규칙4의 어느 규칙도 안 걸린다", async () => {
+    const code = readFileSync(
+      path.join(process.cwd(), "src/shared/ui/button.tsx"),
+      "utf8",
+    );
     const errors = await errorsOf(code, "src/shared/ui/button.tsx");
 
     expect(errors).toEqual([]);

--- a/tests/lint/relative-import.test.ts
+++ b/tests/lint/relative-import.test.ts
@@ -79,4 +79,24 @@ describe("규칙1 — 상대 경로 import 금지", () => {
 
     expect(globalsCssLine.length).toBeGreaterThan(0);
   });
+
+  it("tests/ 아래 파일의 같은 폴더를 가리키는 ./ 상대 import가 걸린다", async () => {
+    const code = `import { x } from "./x";\n\nexport const value = x;\n`;
+
+    const violations = await violationsOf(code, "tests/lint/fixture.ts");
+
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
+  });
+
+  it("tests/ 아래 파일의 상위 폴더를 가리키는 ../ 상대 import가 걸린다", async () => {
+    const code = `import { y } from "../y";\n\nexport const value = y;\n`;
+
+    const violations = await violationsOf(code, "tests/lint/fixture.ts");
+
+    expect(violations.map((violation) => violation.ruleId)).toContain(
+      NO_RESTRICTED_IMPORTS,
+    );
+  });
 });

--- a/tests/lint/rule-catalogue.test.ts
+++ b/tests/lint/rule-catalogue.test.ts
@@ -1,6 +1,8 @@
 import { accessSync, constants, existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { ESLint } from "eslint";
+import { ESLint, type Linter } from "eslint";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
 import { beforeAll, describe, expect, it } from "vitest";
 import {
   DOCUMENTED_LINT_RULE_COUNT,
@@ -58,6 +60,18 @@ function ruleIdsOf(mechanisms: EnforcedRule["mechanism"][]) {
   ).map((rule) => rule.ruleId as string);
 }
 
+function presetBaselineRuleIds() {
+  const baseline = new Set<string>();
+
+  for (const block of [...nextVitals, ...nextTs] as Linter.Config[]) {
+    for (const ruleId of Object.keys(block.rules ?? {})) {
+      baseline.add(ruleId);
+    }
+  }
+
+  return baseline;
+}
+
 describe("규칙 카탈로그", () => {
   let config: Awaited<ReturnType<typeof resolveConfig>>;
 
@@ -113,6 +127,33 @@ describe("규칙 카탈로그", () => {
       .filter((file) => !existsSync(path.join(process.cwd(), file)));
 
     expect([...new Set(missing)]).toEqual([]);
+  });
+
+  it("config가 켜둔 규칙 중 preset baseline에 없는 것은 전부 카탈로그에 있다", () => {
+    const baseline = presetBaselineRuleIds();
+    const turnedOnByConfig = Object.entries(config.rules ?? {})
+      .filter(([, entry]) => isTurnedOn(entry))
+      .map(([ruleId]) => ruleId);
+
+    const beyondBaseline = turnedOnByConfig.filter(
+      (ruleId) => !baseline.has(ruleId),
+    );
+    const catalogued = [...new Set(ruleIdsOf(["eslint", "house"]))];
+
+    expect(beyondBaseline.sort()).toEqual(catalogued.sort());
+  });
+
+  it("카탈로그가 가리키는 테스트 파일은 자기 ruleId를 실제로 언급한다", () => {
+    const withRuleId = RULES.filter((rule) => rule.ruleId !== null);
+    const notMentioned = withRuleId.filter((rule) => {
+      const content = readFileSync(
+        path.join(process.cwd(), rule.test as string),
+        "utf8",
+      );
+      return !content.includes(rule.ruleId as string);
+    });
+
+    expect(notMentioned).toEqual([]);
   });
 });
 

--- a/tests/lint/tailwind-default-palette.test.ts
+++ b/tests/lint/tailwind-default-palette.test.ts
@@ -39,4 +39,34 @@ describe("규칙5 — Tailwind 기본 팔레트 유틸리티", () => {
 
     expect(ruleIds).toContain(NO_DEFAULT_PALETTE_CLASS);
   });
+
+  it("bg-red-500/[0.5]는 대괄호 투명도를 써도 house/no-default-palette-class가 걸린다", async () => {
+    const ruleIds = await ruleIdsOfClassName("bg-red-500/[0.5]");
+
+    expect(ruleIds).toContain(NO_DEFAULT_PALETTE_CLASS);
+  });
+
+  it("text-gray-600/[.25]는 대괄호 투명도를 써도 house/no-default-palette-class가 걸린다", async () => {
+    const ruleIds = await ruleIdsOfClassName("text-gray-600/[.25]");
+
+    expect(ruleIds).toContain(NO_DEFAULT_PALETTE_CLASS);
+  });
+
+  it("bg-white/[0.9]는 무채색이고 대괄호 투명도를 써도 house/no-default-palette-class가 걸린다", async () => {
+    const ruleIds = await ruleIdsOfClassName("bg-white/[0.9]");
+
+    expect(ruleIds).toContain(NO_DEFAULT_PALETTE_CLASS);
+  });
+
+  it("bg-primary/80은 우리 역할 토큰이라 house/no-default-palette-class가 안 걸린다", async () => {
+    const ruleIds = await ruleIdsOfClassName("bg-primary/80");
+
+    expect(ruleIds).not.toContain(NO_DEFAULT_PALETTE_CLASS);
+  });
+
+  it("ring-ring/50은 우리 역할 토큰이라 house/no-default-palette-class가 안 걸린다", async () => {
+    const ruleIds = await ruleIdsOfClassName("ring-ring/50");
+
+    expect(ruleIds).not.toContain(NO_DEFAULT_PALETTE_CLASS);
+  });
 });

--- a/tests/lint/tsx-dumb-ui.test.ts
+++ b/tests/lint/tsx-dumb-ui.test.ts
@@ -226,7 +226,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/shared/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-full border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -244,14 +244,14 @@ const buttonVariants = cva(
       size: {
         default:
           "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        xs: "h-6 gap-1 px-2 text-xs has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 px-2.5 text-xs has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
         lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         icon: "size-8",
         "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+          "size-6 [&_svg:not([class*='size-'])]:size-3",
         "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+          "size-7",
         "icon-lg": "size-9",
       },
     },


### PR DESCRIPTION
## 무엇

하우스 lint 규칙 셋이 공용 파서 `eslint-rules/class-strings.mjs` 를 거쳐 Tailwind 클래스를 읽는데, 하드코딩한 색과 크기가 규칙을 그대로 지나가는 우회로 다섯을 막았다. 여기에 디자인 시스템 문서와 어긋나 있던 버튼 라운딩까지 여덟 조건을 한 번에 닫는다.

파서의 내보내는 것이 바뀐다. `segmentsOf` 가 새로 생기고, `utilityOf` 는 그 마지막 원소를 돌려주는 얇은 함수가 된다. 첫 대괄호 그룹만 꺼내던 `arbitraryValueOf` 는 그룹을 전부 돌려주는 `arbitraryValuesOf` 로 대체됐고 단수 이름은 사라졌다.

## 왜

지난 회차에서 규칙이 **켜져 있는지**는 증명됐지만 **얼마나 세게 켜져 있는지**는 증명되지 않았다는 결론이 나왔다. 그 자리를 실제로 열어보니 구멍이 다섯이었다.

**깊이 카운터를 한 통에 섞어 셌다.** `[` 와 `(` 를 같은 변수로 세다 보니 대괄호 안에 짝 없는 소괄호가 있으면 깊이가 0으로 안 돌아왔고, 뒤따르는 콜론을 세그먼트 구분으로 못 봤다. `[&[title=(]]:bg-red-500` 이 팔레트 규칙을 통째로 빠져나간 경로다. 대괄호 안 소괄호는 선택자의 일부라 짝이 안 맞는 게 정상이므로, 이제 소괄호는 대괄호 깊이가 0일 때만 센다.

**마지막 세그먼트만 봤다.** 변형 접두사는 검사 대상이 아니었다. 그래서 `max-[600px]:hidden` 의 `600px` 과 `min-[48rem]:grid-cols-2` 의 `48rem` 이 그냥 지나갔다. 임의 값은 변형 자리에도 박을 수 있으니 세그먼트를 전부 돈다.

**첫 대괄호 그룹만 꺼냈다.** 유틸리티 하나에 그룹이 둘 이상이면 두 번째부터는 검사 자체가 안 됐다. `w-[var(--w)]-[13px]` 은 첫 그룹이 토큰을 거치니 통과, 두 번째 그룹 `13px` 은 볼 기회조차 없었다.

**`var(` 하나가 값 전체를 사면했다.** 이게 가장 넓은 구멍이었다. 값 안에 `var(` 가 한 번이라도 나오면 나머지를 안 봤기 때문에 `p-[calc(var(--gap)+13px)]` 의 `13px` 이 토큰을 거친 값 행세를 했다. 전면 사면을 지우고, 대신 검사 전에 커스텀 프로퍼티 **식별자만** 걷어낸 뒤 남은 문자열에서 리터럴을 찾는다. 호출 전체가 아니라 식별자만 지우는 게 핵심인데, `var(--gap, 13px)` 처럼 폴백에 숨은 리터럴까지 잡아야 하기 때문이다. 이렇게 하면 `color-mix(in_oklch,var(--secondary),var(--foreground)_5%)` 는 `color-mix(in_oklch,var(),var()_5%)` 로 남아 통과하고, `min(var(--radius-md),12px)` 은 `min(var(),12px)` 로 남아 걸린다.

**정규식 경계가 세 군데 헐거웠다.** 크기 리터럴이 선행 배제 문자군에 `-` 를 넣어둬서 마이너스 부호 뒤 숫자를 리터럴로 안 셌고, `calc(var(--w)-2rem)` 의 `2rem` 과 `mt-[-13px]` 의 `13px` 이 통과했다. `_` 는 배제한 채로 뒀는데, Tailwind 가 공백 자리에 쓰는 문자라 `var()_5%` 의 `5%` 를 크기로 세면 정상 코드가 걸리기 때문이다. hex 는 `\b` 로 끝을 잡다 보니 뒤에 `_` 가 오면 경계가 안 서서 `#6E4F39_10%` 이 빠져나갔고, `(?![0-9a-f])` 로 바꿨다. 팔레트 규칙은 투명도 수식어를 숫자로만 받아 `bg-red-500/[0.5]` 처럼 대괄호 투명도를 쓰면 정규식이 아예 안 맞았다. `bg-primary/80` 과 `ring-ring/50` 은 우리 역할 토큰이라 팔레트 이름에 안 걸려 그대로 통과한다.

**버튼 라운딩이 문서와 어긋나 있었다.** `docs/design-system/components.md` 는 버튼 모양을 `rounded-full` 로 못 박았는데 크기 여덟이 전부 규격 밖이었다. 규격 밖인 것보다 나쁜 건 그 값이 아무 일도 안 하고 있었다는 점이다. `--radius-md` 가 정확히 12px 라서 `min(var(--radius-md),12px)` 은 no-op 이었고, `min(...,10px)` 이 내는 10px 은 우리 라운딩 척도 4·8·12·16·20 밖의 값이었다. base 를 `rounded-full` 로 올리면 여덟 크기가 전부 그것만 물려받는다.

`in-data-[slot=button-group]:rounded-lg` 네 곳도 같이 지웠다. 이 저장소에 ButtonGroup 컴포넌트가 없고 `data-slot="button-group"` 을 내는 코드가 어디에도 없다. `components.md` 에도 ButtonGroup 절이 없다. 존재하지 않는 슬롯을 겨냥한 죽은 override 였다.

## 검증

여섯 명령 전부 초록이다.

- `pnpm test` — 205 passed (18 files). 손대기 전에는 30 failed / 175 passed 였다
- `pnpm lint` — 위반 없음. 규칙을 조인 뒤에도 `card.tsx` 를 포함한 우리 소스에서 새로 걸리는 자리가 없었다
- `pnpm typecheck` — 통과
- `pnpm format:check` — 통과 (`pnpm format` 한 번 돌린 뒤)
- `pnpm build` — 통과
- `pnpm test:integration` — 6 passed
- `pnpm e2e` — 1 passed

## 총괄에게 넘기는 것

`tests/lint/tsx-dumb-ui.test.ts` 의 「회귀 — button.tsx는 어느 규칙도 안 걸린다」가 실제 `button.tsx` 를 베낀 **사본을 인라인 픽스처로** 들고 있었다. 이번에 진짜 파일을 고치면서 그 사본이 낡았고, 그대로 두면 이번에 금지하기로 한 `rounded-[min(...)]` 이 깨끗하다고 주장하는 테스트가 남는다. 단언 `expect(errors).toEqual([])` 은 그대로 두고 입력 문자열에만 같은 편집 셋을 옮겼다(diff 5줄 교체, 단언 줄은 안 건드렸다).

받은 테스트가 아니라 기존 테스트였고 작업 지시에도 없던 자리라 판정이 필요하면 되돌려도 된다. 다만 같은 파일의 회귀 테스트 다섯이 전부 실제 소스의 인라인 사본이라 소스가 바뀔 때마다 같이 썩는다. 이번에 새로 들어온 `tests/lint/design-token-values.test.ts` 의 회귀 테스트는 `readFileSync` 로 실제 파일을 읽는데, 그쪽이 이 썩음을 없애는 모양이다. 다섯을 그 방식으로 옮길지는 별도 task 로 올릴 자리로 보인다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
