### PR TITLE
로컬 Supabase의 analytics를 끈다

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -28,7 +28,7 @@
 - 관리자 승인 경로가 없다. 컬럼 권한은 역할 단위라 `authenticated`에 `approved_at`을 열면 관리자든 아니든 다 열린다. `security definer` 함수로 가야 한다. 지금 스키마는 그 문을 안 열어뒀다.
 - integration 테스트가 사용자를 안 치운다. `tests/integration/supabase.ts`가 사용자를 만들기만 하고 치우는 길을 안 준다. anon 키로는 `auth.users`를 못 지우고 프로필 행 삭제는 테스트가 지키는 바로 그 정책에 걸린다. 지우려면 service role이 필요한데 금지다. 한 번 돌 때 일곱이 로컬 DB에 쌓인다. 무작위 UUID라 지금은 무해하지만 "프로필 전체 목록" 같은 걸 검증하려 들면 걸린다.
 - 로컬에서 연타하면 가입 rate limit에 걸린다. `supabase/config.toml`이 IP당 5분에 30번인데 한 번에 일곱을 쓴다. 5분 안에 네 번 넘게 돌리면 막힌다. CI는 컨테이너가 매번 새로 떠서 무관하다.
-- CI가 1분대에서 4분대로 늘었다. Supabase 이미지 pull이 대부분이다. `config.toml`의 analytics를 끄면 logflare와 vector가 빠져 줄지만, 실제로 아픈지 몇 회차 겪고 정하는 편이 낫다.
+- CI가 1분대에서 4분대로 늘었다. Supabase 이미지 pull이 대부분이다. analytics는 껐으니 logflare와 vector 둘이 빠졌고, 남은 시간이 여전히 아픈지는 몇 회차 더 겪고 정한다.
 - `authenticated`에 `profiles` 테이블 단위 insert와 delete 권한이 열려 있다. 정책이 없어 RLS가 전부 막는 구조다. 지금은 기본 거부라 안전하고 테스트가 delete 쪽을 지킨다.
 - shadcn `accent` 매핑 — `bg.brand-weak`로 걸면 드롭다운 hover마다 브랜드 색이 깜빡여 절제 규칙과 부딪힌다. 실제 화면을 보고 `bg.neutral-weak`로 내릴지 판단이 필요하다.
 - "8월 28일에 나옵니다" 예시 문장 — 어체가 합쇼체라 해요체 규칙과 어긋나고, `docs/domain/schedule.md`에 근무표 확정 마감일이 없어 앱이 날짜를 약속할 근거가 없다. `writing.md`에 확인 요청으로 달려 있다.
@@ -49,6 +49,7 @@
 - 새 개념이 코드에 등장하면 먼저 `docs/domain/`에 있는지 확인한다. 용어 정본과 코드 이름을 잇는 장치가 없어서 어긋나도 아무도 안 막는다.
 - task 완료 조건이 세 문장을 넘거나 예외 규칙이 둘 이상이면 `docs/spec/<task>.md`로 승격한다(ADR-002). 첫 기능 task부터 이 기준을 적용한다.
 - integration 테스트를 돌리려면 로컬에 Docker가 떠 있어야 한다. `pnpm test:integration`이 `supabase start`부터 하니 못 뜨면 그 자리에서 멈춘다.
+- **`supabase/config.toml`의 analytics가 꺼져 있어 Studio에 Logs 탭이 없다.** 로그 자체는 그대로 남으니 `docker logs supabase_db_la-bie-belle` 처럼 컨테이너에서 직접 읽는다. RLS가 막은 순간은 `db` 로그에 `permission denied for table ...` 로 찍힌다. 화면이 붙고 API 트래픽을 화면에서 걸러 봐야 할 때가 오면 다시 켜면 되고, 켜는 비용은 이미지 둘을 다시 받는 것뿐이다.
 - `vitest.config.ts`가 CommonJS로 읽히는데 ESM 문법이라 실행할 때마다 경고가 뜬다. 동작에는 영향이 없다.
 - type-aware lint(`no-floating-promises` 등)는 속도를 이유로 안 켜져 있다. await 빠진 Supabase 호출 같은 건 lint가 못 잡는다.
 - 디자인 값 lint 규칙은 `src/**/__tests__/**`를 예외로 둔다. 대조 테스트가 픽스처로 oklch 리터럴 문자열을 쥐고 있어서다.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -365,7 +365,7 @@ deno_version = 2
 # secret_key = "env(SECRET_VALUE)"
 
 [analytics]
-enabled = true
+enabled = false
 port = 54327
 # Configure one of the supported backends: `postgres`, `bigquery`.
 backend = "postgres"


### PR DESCRIPTION
## 무엇

`supabase/config.toml` 의 `[analytics]` 를 끈다. `supabase start` 가 logflare 와 vector 두 컨테이너를 더는 안 띄운다.

## 왜

logflare 가 로컬 Docker VM 을 메모리째 무너뜨렸다.

2026-08-27 02:31 UTC 에 VM 이 global OOM 을 냈다. 커널이 먼저 logflare 의 Erlang 프로세스(`beam.smp`)를 죽였고 4초 뒤 Docker Desktop 자체 서비스(`lifecycle-serve`, 2.7GB)까지 죽였다. 그러자 VM 이 디스크를 순서대로 unmount 하고 스스로 전원을 내렸다. VM 로그에 그대로 남아 있다.

```
oom-kill: constraint=CONSTRAINT_NONE, global_oom, task=beam.smp
Out of memory: Killed process 17264 (beam.smp) anon-rss:545640kB
Out of memory: Killed process 248 (lifecycle-serve) anon-rss:2678200kB
```

호스트 쪽 `com.docker.backend` 는 살아서 소켓을 계속 쥐고 있었다. 그래서 `docker` 명령이 에러도 없이 무한정 매달렸다. 연결은 되는데 뒤에 답할 놈이 없었기 때문이다.

이 기계는 물리 메모리가 8GB 고 Docker VM 에 기본값인 절반인 3.83GiB 만 간다. logflare 는 갓 띄운 직후에도 608MiB 로 단독 1위였고, 어제 `pnpm test:integration` 뒤 스택을 안 내린 채 밤을 넘기며 자랐다.

## 무엇을 잃나

Supabase Studio 의 Logs 탭 하나다.

로그 자체는 안 사라진다. vector 는 각 컨테이너의 stdout 을 긁어 logflare 로 나르기만 했고, 그 stdout 은 `docker logs` 로 그대로 읽힌다. logflare 가 더해주던 것은 화면에서 SQL 로 검색하고 거르는 기능이다.

RLS 정책이 막은 순간처럼 실제로 필요한 것도 `db` 로그에 그대로 찍힌다.

```
authenticator@postgres ERROR:  permission denied for table profiles
STATEMENT:  WITH pgrst_source AS (UPDATE "public"."profiles" SET "approved_at" = ...
```

저장소에는 `analytics` 도 `logflare` 도 포트 `54327` 도 참조하는 코드가 `src/` 와 `tests/` 어디에도 없다. 지금 Supabase 를 쓰는 것은 integration 테스트 한 파일뿐이고 그 테스트는 Studio 를 안 연다.

화면이 붙고 실제 API 트래픽을 화면에서 걸러 봐야 할 때가 오면 다시 켠다. 켜는 비용은 이미지 둘을 다시 받는 것뿐이다.

## 검증

`supabase stop` 뒤 `pnpm test:integration` 을 다시 돌렸다.

- `Stopped services: [supabase_imgproxy supabase_analytics supabase_vector supabase_pooler]` — 둘이 목록에서 빠졌다
- **6 passed** — integration 테스트는 그대로다
- 컨테이너 전체 RAM 합계가 2364MiB 에서 1484MiB 로 줄었다. VM 사용률 60% → 38%
- `pnpm format:check` 통과

## 같이 손댄 것

`docs/handoff.md` 의 열린 결정에 「analytics 를 끄면 logflare 와 vector 가 빠져 줄지만 실제로 아픈지 몇 회차 겪고 정하는 편이 낫다」가 있었다. 겪었고 정해졌으니 그 줄을 결정된 문장으로 바꿨다. CI 시간이 여전히 아픈지는 아직 열려 있어 그쪽은 남겼다.

「주의」에 Logs 탭이 없다는 것과 대신 `docker logs` 를 쓴다는 것을 한 줄 더했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vBoxavpXotgpxE6Xdx6xt