### PR TITLE
문서만 바뀐 PR에서 무거운 CI 단계를 건너뛴다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: 문서만 바뀐 PR인지 본다
+        id: scope
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD")
+          if printf '%s\n' "$changed" | grep -qvE '^(docs/|\.claude/)'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "docs/ 와 .claude/ 만 바뀌었다. DB와 브라우저를 쓰는 단계를 건너뛴다."
+          fi
       - uses: pnpm/action-setup@v6
         with:
           version: 8.15.2
@@ -23,15 +39,24 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm test
       - uses: supabase/setup-cli@v1
+        if: steps.scope.outputs.code == 'true'
         with:
           version: 2.75.0
-      - run: pnpm test:integration
+      - name: 테스트가 쓰는 서비스만 띄운다
+        if: steps.scope.outputs.code == 'true'
+        run: supabase start -x realtime,storage-api,imgproxy,mailpit,postgres-meta,studio,edge-runtime
+      - run: pnpm test:integration:run
+        if: steps.scope.outputs.code == 'true'
       - name: 로컬 Supabase 접속 정보를 앱 env로 넘긴다
+        if: steps.scope.outputs.code == 'true'
         run: |
           supabase status -o env \
             | sed -n 's/^API_URL="\(.*\)"$/NEXT_PUBLIC_SUPABASE_URL=\1/p' >> "$GITHUB_ENV"
           supabase status -o env \
             | sed -n 's/^ANON_KEY="\(.*\)"$/NEXT_PUBLIC_SUPABASE_ANON_KEY=\1/p' >> "$GITHUB_ENV"
       - run: pnpm build
+        if: steps.scope.outputs.code == 'true'
       - run: pnpm exec playwright install --with-deps chromium
+        if: steps.scope.outputs.code == 'true'
       - run: pnpm e2e
+        if: steps.scope.outputs.code == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,9 +37,12 @@ Next.js 16(App Router, TypeScript) + Tailwind CSS 4 + shadcn/ui(`@base-ui/react`
 - `pnpm typecheck` — tsc 타입 검사
 - `pnpm test` — vitest 단위 테스트
 - `pnpm test:integration` — 로컬 Supabase에 붙는 vitest (Docker가 필요하고 스크립트가 스택을 띄운다)
+- `pnpm test:integration:run` — 스택이 이미 떠 있을 때 마이그레이션과 테스트만 돌린다
 - `pnpm e2e` — Playwright e2e (먼저 `pnpm build`가 필요하다)
 
 CI(`.github/workflows/ci.yml`)는 PR마다 lint → test → integration → build → e2e를 돌리고 `ci` job이 branch protection 필수 검사다. 기능 PR은 코드 모양이 아니라 화면 흐름이 실제로 도는지까지 본다.
+
+`docs/`와 `.claude/`만 바뀐 PR은 DB와 브라우저를 쓰는 뒤쪽 넷을 건너뛴다. lint와 format과 typecheck와 단위 테스트는 그때도 돈다 — 문서가 테스트 입력이라 문서 변경만으로도 깨지는 자리가 있다.
 
 ## 코드 구조
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "format:check": "prettier --check .",
     "typecheck": "next typegen && tsc --noEmit",
     "test": "vitest run --project unit",
-    "test:integration": "supabase start && supabase migration up && vitest run --project integration",
-    "e2e": "playwright test"
+    "test:integration": "supabase start && pnpm test:integration:run",
+    "e2e": "playwright test",
+    "test:integration:run": "supabase migration up && vitest run --project integration"
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",


### PR DESCRIPTION
## 무엇을

`docs/`와 `.claude/`만 바뀐 PR에서 integration과 build와 e2e를 건너뛴다. CI가 띄우는 Supabase 서비스도 테스트가 쓰는 것만 남겼다.

## 왜

측정부터 했다.

| 단계 | 시간 |
| --- | --- |
| **`pnpm test:integration`** | **153초** |
| playwright install | 22초 |
| `pnpm test` | 15초 |
| `pnpm build` | 12초 |
| 나머지 전부 | 합쳐 33초 |

전체 235초 중 integration이 65%다. 그 안에서 실제 테스트는 6개고 몇 초면 끝난다 — 나머지가 전부 `supabase start`의 컨테이너 기동이다.

그리고 **최근 PR 다섯이 전부 문서였는데 매번 DB를 띄우고 브라우저를 설치했다.**

## 무엇을 건너뛰고 무엇을 안 건너뛰는가

건너뛰는 것은 DB와 브라우저를 쓰는 넷이다 — supabase 기동, integration, build, e2e.

**lint와 format과 typecheck와 단위 테스트는 문서 PR에서도 돈다.** 이 저장소는 문서가 테스트 입력이다. `tokens.md`를 고치면 파리티 테스트가 깨지고, 그건 문서만 바꿔도 나는 일이다. 넷을 합쳐 25초라 싸고, 건너뛰면 정작 문서 PR이 지켜야 할 것을 놓친다.

`tokens.md` 8절을 고치는 경우는 `globals.css`도 같이 움직여야 하니 `src/`가 바뀌고, 그러면 자동으로 전체가 돈다. 조건이 저절로 맞물린다.

## 판정 방법

외부 액션을 안 쓰고 `git diff --name-only <base>...HEAD`로 직접 본다. `docs/`나 `.claude/`로 시작하지 않는 줄이 하나라도 있으면 전체를 돌린다. main으로 가는 push는 언제나 전체다.

`fetch-depth: 0`이 필요해서 checkout에 붙였다. 지금 checkout이 0초라 영향이 없다.

## 서비스도 줄였다

`realtime`·`storage-api`·`imgproxy`·`mailpit`·`postgres-meta`·`studio`·`edge-runtime` 일곱은 우리 테스트가 안 건드린다. 필요한 것은 `gotrue`(auth)와 `postgrest`와 `kong`뿐이다.

**로컬은 그대로 둔다.** studio는 로컬 개발에서 DB를 눈으로 볼 때 쓴다. 그래서 config.toml을 안 고치고 CI에서만 `-x`를 준다.

그러려면 스택 기동과 테스트 실행이 갈려야 해서 `package.json`을 이렇게 나눴다.

- `test:integration` — 스택을 띄우고 아래를 부른다. 로컬에서 쓰던 그대로다
- `test:integration:run` — 마이그레이션과 vitest만. CI가 이걸 부른다

## 검증

이 PR은 `.github/`와 `package.json`을 건드려서 code=true로 판정되고 전체가 돈다. 서비스를 줄인 채로 integration과 e2e가 통과하는지가 여기서 드러난다.

건너뛰는 경로가 실제로 도는지는 다음 문서 PR에서 확인된다.

## 돌려보니 서비스 제외는 효과가 없었다

이 PR의 CI에서 잰 값이다.

| 단계 | 전 | 후 |
| --- | --- | --- |
| supabase 기동 | 153초(테스트 포함) | **158초** |
| `test:integration:run` | — | **2초** |

**실제 integration 테스트는 2초다.** 나머지 156초가 전부 `supabase start`고, 서비스를 일곱 빼도 그대로였다. 컨테이너 기동이 아니라 **Docker 이미지를 내려받는 시간**이라는 뜻이다. 제외한 서비스의 이미지를 안 받아도 남은 것들(postgres·gotrue·kong·postgrest)이 그만큼 크다.

그래서 이 PR의 이득은 **전부 조건부 스킵에서 온다.** 문서 PR에서 197초를 아낀다.

서비스 제외는 되돌리지 않고 남긴다. 해가 없고, 러너 메모리에 여유가 생기며, 이미지 캐시를 붙이면 그때 기동 시간이 드러난다. 다만 **지금은 시간을 안 줄인다**는 것을 여기 적어둔다.

이미지 캐시는 이번에 안 한다. 이미지가 수백 MB라 캐시 복원 자체가 느릴 수 있어서 재보고 정할 자리다.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
