### PR TITLE
tokens.md 7절 대비값을 기계가 재게 한다

### DIFF
--- a/scripts/generate-globals-css.mts
+++ b/scripts/generate-globals-css.mts
@@ -2,8 +2,15 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { format, resolveConfig } from "prettier";
+import {
+  bySection,
+  EMPTY_CELL,
+  PALETTE_HEADER,
+  requireRows,
+  ROLE_HEADER,
+  type Row,
+} from "./tokens-md.mts";
 
-type Row = { cells: string[]; section: string };
 type Declaration = { name: string; value: string };
 type Group = Declaration[];
 type Side = "light" | "dark";
@@ -12,14 +19,6 @@ const ROOT = path.resolve(fileURLToPath(import.meta.url), "../..");
 const TOKENS_PATH = path.join(ROOT, "docs/design-system/tokens.md");
 const GLOBALS_PATH = path.join(ROOT, "src/app/globals.css");
 
-const PALETTE_HEADER = [
-  "단계",
-  "라이트 hex",
-  "라이트 oklch",
-  "다크 hex",
-  "다크 oklch",
-];
-const ROLE_HEADER = ["토큰", "팔레트", "라이트", "다크", "Tailwind 유틸"];
 const TYPOGRAPHY_HEADER = [
   "유틸",
   "크기",
@@ -34,7 +33,6 @@ const DURATION_HEADER = ["변수", "값", "Tailwind 유틸", "쓰는 자리"];
 const CADENCE_HEADER = ["변수", "값", "쓰는 자리"];
 const VENDOR_HEADER = ["변수", "값", "자리", "Tailwind 유틸"];
 
-const EMPTY_CELL = "—";
 const SUBSECTION = /^###\s+(.+?)\s*$/;
 const FENCE_OPEN = "```css";
 const FENCE_CLOSE = "```";
@@ -58,85 +56,11 @@ const SURFACE_STROKE_IN_DARK = "var(--palette-neutral-200)";
 const STATIC_RADIUS_UTILITIES = new Set(["rounded-none", "rounded-full"]);
 const ALIASED_PREFIX = /^--(?:palette|role|vendor)-/;
 
-function cellsOf(line: string): string[] | null {
-  const trimmed = line.trim();
-  if (!trimmed.startsWith("|")) {
-    return null;
-  }
-  return trimmed
-    .replace(/^\|/, "")
-    .replace(/\|$/, "")
-    .split("|")
-    .map((cell) => cell.trim().replace(/^`|`$/g, "").trim());
-}
-
-function isHeader(cells: string[], header: string[]): boolean {
-  return (
-    cells.length === header.length &&
-    header.every((label, index) => cells[index] === label)
-  );
-}
-
-function readRows(markdown: string, header: string[]): Row[] {
-  const lines = markdown.split("\n");
-  const rows: Row[] = [];
-  let section = "";
-  let index = 0;
-
-  while (index < lines.length) {
-    const heading = SUBSECTION.exec(lines[index]);
-    if (heading) {
-      section = heading[1];
-      index += 1;
-      continue;
-    }
-
-    const cells = cellsOf(lines[index]);
-    if (!cells || !isHeader(cells, header)) {
-      index += 1;
-      continue;
-    }
-
-    index += 2;
-    while (index < lines.length) {
-      const row = cellsOf(lines[index]);
-      if (!row || row.length !== header.length) {
-        break;
-      }
-      rows.push({ cells: row, section });
-      index += 1;
-    }
-  }
-
-  return rows;
-}
-
-function requireRows(markdown: string, header: string[], label: string): Row[] {
-  const rows = readRows(markdown, header);
-  if (rows.length === 0) {
-    throw new Error(`${label} 표를 tokens.md에서 찾지 못했다.`);
-  }
-  return rows;
-}
-
 function requireOne(rows: Row[], label: string): Row {
   if (rows.length !== 1) {
     throw new Error(`${label} 는 한 줄이어야 하는데 ${rows.length} 줄이다.`);
   }
   return rows[0];
-}
-
-function bySection(rows: Row[]): Row[][] {
-  const sections = new Map<string, Row[]>();
-  for (const row of rows) {
-    const bucket = sections.get(row.section);
-    if (bucket) {
-      bucket.push(row);
-    } else {
-      sections.set(row.section, [row]);
-    }
-  }
-  return [...sections.values()];
 }
 
 function readFences(markdown: string): Map<string, string[]> {

--- a/scripts/tokens-md.mts
+++ b/scripts/tokens-md.mts
@@ -1,0 +1,98 @@
+export type Row = { cells: string[]; section: string };
+
+export const PALETTE_HEADER = [
+  "단계",
+  "라이트 hex",
+  "라이트 oklch",
+  "다크 hex",
+  "다크 oklch",
+];
+export const ROLE_HEADER = [
+  "토큰",
+  "팔레트",
+  "라이트",
+  "다크",
+  "Tailwind 유틸",
+];
+
+export const EMPTY_CELL = "—";
+
+const SUBSECTION = /^###\s+(.+?)\s*$/;
+
+function cellsOf(line: string): string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|")) {
+    return null;
+  }
+  return trimmed
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim().replace(/^`|`$/g, "").trim());
+}
+
+function isHeader(cells: string[], header: string[]): boolean {
+  return (
+    cells.length === header.length &&
+    header.every((label, index) => cells[index] === label)
+  );
+}
+
+export function readRows(markdown: string, header: string[]): Row[] {
+  const lines = markdown.split("\n");
+  const rows: Row[] = [];
+  let section = "";
+  let index = 0;
+
+  while (index < lines.length) {
+    const heading = SUBSECTION.exec(lines[index]);
+    if (heading) {
+      section = heading[1];
+      index += 1;
+      continue;
+    }
+
+    const cells = cellsOf(lines[index]);
+    if (!cells || !isHeader(cells, header)) {
+      index += 1;
+      continue;
+    }
+
+    index += 2;
+    while (index < lines.length) {
+      const row = cellsOf(lines[index]);
+      if (!row || row.length !== header.length) {
+        break;
+      }
+      rows.push({ cells: row, section });
+      index += 1;
+    }
+  }
+
+  return rows;
+}
+
+export function requireRows(
+  markdown: string,
+  header: string[],
+  label: string,
+): Row[] {
+  const rows = readRows(markdown, header);
+  if (rows.length === 0) {
+    throw new Error(`${label} 표를 tokens.md에서 찾지 못했다.`);
+  }
+  return rows;
+}
+
+export function bySection(rows: Row[]): Row[][] {
+  const sections = new Map<string, Row[]>();
+  for (const row of rows) {
+    const bucket = sections.get(row.section);
+    if (bucket) {
+      bucket.push(row);
+    } else {
+      sections.set(row.section, [row]);
+    }
+  }
+  return [...sections.values()];
+}

--- a/tests/lint/contrast-check.test.ts
+++ b/tests/lint/contrast-check.test.ts
@@ -1,0 +1,156 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  contrastRatio,
+  droppedContrastRows,
+  measuredContrastRows,
+  parseComboCell,
+  parseDroppedComboCell,
+  resolveTokenHex,
+} from "@tests/lint/contrast-check";
+
+const TOKENS_MARKDOWN = readFileSync(
+  path.join(process.cwd(), "docs/design-system/tokens.md"),
+  "utf8",
+);
+
+const AA_THRESHOLD = 4.5;
+
+function titleOf(left: string, right: string): string {
+  return `${left} / ${right}`;
+}
+
+describe("리스크 10 — WCAG 공식 자체를 tokens.md와 무관한 표준 벡터로 검증한다", () => {
+  it("흰색과 검정의 대비는 21:1이다", () => {
+    expect(contrastRatio("#FFFFFF", "#000000")).toBeCloseTo(21, 4);
+  });
+
+  it("같은 색끼리의 대비는 1:1이다", () => {
+    expect(contrastRatio("#334455", "#334455")).toBeCloseTo(1, 5);
+  });
+});
+
+describe("리스크 7 — 밝은쪽/어두운쪽을 순서가 아니라 휘도로 가른다", () => {
+  it("두 색의 인자 순서를 바꿔도 대비값이 같다", () => {
+    const forward = contrastRatio("#112233", "#EEDDCC");
+    const backward = contrastRatio("#EEDDCC", "#112233");
+
+    expect(backward).toBe(forward);
+  });
+
+  it("첫 인자가 더 어두운 색이어도(다크 팔레트처럼 fg가 밝은 경우) 1 미만으로 떨어지지 않는다", () => {
+    expect(contrastRatio("#0D0C0B", "#ECE9E6")).toBeGreaterThan(1);
+  });
+});
+
+describe("리스크 3 — cellsOf가 벗기지 못한 가운데 백틱을 파서가 마저 지운다", () => {
+  it("`fg.neutral` on `bg.neutral` 형태를 나누면 양쪽에 백틱이 남지 않는다", () => {
+    const combo = parseComboCell("`fg.neutral` on `bg.neutral`");
+
+    expect(combo).toEqual({ left: "fg.neutral", right: "bg.neutral" });
+  });
+});
+
+describe("리스크 5 — on이 아니라 vs로 나뉜 행도 좌우를 가른다", () => {
+  it("brand-800 vs warning-800 을 좌우로 정확히 가른다", () => {
+    const combo = parseDroppedComboCell("brand-800 vs warning-800 (라이트)");
+
+    expect(combo.left).toBe("brand-800");
+    expect(combo.right).toBe("warning-800");
+  });
+});
+
+describe("리스크 6 — (라이트)/(다크) 꼬리로 테마를 정한다", () => {
+  it("(라이트) 꼬리는 테마를 라이트로 읽는다", () => {
+    const combo = parseDroppedComboCell("neutral-600 on `bg.neutral` (라이트)");
+
+    expect(combo.theme).toBe("light");
+  });
+
+  it("실데이터에는 없는 (다크) 꼬리도 테마를 다크로 읽는다", () => {
+    const combo = parseDroppedComboCell(
+      "`fg.neutral-subtle` on `bg.informative-weak` (다크)",
+    );
+
+    expect(combo.theme).toBe("dark");
+  });
+});
+
+describe("리스크 4 — 팔레트 단계와 역할 토큰을 점(.)의 유무로 구분한다", () => {
+  it("점이 있는 역할 토큰은 2절 매핑을 거쳐 1절 hex를 찾는다", () => {
+    expect(resolveTokenHex(TOKENS_MARKDOWN, "fg.neutral", "light")).toBe(
+      "#1B1917",
+    );
+    expect(resolveTokenHex(TOKENS_MARKDOWN, "fg.neutral", "dark")).toBe(
+      "#ECE9E6",
+    );
+  });
+
+  it("점이 없는 팔레트 단계는 2절을 거치지 않고 1절을 곧장 찾는다", () => {
+    expect(resolveTokenHex(TOKENS_MARKDOWN, "neutral-600", "light")).toBe(
+      "#8A8785",
+    );
+    expect(resolveTokenHex(TOKENS_MARKDOWN, "brand-800", "dark")).toBe(
+      "#C7A48C",
+    );
+  });
+});
+
+describe("리스크 1·2 — 표 두 개가 통째로 안 읽히거나 일부 행만 스킵되면 행 수가 어긋난다", () => {
+  it("측정한 조합 표는 16행이다", () => {
+    expect(measuredContrastRows(TOKENS_MARKDOWN)).toHaveLength(16);
+  });
+
+  it("떨어진 조합 표는 4행이다", () => {
+    expect(droppedContrastRows(TOKENS_MARKDOWN)).toHaveLength(4);
+  });
+});
+
+describe("완료 조건 — 측정한 조합의 재계산값이 표에 적힌 라이트 값과 같다", () => {
+  const cases = measuredContrastRows(TOKENS_MARKDOWN).map(
+    (row) => [titleOf(row.combo.left, row.combo.right), row] as const,
+  );
+
+  it.each(cases)("%s", (_title, row) => {
+    expect(row.recomputed.light).toBeCloseTo(row.reported.light, 2);
+  });
+});
+
+describe("완료 조건 — 측정한 조합의 재계산값이 표에 적힌 다크 값과 같다", () => {
+  const cases = measuredContrastRows(TOKENS_MARKDOWN).map(
+    (row) => [titleOf(row.combo.left, row.combo.right), row] as const,
+  );
+
+  it.each(cases)("%s", (_title, row) => {
+    expect(row.recomputed.dark).toBeCloseTo(row.reported.dark, 2);
+  });
+});
+
+describe("완료 조건 — 떨어진 조합의 재계산값이 표에 적힌 결과값과 같다", () => {
+  const cases = droppedContrastRows(TOKENS_MARKDOWN).map(
+    (row) =>
+      [
+        `${titleOf(row.combo.left, row.combo.right)} (${row.combo.theme})`,
+        row,
+      ] as const,
+  );
+
+  it.each(cases)("%s", (_title, row) => {
+    expect(row.recomputed).toBeCloseTo(row.reported, 2);
+  });
+});
+
+describe("완료 조건 — 측정한 조합은 재계산값 기준으로 4.5:1 아래로 내려가지 않는다", () => {
+  const cases = measuredContrastRows(TOKENS_MARKDOWN).map(
+    (row) => [titleOf(row.combo.left, row.combo.right), row] as const,
+  );
+
+  it.each(cases)("%s 라이트 재계산값이 4.5 이상이다", (_title, row) => {
+    expect(row.recomputed.light).toBeGreaterThanOrEqual(AA_THRESHOLD);
+  });
+
+  it.each(cases)("%s 다크 재계산값이 4.5 이상이다", (_title, row) => {
+    expect(row.recomputed.dark).toBeGreaterThanOrEqual(AA_THRESHOLD);
+  });
+});

--- a/tests/lint/contrast-check.test.ts
+++ b/tests/lint/contrast-check.test.ts
@@ -154,3 +154,22 @@ describe("완료 조건 — 측정한 조합은 재계산값 기준으로 4.5:1 
     expect(row.recomputed.dark).toBeGreaterThanOrEqual(AA_THRESHOLD);
   });
 });
+
+describe("완료 조건 — 4.5 판정을 표기값이 아니라 실제값으로 가른다", () => {
+  const boundary = measuredContrastRows(TOKENS_MARKDOWN).filter(
+    (row) =>
+      row.combo.left === "fg.neutral-disabled" &&
+      row.combo.right === "bg.neutral-disabled",
+  );
+
+  it("4.5 경계에 붙은 행이 표에 하나 있다", () => {
+    expect(boundary).toHaveLength(1);
+  });
+
+  it.each(boundary.map((row) => [row.recomputed.light] as const))(
+    "재계산한 라이트 값 %s 는 자기 자신을 둘째 자리로 반올림한 값과 다르다",
+    (light) => {
+      expect(light).not.toBe(Math.round(light * 100) / 100);
+    },
+  );
+});

--- a/tests/lint/contrast-check.ts
+++ b/tests/lint/contrast-check.ts
@@ -1,0 +1,190 @@
+import {
+  PALETTE_HEADER,
+  requireRows,
+  ROLE_HEADER,
+} from "@scripts/tokens-md.mts";
+
+export type Theme = "light" | "dark";
+export type Combo = { left: string; right: string };
+export type DroppedCombo = Combo & { theme: Theme };
+
+export type MeasuredContrastRow = {
+  combo: Combo;
+  reported: { light: number; dark: number };
+  recomputed: { light: number; dark: number };
+};
+
+export type DroppedContrastRow = {
+  combo: DroppedCombo;
+  reported: number;
+  recomputed: number;
+};
+
+const MEASURED_HEADER = ["조합", "라이트", "다크"];
+const DROPPED_HEADER = ["조합", "결과", "판정"];
+
+const COMBO_COLUMN = 0;
+const MEASURED_RATIO_COLUMN: Record<Theme, number> = { light: 1, dark: 2 };
+const DROPPED_RATIO_COLUMN = 1;
+const ROLE_PALETTE_COLUMN = 1;
+const PALETTE_HEX_COLUMN: Record<Theme, number> = { light: 1, dark: 3 };
+
+const COMBO_SEPARATOR = /\s+(?:on|vs)\s+/;
+const THEME_SUFFIXES: { suffix: string; theme: Theme }[] = [
+  { suffix: "(라이트)", theme: "light" },
+  { suffix: "(다크)", theme: "dark" },
+];
+
+const SIX_HEX_DIGITS = /^[0-9a-fA-F]{6}$/;
+const SRGB_LINEAR_CUTOFF = 0.03928;
+const LUMINANCE_WEIGHTS = [0.2126, 0.7152, 0.0722];
+const LUMINANCE_OFFSET = 0.05;
+
+function channelsOf(hex: string): number[] {
+  const digits = hex.trim().replace(/^#/, "");
+  if (!SIX_HEX_DIGITS.test(digits)) {
+    throw new Error(`여섯 자리 hex로 읽을 수 없는 색이다: ${hex}`);
+  }
+  return [0, 2, 4].map(
+    (start) => Number.parseInt(digits.slice(start, start + 2), 16) / 255,
+  );
+}
+
+function linearize(channel: number): number {
+  return channel <= SRGB_LINEAR_CUTOFF
+    ? channel / 12.92
+    : ((channel + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(hex: string): number {
+  return channelsOf(hex).reduce(
+    (total, channel, index) =>
+      total + LUMINANCE_WEIGHTS[index] * linearize(channel),
+    0,
+  );
+}
+
+export function contrastRatio(hexA: string, hexB: string): number {
+  const [darker, lighter] = [
+    relativeLuminance(hexA),
+    relativeLuminance(hexB),
+  ].sort((a, b) => a - b);
+
+  return (lighter + LUMINANCE_OFFSET) / (darker + LUMINANCE_OFFSET);
+}
+
+export function parseComboCell(comboText: string): Combo {
+  const [left, right, ...rest] = comboText
+    .replaceAll("`", "")
+    .split(COMBO_SEPARATOR);
+
+  if (right === undefined || rest.length > 0) {
+    throw new Error(
+      `조합 셀을 " on " 이나 " vs " 로 가르지 못했다: ${comboText}`,
+    );
+  }
+
+  return { left: left.trim(), right: right.trim() };
+}
+
+export function parseDroppedComboCell(comboText: string): DroppedCombo {
+  const trimmed = comboText.trim();
+  const tail = THEME_SUFFIXES.find((candidate) =>
+    trimmed.endsWith(candidate.suffix),
+  );
+
+  if (!tail) {
+    throw new Error(
+      `조합 셀 끝에서 (라이트)나 (다크) 꼬리를 찾지 못했다: ${comboText}`,
+    );
+  }
+
+  return {
+    ...parseComboCell(trimmed.slice(0, -tail.suffix.length)),
+    theme: tail.theme,
+  };
+}
+
+function paletteStepOf(markdown: string, roleToken: string): string {
+  const row = requireRows(markdown, ROLE_HEADER, "역할 토큰").find(
+    (candidate) => candidate.cells[COMBO_COLUMN] === roleToken,
+  );
+
+  if (!row) {
+    throw new Error(`역할 토큰 ${roleToken} 을 tokens.md 2절에서 찾지 못했다.`);
+  }
+
+  return row.cells[ROLE_PALETTE_COLUMN];
+}
+
+export function resolveTokenHex(
+  markdown: string,
+  tokenOrStep: string,
+  theme: Theme,
+): string {
+  const step = tokenOrStep.includes(".")
+    ? paletteStepOf(markdown, tokenOrStep)
+    : tokenOrStep;
+
+  const boundary = step.lastIndexOf("-");
+  const series = step.slice(0, boundary);
+  const level = step.slice(boundary + 1);
+
+  const row = requireRows(markdown, PALETTE_HEADER, "팔레트").find(
+    (candidate) => candidate.section === series && candidate.cells[0] === level,
+  );
+
+  if (!row) {
+    throw new Error(`팔레트 단계 ${step} 을 tokens.md 1절에서 찾지 못했다.`);
+  }
+
+  return row.cells[PALETTE_HEX_COLUMN[theme]];
+}
+
+function reportedRatioOf(cell: string, comboText: string): number {
+  const ratio = Number(cell);
+  if (!Number.isFinite(ratio)) {
+    throw new Error(`${comboText} 의 대비값을 숫자로 읽지 못했다: ${cell}`);
+  }
+  return ratio;
+}
+
+// 재계산값은 반올림하지 않는다. 표의 둘째 자리와 맞추는 일은 테스트의 toBeCloseTo(…, 2)가 이미 하고, 4.5 판정은 4.5065처럼 경계에 붙은 줄을 표기값이 아니라 실제값으로 갈라야 한다.
+function recomputedRatio(markdown: string, combo: Combo, theme: Theme): number {
+  return contrastRatio(
+    resolveTokenHex(markdown, combo.left, theme),
+    resolveTokenHex(markdown, combo.right, theme),
+  );
+}
+
+export function measuredContrastRows(markdown: string): MeasuredContrastRow[] {
+  return requireRows(markdown, MEASURED_HEADER, "측정한 조합").map((row) => {
+    const cell = row.cells[COMBO_COLUMN];
+    const combo = parseComboCell(cell);
+
+    return {
+      combo,
+      reported: {
+        light: reportedRatioOf(row.cells[MEASURED_RATIO_COLUMN.light], cell),
+        dark: reportedRatioOf(row.cells[MEASURED_RATIO_COLUMN.dark], cell),
+      },
+      recomputed: {
+        light: recomputedRatio(markdown, combo, "light"),
+        dark: recomputedRatio(markdown, combo, "dark"),
+      },
+    };
+  });
+}
+
+export function droppedContrastRows(markdown: string): DroppedContrastRow[] {
+  return requireRows(markdown, DROPPED_HEADER, "떨어진 조합").map((row) => {
+    const cell = row.cells[COMBO_COLUMN];
+    const combo = parseDroppedComboCell(cell);
+
+    return {
+      combo,
+      reported: reportedRatioOf(row.cells[DROPPED_RATIO_COLUMN], cell),
+      recomputed: recomputedRatio(markdown, combo, combo.theme),
+    };
+  });
+}

--- a/tests/lint/contrast-check.ts
+++ b/tests/lint/contrast-check.ts
@@ -149,7 +149,6 @@ function reportedRatioOf(cell: string, comboText: string): number {
   return ratio;
 }
 
-// 재계산값은 반올림하지 않는다. 표의 둘째 자리와 맞추는 일은 테스트의 toBeCloseTo(…, 2)가 이미 하고, 4.5 판정은 4.5065처럼 경계에 붙은 줄을 표기값이 아니라 실제값으로 갈라야 한다.
 function recomputedRatio(markdown: string, combo: Combo, theme: Theme): number {
   return contrastRatio(
     resolveTokenHex(markdown, combo.left, theme),


### PR DESCRIPTION
## 무엇

`docs/design-system/tokens.md` 7절 「대비 검증」의 대비비를 1절 팔레트 hex에서 다시 계산해 표에 적힌 값과 대조하는 검사를 세웠다. 「측정한 조합」 16행이 라이트와 다크 양쪽, 「떨어진 조합」 4행이 제 테마 한쪽. 스물넷이다.

측정한 조합은 값 대조에 더해 4.5:1 이상인지도 본다. 7절 머리에 적힌 「측정한 조합 전부가 WCAG AA 본문 기준 4.5:1을 넘는다」가 그 단언이다.

표 파서는 `scripts/generate-globals-css.mts`에서 `scripts/tokens-md.mts`로 뺐다. `readRows`·`requireRows`·`bySection`과 두 헤더 상수를 생성기와 검사가 함께 쓴다.

## 안 재는 것

「떨어진 조합」의 「판정」 칸은 산문이라 검사 대상이 아니다. `fg.neutral-subtle`에서 탈락했다거나 neutral-700으로 올렸다는 서술은 기계가 확인할 수 있는 형태가 아니다. 재는 것은 「결과」 칸의 숫자뿐이다.

2절 팔레트 매핑과 1절 hex 자체도 안 잰다. 검사는 그 둘을 정본으로 놓고 7절이 거기서 나오는 값과 맞는지만 본다. hex와 oklch가 서로 맞는지는 이 검사 밖이다.

## 왜 초록불을 못 믿었나

표 값은 처음부터 전부 맞았다. 구현이 끝나자 테스트가 그냥 통과했다.

지난 회차(`docs/log/2026-08-26-5.md:47`)에 같은 자리에서 한 번 데였다. 규칙이 켜져 있는 것은 증명되는데 볼 대상이 남아 있는지는 증명이 안 돼서, 아홉 가지 조작이 병합 직후 전부 초록이었다. 검사가 도는 것과 검사가 무는 것은 다르다.

그래서 표를 넷으로 흔들어 봤다. 매번 되돌리고 다음 것을 걸었다.

| 변이 | 결과 |
| --- | --- |
| 측정값 `17.40` → `17.41` | RED. `expected 17.40118915632672 to be close to 17.41, difference is 0.0088, but expected 0.005` |
| 떨어진 조합 `3.54` → `3.64` | RED. `expected 3.542451100979327 to be close to 3.64` |
| 측정 행 하나 삭제 | RED. `expected [...] to have a length of 16 but got 15` |
| 측정 헤더 `조합` → `조합들` | RED. `Error: 측정한 조합 표를 tokens.md에서 찾지 못했다.` |

넷째가 이번 설계의 핵심이다. 헤더가 깨지면 파서는 0행을 읽는다. 그대로 두면 잴 것이 없어 초록으로 통과한다. 그래서 `readRows`가 아니라 0행에서 던지는 `requireRows`로 부른다. 표를 못 찾은 것과 표가 맞는 것이 같은 색이면 안 된다.

넷을 되돌린 뒤 `git diff docs/design-system/tokens.md`가 비어 있는 것까지 확인했다.

## 반올림을 안 하고, 그것을 단언으로 못 박았다

재계산값은 반올림하지 않고 그대로 둔다. 표는 둘째 자리 표기라 어떻게든 맞춰야 할 것 같지만, 그 일은 테스트의 `toBeCloseTo(…, 2)`가 이미 한다. 앞에서 반올림을 한 번 더 하면 같은 일을 두 번 하면서 정밀도만 잃는다.

잃으면 곤란한 자리가 실제로 있다. `fg.neutral-disabled on bg.neutral-disabled` 라이트가 4.5065다. 4.5 경계에 붙어 있다. 반올림한 값으로 판정하면 언젠가 진짜 4.497인 조합이 4.50으로 올라가 AA를 통과한다. 표기값이 아니라 실제값으로 갈라야 그 일이 안 난다.

버림은 아예 못 쓴다. 4.5065를 4.50으로 깎으면 표의 4.51과 0.01 어긋나 값 대조가 먼저 깨진다.

처음에는 이 근거를 코드 주석 한 줄로 남겼다가 단언으로 바꿨다. 주석이 막으려는 회귀를 그때 아무 테스트도 안 잡고 있었기 때문이다. 재계산 경로에 `Math.round(x * 100) / 100`을 넣어보면 기존 단언 81개가 전부 통과한다 — 값 대조는 `toBeCloseTo(…, 2)`라 통과하고 4.5 판정도 4.51이라 통과한다. 주석은 사람이 기억해야 지켜지는 것이고, 언젠가 안 지켜진다.

그래서 4.5 경계 행의 재계산값이 자기 자신을 둘째 자리로 반올림한 값과 다르다는 단언을 더했다. 같은 변이를 다시 걸면 이제 이 단언 하나만 빨개진다.

```
× 재계산한 라이트 값 4.51 는 자기 자신을 둘째 자리로 반올림한 값과 다르다
  AssertionError: expected 4.51 not to be 4.51
  Tests  1 failed | 81 passed (82)
```

## 표 파서를 왜 뺐나

생성기와 이 검사가 같은 표를 읽는다. 파서를 두 벌 두면 표 형식이 바뀔 때 한쪽만 고치는 사고가 난다. 값을 두 곳에 적어서 어긋났던 것이 8절을 지운 이유였는데(#222), 그 값을 읽는 코드를 두 벌 두면 같은 사고를 한 층 위에서 되풀이하는 셈이다.

옮긴 것은 `Row` 타입, `PALETTE_HEADER`·`ROLE_HEADER`·`EMPTY_CELL`, 그리고 `readRows`·`requireRows`·`bySection`이다. 이들이 안에서 쓰는 `cellsOf`·`isHeader`·`SUBSECTION`은 같이 옮기되 안 내보낸다.

순수 이동이라 정규식도 시그니처도 안 건드렸다. `tests/lint/generate-globals-css.test.ts`를 한 글자도 안 고치고 그대로 돌려 26개가 전부 통과하는 것이 그 증거다. 옮긴 다섯 함수와 네 상수를 원본과 문자 단위로 대조했고, 어긋난 둘은 `export`가 붙어 줄이 길어지며 prettier가 줄바꿈과 트레일링 콤마를 넣은 것뿐이다.

`SUBSECTION`은 생성기에도 한 벌 남았다. `readFences`가 쓰는데, 그쪽은 heading에서 `"8.1"`처럼 번호만 떼어 쓰는 다른 파서라 표 파서와 계약을 공유하지 않는다. 마크다운 heading 정규식 리터럴이 우연히 겹친 것이라 이번에 막으려던 「표 파서 두 벌」과는 성격이 다르다.

7절 표 헤더 둘은 공유 모듈이 아니라 `tests/lint/contrast-check.ts`에 뒀다. 생성기는 7절을 안 읽는다.

## 확인

`pnpm test` 326개 통과. `pnpm tokens:css`는 리팩터 뒤에도 돌고 `globals.css`를 안 바꾼다. `pnpm lint`·`format:check`·`typecheck`·`build`·`test:integration`·`e2e` 전부 통과했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
