### PR TITLE
docs: 2026-08-26 (6) 회차를 기록한다

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -4,17 +4,17 @@
 
 ## 지금 상태
 
-`docs/design-system/`이 섰다. `tokens.md`(팔레트 6계열 × 11단계, 역할 토큰 매핑, 타이포·스페이싱·라운딩·그림자·모션, Tailwind 4 `@theme` 전문)를 정본으로 두고, `foundation/`의 색·타이포·스페이싱과 형태·모션 넷과 `writing.md`·`components.md`·`README.md`가 그 정본을 이름으로만 부른다. 브랜드 색은 절제 규칙(버튼 한 자리) 아래 있고, warning은 brand와 밝기가 거의 같아 글자색으로는 안 쓴다.
+`eslint-rules/class-strings.mjs`를 거치는 하우스 lint 규칙 셋(`no-arbitrary-class-values`·`no-color-literals`·`no-default-palette-class`)이 이전엔 놓치던 우회로 다섯을 막는다. 깊이 카운터가 `bracketDepth`와 `parenDepth`로 갈라져 대괄호 안 짝 없는 소괄호를 더는 안 헷갈린다. 임의 값 검사가 마지막 세그먼트만이 아니라 변형 접두사 세그먼트 전부와, 유틸리티 하나에 대괄호 그룹이 둘 이상이어도 전부를 돈다. `var(...)`가 한 번이라도 나오면 값 전체를 사면하던 방식을 버리고, 커스텀 프로퍼티 식별자만 걷어낸 뒤 남는 문자열에서 리터럴을 찾는다(`calc(var(--gap)+13px)`의 `13px`을 잡는다). 정규식 경계 셋 — `SIZE_LITERAL`의 선행 배제 문자군에서 `-`를 뺀 것, hex 리터럴의 끝을 `\b` 대신 `(?![0-9a-f])`로 잡은 것, 팔레트 규칙이 대괄호 투명도(`bg-red-500/[0.5]`)도 매칭하게 한 것 — 도 조여졌다. 파서가 내보내는 이름이 바뀌었다. `eslint-rules/class-strings.mjs`는 이제 `classStringVisitor`·`segmentsOf`·`utilityOf`·`arbitraryValuesOf`(복수) 넷을 내보내고, 첫 대괄호 그룹만 돌려주던 `arbitraryValueOf`(단수)는 사라졌다.
 
-규칙 열일곱(lint가 집행하는 열넷 + `.claude/hooks/`의 TDD 가드 둘 + `.githooks/pre-commit`의 시크릿 검사)이 `tests/lint/rules.ts`의 카탈로그로 코드에 존재한다. 카탈로그는 규칙이 켜져 있는지를 `ESLint#calculateConfigForFile()`로 직접 읽고, 훅은 `settings.json` 등록 여부를, pre-commit은 실제 스크립트 실행으로 확인한다. 문서 번호 6·7·8은 아무 자리에도 없어 지어내지 않고 `RULE_NUMBERS_NEVER_ASSIGNED`로 구조에 박아뒀다.
+`src/shared/ui/button.tsx`의 라운딩이 `docs/design-system/components.md`와 맞춰졌다. base가 `rounded-full`로 올라가 크기 여덟(`default`·`xs`·`sm`·`lg`·`icon`·`icon-xs`·`icon-sm`·`icon-lg`)이 전부 그것만 물려받고, 없는 ButtonGroup 컴포넌트를 겨냥하던 `in-data-[slot=button-group]:rounded-lg` 네 곳이 지워졌다. 새 `src/shared/ui/__tests__/button.test.ts`가 이 계약을 크기별로 직접 검사한다.
 
-`tests/lint/`의 lint 확인은 `rule-check.ts` 하나로 모였다 — `violationsOf`와 `errorsOf`와 `fixedCode` 셋만 노출하고 ESLint 인스턴스는 모듈 스코프에 두 개(평범한 것, `fix: true`)만 둔다. 단위 성격의 단언은 `errorCount`가 아니라 `ruleId`로 좁혀져 어느 규칙이 걸렸는지까지 못 박고, 실제 파일 전문을 픽스처로 쓰는 회귀 케이스는 `errorsOf`로 「어느 규칙도 안 걸린다」를 본다. `token-css-parity`는 `src/shared/lib/`에서 `tests/lint/token-css-parity.ts`로 옮겨졌고 입구가 `tokenCssParity(markdown, css)` 하나로 좁아졌다. `.claude/hooks/`의 훅 둘은 payload 해독 공통 층을 `guard.py`로 뺐다.
+`tests/lint/rule-catalogue.test.ts`에 카탈로그와 config를 preset baseline으로 맞대는 검사가 붙었다. `eslint-config-next/core-web-vitals`와 `.../typescript`가 내보내는 rules 키 집합을 baseline으로 두고, 그 밖에서 error로 켜진 규칙이 카탈로그의 ruleId 집합과 정확히 일치하는지 본다(둘 다 11개). `eslint-config-next`가 올라가도 baseline이 같이 움직여 노후화가 안 생긴다. `tests/lint/relative-import.test.ts`엔 `tests/` 경로 fixture 검사가, `tests/lint/tailwind-default-palette.test.ts`엔 대괄호 투명도 케이스 다섯이 늘었다. `pnpm test`는 205개(18개 파일) 전부 초록이다.
 
-이 다섯 변경은 병합만으로 끝나지 않았다. 병합 뒤 `pr-diff`·적대적 검증자·codex 셋을 토론시켜 변이 아홉 가지(카탈로그 최소 편집, 훅 제거, 규칙 강등 등)로 실제로 막는지 확인했고, 그 자리에서 세 가지 실공백이 드러나 고쳐졌다. 토큰 대조가 파싱 실패 시 공허하게 통과하던 것, 회귀 픽스처 열셋이 `errorsOf`로 다시 열리기 전엔 다른 규칙 위반을 못 보던 것, 훅이 `PYTHONSAFEPATH=1`에서 조용히 통과로 돌아서던 것이다. `class-strings.mjs:90-93`이 `(`와 `[`를 한 깊이로 섞어 세는 실제 lint 우회로는 확인만 됐고 이번 회차엔 안 고쳤다.
-
-제품 코드는 여전히 integration 테스트 한 파일(`src/entities/profile/dals/__tests__/profile.integration.test.ts`)뿐이다. `dals` 실행 코드도 화면도 없다. `docs/domain/`의 여섯 파일은 두 회차 전에 첫 인터뷰를 돌았고 이번 회차에서는 안 건드렸다.
+제품 코드는 여전히 integration 테스트 한 파일(`src/entities/profile/dals/__tests__/profile.integration.test.ts`)뿐이다. `dals` 실행 코드도 화면도 없다. `docs/domain/`의 여섯 파일은 이번 회차에서도 안 건드렸다.
 
 ## 다음 첫 수
+
+지난 회차의 다음 첫 수가 그대로 남아 있다. 이번 회차(#206)는 그 사이 드러난 lint 우회로를 먼저 막은 곁가지였다.
 
 `tokens.md` 8절이 덮지 않는 자리 넷을 메운다. `globals.css`를 8절 전문으로 교체하며 드러났다. 넷 중 진짜 버그는 `@custom-variant dark`가 없어 `dark:` 유틸리티가 `[data-theme="dark"]`를 안 따라가는 것이다 — `button.tsx`가 `dark:` 클래스를 여럿 쓴다. 나머지 셋은 `@layer base` 없이 body 색이 `color-scheme`에만 기대는 것, `card.tsx`가 쓰는 `--font-heading`이 사라진 것, `--font-sans`가 가리키는 Pretendard 파일이 없어 `-apple-system` 폴백으로 떨어지는 것이다. 완료 조건은 `docs/plan.md` 「다음」에 그대로 있다.
 
@@ -22,7 +22,7 @@
 
 ## 열린 결정
 
-- `class-strings.mjs`의 실제 lint 우회로. `max-[600px]:hidden`, `bg-red-500/[0.5]`, `p-[calc(var(--gap)+13px)]` 셋이 유효 CSS를 만드는데 아무 규칙에도 안 걸린다. 뿌리는 `eslint-rules/class-strings.mjs:90-93`이 `(`와 `[`를 한 깊이 카운터에 섞어 세는 것이다. 새 회귀가 아니라 원래 있던 구멍이 테스트로 드러난 것이고, `class-strings.test.ts:127`이 이 한계를 정상 계약처럼 적어둔 건 테스트 부채로 남아 있다. `docs/plan.md`의 task로는 아직 안 올렸다.
+- `tests/lint/tsx-dumb-ui.test.ts`의 회귀 테스트 다섯(`page.tsx`·`layout.tsx`·`providers.tsx`·`button.tsx`·`card.tsx`)이 전부 실제 소스를 베낀 인라인 사본을 픽스처로 들고 있다. 소스가 바뀌면 사본이 같이 썩는다 — 이번에 `button.tsx`를 고치며 실제로 하나가 썩었고, 단언은 그대로 둔 채 입력 문자열만 동기화해 넘겼다. `tests/lint/design-token-values.test.ts`의 회귀 테스트는 이번에 `readFileSync`로 실제 파일을 읽는 방식으로 바뀌어 이 썩음이 없다. 다섯을 그 방식으로 옮길지는 안 정해졌다.
 - `token-css-parity`가 `tests/lint/`로 옮겨가며 `tdd-guard-unit.py`의 사전 차단(`src/` 아래만 봄)에서 빠졌다. CI의 `pnpm test`가 대신 잡지만, 편집 순간 손이 막히는 장치는 잃었다. 훅이 `tests/` 아래 `.test.ts`가 아닌 `.ts`까지 보게 넓힐지는 판단이 남아 있다.
 - 도메인 규칙의 미정 항목은 `docs/domain/`의 각 파일 "아직 안 정한 것" 절이 정본이다. 여기 옮겨 적지 않는다.
 - 관리자 승인 경로가 없다. 컬럼 권한은 역할 단위라 `authenticated`에 `approved_at`을 열면 관리자든 아니든 다 열린다. `security definer` 함수로 가야 한다. 지금 스키마는 그 문을 안 열어뒀다.

--- a/docs/log/2026-08-26-6.md
+++ b/docs/log/2026-08-26-6.md
@@ -1,0 +1,47 @@
+# 2026-08-26 (6) — 켜져 있다는 증명과 세게 켜져 있다는 증명은 다르다
+
+PR 하나(#206)가 들어간 회차다. 직전 회차 끝에서 셋(subagent와 codex)이 토론해 도달한 결론 — 규칙이 켜져 있는지는 증명됐지만 얼마나 세게 켜져 있는지는 증명되지 않았다 — 을 실제로 열어본 회차다. `eslint-rules/class-strings.mjs`를 거치는 하우스 lint 규칙 셋이 하드코딩한 색과 크기를 놓치는 우회로가 다섯이었고, 여기에 디자인 시스템 문서와 어긋나 있던 버튼 라운딩까지 여덟 조건을 한 번에 닫았다.
+
+## 우회로가 발견인지 회귀인지부터 갈랐다
+
+직전 회차에서 다섯 후보를 각각 Orca 작업트리로 병렬 처리하고 한 브랜치로 합친 뒤, subagent와 codex를 불러 셋이 토론하는 방식으로 검증했다. 그 토론에서 class-strings 우회로가 회귀가 아니라 발견으로 판정됐다. 규칙 구현이 담긴 `.mjs` 파일들이 #199~#205 어느 PR에서도 안 바뀌었으니, 이번에 잡은 구멍은 새로 생긴 게 아니라 테스트가 얇아 안 보이던 자리를 드러낸 것이다. 이번 회차는 그 자리를 판 것이지 되돌린 것이 아니다.
+
+## 다섯 우회로
+
+**깊이 카운터를 한 통에 섞어 셌다.** `segmentsOf`(옛 `utilityOf`)가 `[`와 `(`를 같은 변수로 세다 보니, 대괄호 안에 짝 없는 소괄호가 있으면 깊이가 0으로 안 돌아왔고 뒤따르는 콜론을 세그먼트 구분으로 못 봤다. `[&[title=(]]:bg-red-500`이 팔레트 규칙을 통째로 빠져나간 경로다. 대괄호 안 소괄호는 선택자의 일부라 짝이 안 맞는 게 정상이므로, 소괄호는 대괄호 깊이가 0일 때만 세도록 카운터를 `bracketDepth`와 `parenDepth` 둘로 갈랐다.
+
+**마지막 세그먼트만 봤다.** 변형 접두사는 검사 대상이 아니어서 `max-[600px]:hidden`의 `600px`과 `min-[48rem]:grid-cols-2`의 `48rem`이 그냥 지나갔다. `arbitraryValuesOf`가 세그먼트 전부를 도는 `no-arbitrary-class-values.mjs`의 `literalIn`으로 옮겨갔다.
+
+**첫 대괄호 그룹만 꺼냈다.** 옛 `arbitraryValueOf`(단수)는 유틸리티 하나에 그룹이 둘 이상이면 두 번째부터는 볼 기회조차 없었다. `w-[var(--w)]-[13px]`은 첫 그룹이 토큰을 거치니 통과, 두 번째 그룹 `13px`은 검사 밖이었다. 그룹을 전부 배열로 돌려주는 `arbitraryValuesOf`(복수)로 대체하고 단수 이름은 없앴다.
+
+**`var(` 하나가 값 전체를 사면했다.** 가장 넓은 구멍이었다. 값 안에 `var(`가 한 번이라도 나오면 나머지를 안 봤기 때문에 `p-[calc(var(--gap)+13px)]`의 `13px`이 토큰을 거친 값 행세를 했다. 전면 사면 정규식(`THROUGH_TOKEN`)을 지우고, 대신 `CUSTOM_PROPERTY` 정규식으로 커스텀 프로퍼티 식별자만 걷어낸 뒤 남는 문자열에서 리터럴을 찾는 `beyondTokens`로 바꿨다. 호출 전체가 아니라 식별자만 지우는 게 핵심이다 — `var(--gap, 13px)`처럼 폴백에 숨은 리터럴까지 잡아야 하기 때문이다. `color-mix(in_oklch,var(--secondary),var(--foreground)_5%)`는 `color-mix(in_oklch,var(),var()_5%)`로 남아 통과하고, `min(var(--radius-md),12px)`은 `min(var(),12px)`로 남아 걸린다.
+
+**정규식 경계가 세 군데 헐거웠다.** `SIZE_LITERAL`의 선행 배제 문자군에 `-`가 들어 있어 마이너스 부호 뒤 숫자를 리터럴로 안 셌고, `calc(var(--w)-2rem)`의 `2rem`과 `mt-[-13px]`의 `13px`이 통과했다. `_`는 배제한 채로 뒀는데, Tailwind가 공백 자리에 쓰는 문자라 `var()_5%`의 `5%`를 크기로 세면 정상 코드가 걸리기 때문이다. hex는 `\b`로 끝을 잡다 보니 뒤에 `_`가 오면 경계가 안 서서 `#6E4F39_10%`이 빠져나갔고, `(?![0-9a-f])`로 바꿨다. 팔레트 규칙은 투명도 수식어를 숫자로만 받아 `bg-red-500/[0.5]`처럼 대괄호 투명도를 쓰면 정규식이 아예 안 맞았다 — `STEPPED`와 `ACHROMATIC` 둘 다 `/(?:\d+|\[[^\]]*\])`로 열었다. `bg-primary/80`과 `ring-ring/50`은 우리 역할 토큰이라 팔레트 이름에 안 걸려 그대로 통과한다.
+
+이 셋 중 `SIZE_LITERAL`의 `-`와 hex의 `\b`는 여덟 조건을 정한 뒤에 테스트를 검수하다 추가로 나왔다. 원래 조건 5의 "예외 없다"에 포함시켜 같이 막았고, 기존 회귀 목록 열여덟 개를 시뮬레이터로 전부 돌려 하나도 안 깨지는 것을 확인한 뒤 구현에 넘겼다.
+
+## 버튼 라운딩이 문서와 어긋나 있었다
+
+`docs/design-system/components.md`는 버튼 모양을 `rounded-full`로 못 박았는데 크기 여덟이 전부 규격 밖이었다. 규격 밖인 것보다 나쁜 건 그 값이 아무 일도 안 하고 있었다는 점이다. `--radius-md`가 정확히 12px라서 `rounded-[min(var(--radius-md),12px)]`은 no-op이었고, `min(...,10px)`이 내는 10px은 우리 라운딩 척도 4·8·12·16·20 밖의 값이었다. base를 `rounded-full`로 올리면 여덟 크기가 전부 그것만 물려받는다.
+
+`in-data-[slot=button-group]:rounded-lg` 네 곳을 지울지 `rounded-full`로 바꿀지는 완료 조건에 없어 계획 단계에서 막혔다. 총괄이 판정했다 — 이 저장소에 ButtonGroup 컴포넌트가 없고 `data-slot="button-group"`을 내는 코드도 없고 `components.md`에 ButtonGroup 절도 없다. 존재하지 않는 슬롯을 겨냥한 죽은 override라 지웠다.
+
+## 조건 둘은 코드가 이미 맞았다
+
+조건 7(`tests/` 경로 fixture)과 조건 8(카탈로그 양방향)은 구현할 게 없는 자리였다. 코드가 이미 맞아서 빨강을 못 보는 대신 변이로 증명했다. `eslint.config.mjs`의 `"tests/**/*.ts"`를 지우면 `relative-import.test.ts`의 새 테스트(`tests/lint/fixture.ts`에서 `./x`·`../y`를 import)가 실패하고, `tests/lint/rules.ts`에서 카탈로그 항목 하나를 지우면 `rule-catalogue.test.ts`의 역방향 검사가 실패하는 것을 확인한 뒤 되돌렸다.
+
+조건 8의 baseline은 처음에 `react/`·`react-hooks/`·`@next/next/` 접두사로 preset 규칙을 걸러내는 안이었다. 실측해보니 `no-var`·`prefer-const`·`prefer-rest-params`·`prefer-spread`처럼 접두사가 없는 preset 규칙이 안 걸러졌다. 그래서 `eslint-config-next/core-web-vitals`와 `.../typescript`를 직접 import해 그 rules 키 집합을 baseline으로 삼는 `presetBaselineRuleIds`로 갔다. `eslint-config-next`를 올려도 baseline이 따라 움직여 노후화가 안 생긴다. baseline 113개를 빼면 error로 켜진 게 정확히 11개고 카탈로그의 distinct ruleId 11개와 일치한다.
+
+## 손을 넷으로 나눴다
+
+`test-planner`가 리스크와 테스트 층을 정하고, `unit-test-writer`가 실패하는 테스트를 쓰고, `implementer`가 통과시키고, `pr-diff`가 diff를 감사했다. 쓰는 손과 구현하는 손을 분리한 게 이번에 실제로 작동했다. `implementer`가 테스트 단언을 못 바꾸니 조건이 느슨해질 여지가 없었다.
+
+## 총괄이 정한 것 — plan에는 안 올린다
+
+class-strings 우회로를 `docs/plan.md`의 task로 올리지 않고 이 브랜치에서 바로 마무리하기로 했다. 사람이 정한 것이다.
+
+## 남은 것 — 회귀 픽스처의 인라인 사본
+
+`tests/lint/tsx-dumb-ui.test.ts`의 회귀 테스트 다섯(`page.tsx`·`layout.tsx`·`providers.tsx`·`button.tsx`·`card.tsx`)이 전부 실제 소스를 베낀 인라인 사본을 픽스처로 들고 있다. 소스가 바뀌면 사본이 같이 썩는다. 이번에 `button.tsx`를 고치면서 실제로 하나가 썩었고, `implementer`가 단언은 그대로 둔 채 입력 문자열만 동기화해 넘겼다.
+
+이번에 새로 들어온 `tests/lint/design-token-values.test.ts`의 회귀 테스트는 `readFileSync`로 실제 파일을 읽는 방식이라 이 썩음이 없다. 다섯을 그 방식으로 옮길지는 아직 결정 안 났다. 사람이 판단할 자리로 남는다.


### PR DESCRIPTION
## 무엇

PR #206(lint 규칙 우회로 다섯과 버튼 라운딩까지 여덟 조건을 닫은 회차)을 회차 로그로 남기고 handoff를 갱신한다.

## 왜

- `docs/log/2026-08-26-6.md` — PR #206 본문과 대화에서만 오간 근거(우회로가 발견인지 회귀인지, 조건 7·8이 변이로 증명된 이유, baseline을 preset import로 잡은 이유, button-group override를 지운 판정, 손을 넷으로 나눈 파이프라인, 회귀 픽스처 인라인 사본 문제)를 함께 기록했다.
- `docs/handoff.md` — 지금 상태를 이번 회차 뒤의 사실로 다시 쓰고, 닫힌 열린 결정(class-strings 우회로)을 지우고 새로 남은 것(tsx-dumb-ui.test.ts 회귀 픽스처 다섯의 인라인 사본 문제)을 추가했다. 다음 첫 수는 지난 회차와 동일 — `tokens.md` 8절 미비 자리 넷 — 이며 이번 PR은 그 사이의 곁가지였음을 밝혔다.
- `docs/plan.md`는 안 건드렸다. class-strings 우회로 수정을 plan task로 올리지 않고 브랜치에서 바로 마무리하기로 총괄이 정했고, 다른 task 상태 변화도 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)