### PR TITLE
루트 md 파일도 문서 취급으로 CI를 줄인다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
             exit 0
           fi
           changed=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD")
-          if printf '%s\n' "$changed" | grep -qvE '^(docs/|\.claude/)'; then
+          if printf '%s\n' "$changed" | grep -qvE '^(docs/|\.claude/|[^/]+\.md$)'; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
             echo "code=false" >> "$GITHUB_OUTPUT"
-            echo "docs/ 와 .claude/ 만 바뀌었다. DB와 브라우저를 쓰는 단계를 건너뛴다."
+            echo "문서만 바뀌었다. DB와 브라우저를 쓰는 단계를 건너뛴다."
           fi
       - uses: pnpm/action-setup@v6
         with:


### PR DESCRIPTION
## 왜

`docs/`·`.claude/`만 바뀐 PR은 무거운 넷(integration·build·e2e)을 건너뛰는데, 루트의 `CLAUDE.md`가 패턴 밖이라 문서 개편 PR이 전부 4분대 풀 CI를 탔다. CLAUDE.md는 문서지 코드가 아니다.

## 무엇

스킵 패턴 `^(docs/|\.claude/)`에 루트 마크다운(`[^/]+\.md$`)을 더한다. lint·format·typecheck·단위 테스트는 그때도 전부 돈다 — 문서가 테스트 입력인 자리는 이 앞단이 계속 지킨다.

## 검증

이 PR 자체가 `.github/` 변경이라 풀 CI를 탄다. 다음 문서 PR부터 스킵이 걸리는지는 곧 이어질 CLAUDE.md 슬림 PR에서 확인된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)