### PR TITLE
2026-09-04 회차를 기록한다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ FSD: `src/` 아래 `app` · `screens` · `features` · `entities` · `shared`. `
 
 ## 기록
 
-회차 마감은 `session-recorder`가 한다 — log 추가, plan 상태 갱신, handoff 덮어쓰기. 근거는 merge된 PR 본문에서 읽는다.
+회차 마감은 `session-recorder`가 한다 — log 추가, backlog 상태 갱신, handoff 덮어쓰기. 근거는 merge된 PR 본문에서 읽는다.
 
 ## 증축 규칙
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -10,10 +10,11 @@ task 보드다. 행 하나가 task 하나고, 완료 조건은 그 행이 링크
 
 ## 진행
 
-- [ ] spec 승인 게이트와 문서 구조 검사를 단다 — [spec](2-design/spec/sdlc-gate.md)
+(비어 있음)
 
 ## 완료
 
+- [x] spec 승인 게이트와 문서 구조 검사를 단다 — [docs/log/2026-09-04.md](log/2026-09-04.md)
 - [x] `tokens.md` 7절의 대비값을 기계가 재게 한다 — [docs/log/2026-08-29-2.md](log/2026-08-29-2.md)
 - [x] `src/app/globals.css`를 `tokens.md`에서 생성한다 — [docs/log/2026-08-29-2.md](log/2026-08-29-2.md)
 - [x] 로그인 화면과 승인 대기 화면의 디자인을 정한다 — [docs/log/2026-08-29.md](log/2026-08-29.md)

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -4,40 +4,33 @@
 
 ## 지금 상태
 
-**작업 트리가 둘 서 있다.** `~/orca/workspaces/la-bie-belle/` 아래 `design`과 `dev`고, 둘 다 detached로 최신 main에 서 있다. 훅 경로와 env와 의존성까지 준비돼 있다. 무엇을 어디서 하는지는 그때 사람이 정하고 문서에 못 박지 않았다. 트리를 열고 닫는 절차는 `.claude/skills/worktree/`에 있다.
+**`docs/`가 SDLC 여섯 단계 폴더로 섰다.** `1-plan/`(prd·scenarios·roadmap·metrics·intent) → `2-design/`(domain·architecture·design-system·adr·spec) → `3-build/`(plans) → `4-test/`(strategy) → `5-deploy/` → `6-maintain/` 순이다. `handoff.md`·`backlog.md`·`CHANGELOG.md`·`log/`는 어느 단계에도 안 속해 루트에 남는다. 근거와 새 배치 전체는 ADR-005가 정본이다.
 
-**`globals.css`가 이제 `tokens.md`에서 생성된다.** `pnpm tokens:css`가 표를 읽어 `src/app/globals.css`를 통째로 쓴다. 8절 「CSS 전문」은 표로 담을 칸이 없는 넷(뼈대, Tailwind 기본값 초기화와 서체, shadcn 다리, `@layer base`의 body)만 남았고 나머지는 표에서 생성된다. 첫 실행이 바꾼 건 순서 셋뿐이었다 — `@custom-variant dark` 위치, `--text-*` 순서, `--radius-*` 위치. 값은 한 자도 안 바뀌었다. 옛 파리티 검사(`tests/lint/token-css-parity.ts`와 그 test)는 지워졌고, `tests/lint/generate-globals-css.test.ts`가 생성 결과와 저장된 파일을 통째로 대조한다.
+**기능마다 intent→spec→plan 사슬을 걷는다.** `1-plan/intent/<슬러그>.md` → `2-design/spec/<슬러그>.md`(완료 조건과 `status` 승인 마크) → `3-build/plans/<슬러그>.md`다. 관문은 spec→구현 한 마디뿐이고 `.claude/hooks/spec-gate.py`가 지킨다 — `feat/<슬러그>` 브랜치에서 `src/`를 고치는데 `docs/2-design/spec/<슬러그>.md`가 없거나 `status: approved`가 아니면 막는다. `feat/`가 아닌 브랜치와 `src/` 밖 경로는 안 막는다.
 
-**7절 대비값도 이제 기계가 잰다.** `tests/lint/contrast-check.ts`가 1절 팔레트 hex에서 WCAG 공식으로 다시 계산해 「측정한 조합」 16행(라이트·다크)과 「떨어진 조합」 4행을 대조하고, 측정한 조합은 4.5:1 이상인지도 본다. 표 값은 재계산해도 전부 맞았다 — 검사를 세운 건 붉은불을 켜기 위해서가 아니라 초록불이 증거가 되게 하기 위해서였고, 변이 다섯(값 어긋남 둘, 행 삭제, 헤더 파손, 반올림 삽입)으로 실제로 무는 걸 확인했다. 표 파서(`Row` 타입·`readRows`·`requireRows`·`bySection`·헤더 상수)는 `scripts/tokens-md.mts`로 빠져 생성기와 검사가 같이 쓴다.
+**`backlog.md`가 `plan.md`를 대체했다.** 행 하나가 task 하나고 완료 조건은 이제 항상 그 행이 링크하는 spec에 산다(ADR-002의 승격 기준을 ADR-005가 대체했다). 지금 「진행」은 비어 있고 「다음」에 셋(대시보드 디자인·로그인 화면·대시보드 구현)이 남아 있는데, 첫 행은 아래 「다음 첫 수」에 적은 대로 상태가 이상하다.
 
-생성기와 검사 스크립트는 `.mts` 확장자로 `node --experimental-strip-types`로 돈다. `eslint.config.mjs`의 files 글롭에 `mts`를 더했다.
+**CLAUDE.md는 라우터다.** 108줄이 58줄로 줄었고 협업 구조를 설명하던 서두가 빠졌다. 근거 산문은 ADR과 design-system README와 정의문으로의 포인터로 바뀌었으니, 왜를 알아야 하면 CLAUDE.md가 아니라 그 정본을 읽는다.
 
-`backlog.md`의 「다음」이 디자인 task 하나로 줄었다. 코드 쪽 task는 지금 없다.
+**CI에서 문서만 바뀐 PR은 더 빠르다.** 스킵 패턴이 `docs/`·`.claude/`에 루트 마크다운(`[^/]+\.md$`)까지 넓어져서 문서 전용 PR이 4분대에서 48초로 줄었다. lint·format·typecheck·단위 테스트는 여전히 문서 PR에서도 돈다.
 
-페이지별 디자인 문서는 여전히 `docs/2-design/design-system/pages/login.md` 하나뿐이다. 로그인 화면과 승인 대기 화면의 짜임, 역할 토큰, 화면 문안, 모션이 들어 있고 그 틀(화면 절 넷 + 안 담은 것 + 규칙과 부딪힌 자리 + 아직 안 정한 것)이 `README.md`에 박혔다. 뒤따르는 화면은 이 틀을 따른다.
+**문서 구조를 지키는 검사 둘이 `pnpm test`에 낀다.** `tests/lint/doc-map.ts`는 CLAUDE.md 문서 지도의 백틱 경로가 실존하는지 확인하고, `tests/lint/legacy-doc-paths.ts`는 개편 전 `docs/` 바로 아래 있던 옛 경로 여섯 종(plan.md · prd.md · domain · adr · spec · design-system)이 문서·정의문·코드에 남았는지 훑는다. `docs/log/`는 당시 사실의 기록이라 통째로 빠진다.
 
-코드는 세션 기반이 서 있고 화면은 아직 없다. 브라우저용 Supabase 클라이언트도 아직 없다.
+**코드 층은 이번 회차에서 안 건드렸다.** 세션 기반은 서 있고 화면은 아직 없다. 브라우저용 Supabase 클라이언트 팩토리도 없다. `globals.css`는 여전히 `tokens.md`에서 생성되고 7절 대비값은 여전히 기계가 잰다 — 위치만 `docs/2-design/design-system/`으로 옮겨왔다.
 
 ## 다음 첫 수
 
-`backlog.md`의 「다음」에 「근무자 대시보드 디자인을 정한다」 하나만 남았다. 시안을 사람이 보고 고르는 디자인 task다. 코드 쪽 task는 지금 비어 있다.
+`docs/1-plan/`의 `scenarios.md`·`roadmap.md`·`metrics.md`를 태관 인터뷰로 채운다. 셋 다 #236이 튼 틀만 있고 백지다. 각 파일 안 「틀」 절이 인터뷰에서 물을 항목을 이미 적어뒀다 — 시나리오는 누가·언제·무엇을·어떻게 끝나나, 로드맵은 릴리스별 담는 것·빼는 것·판정 기준, 지표는 이름과 정의·왜 이것인가·목표선이다.
 
-## 다음에 그릴 화면
-
-`pages/`에는 로그인 하나뿐이다. 나머지는 근거가 될 도메인 문서의 「아직 안 정한 것」이 비었는지로 갈린다.
-
-**지금 그릴 수 있다.** 근무자 쪽은 대시보드·근무표 조회·출근 인증·교대 요청·휴무 희망 신청·프로필·스플래시고, 관리자 쪽은 대시보드·근무표 편집·교대 승인·출근 기록 조회·계정 승인·휴무 희망 조회다.
-
-**급여도 막혀 있지 않다.** 조사가 `prd.md`의 "급여 쪽이 가장 크고 가장 급하다"를 미완성 표시로 읽었는데, `payroll.md`가 「아직 안 정한 것」 첫 줄에 "계산 규칙 자체는 다 정해졌다"고 적어뒀다. 남은 둘은 공휴일 데이터를 받아오는 쪽이라 계산을 막지 않는다. 급여 상세와 관리자 통계도 지금 그릴 수 있다.
-
-승인 대기 화면의 알림 영역은 `pages/login.md`에 이미 들어 있다. 따로 그릴 화면이 아니다.
+`backlog.md`의 「다음」 첫 행("근무자 대시보드 디자인을 정한다")은 다음 첫 수 후보가 아니다. 그 작업은 PR #225(2026-08-30 merge)가 이미 끝냈다 — 화면 셋(대시보드·출근 인증·사유 시트)을 정하고 시안까지 커밋했다. 그 회차를 기록할 PR #226("2026-08-30 회차를 기록한다")이 `tkyoun0421/design` 브랜치에 열린 채 아직 안 merge돼서, `backlog.md`가 그 완료를 못 옮기고 「다음」에 남아 있다. PR #226을 merge하거나 다시 기록하면 이 행이 「완료」로 내려가고 「로그인 화면과 승인 대기 화면을 만든다」가 「다음」 맨 위로 올라온다.
 
 ## 열린 결정
 
-- **2절 표에 「참조」 열을 열지.** `scripts/generate-globals-css.mts`의 `SURFACE_STROKE_IN_DARK = "var(--palette-neutral-200)"`가 값이 문서 밖에 사는 유일한 자리다. 2절 `stroke.surface` 행의 다크 칸이 hex(`#272523`)라 팔레트 참조로 되돌릴 수 없고 표에 그 참조를 담을 칸도 없어서, 지금은 8절 산문에 그 사실만 적어뒀다. 2절 표에 칸을 열어 끌어올릴지는 안 정했다.
+- **PR #226의 처분.** `tkyoun0421/design` 브랜치에 열려 있는 미merge 상태다. merge할지, 닫고 이번 사실 기준으로 다시 기록할지는 총괄 몫이다.
+- **2절 표에 「참조」 열을 열지.** `scripts/generate-globals-css.mts`의 `SURFACE_STROKE_IN_DARK = "var(--palette-neutral-200)"`가 값이 문서 밖에 사는 유일한 자리다. `tokens.md` 2절 `stroke.surface` 행의 다크 칸이 hex(`#272523`)라 팔레트 참조로 되돌릴 수 없고 표에 그 참조를 담을 칸도 없어서, 지금은 8절 산문에 그 사실만 적어뒀다. 2절 표에 칸을 열어 끌어올릴지는 안 정했다.
 - **`src/` 처분.** "따로 건질 건 없을 것 같다"고 했지만 총괄이 삭제 지시로 읽지 않고 그대로 뒀다 — 되돌리기 어려운 쪽을 기본값으로 삼지 않았다. 실제로 지우려면 말해줘야 한다.
-- **권한을 거부한 뒤의 알림 영역 모습.** 브라우저는 한 번 거부하면 다시 묻지 않는다. 첫째 모습(아직 안 켬)을 그대로 두면 눌러도 아무 일이 없는 버튼이 남고, 아이폰 안내를 띄우면 물을 길이 없는 경우와 물었다 거부당한 경우를 뒤섞는다. `pages/login.md`의 「아직 안 정한 것」에 있다.
-- **거절됐을 때 알림을 보낼지.** 승인이 알림으로 나가니 거절도 대칭으로 나갈 법한데, 거절은 이번만이고 같은 사람이 다시 가입할 수 있다. 통보가 최종 판정처럼 읽히면 다시 올 사람을 돌려세운다. 안 보내면 승인 대기 화면에 계속 남는다. `domain/notification.md`에 있다.
+- **권한을 거부한 뒤의 알림 영역 모습.** 브라우저는 한 번 거부하면 다시 묻지 않는다. 첫째 모습(아직 안 켬)을 그대로 두면 눌러도 아무 일이 없는 버튼이 남고, 아이폰 안내를 띄우면 물을 길이 없는 경우와 물었다 거부당한 경우를 뒤섞는다. `docs/2-design/design-system/pages/login.md`의 「아직 안 정한 것」에 있다.
+- **거절됐을 때 알림을 보낼지.** 승인이 알림으로 나가니 거절도 대칭으로 나갈 법한데, 거절은 이번만이고 같은 사람이 다시 가입할 수 있다. 통보가 최종 판정처럼 읽히면 다시 올 사람을 돌려세운다. 안 보내면 승인 대기 화면에 계속 남는다. `docs/2-design/domain/notification.md`에 있다.
 - **구글 버튼의 Google Sans Medium.** 구글 문서가 그 서체를 적었는데 서드파티 웹에 배포되지 않아 우리 서체로 그려야 한다. 그 어긋남을 OAuth 심사가 어떻게 보는지 모른다. 버튼 이미지를 통째로 쓰면 규정에 맞지만 문구를 우리말로 못 쓴다.
 - **라이트와 다크에서 구글 버튼 테마를 나눌지.** 지금은 양쪽 다 어두운 배경 하나고, 라이트와 중립 테마의 값은 `tokens.md`에 안 옮겼다. 구글이 테마별로 다른 버튼을 쓰는 것을 막지 않는다. 실제 화면을 보고 정한다.
 - **알림 블록의 중립 종류를 `components.md`에 올릴지.** 「아직 안 켬」이 안내·성공·경고·오류 넷 중 어디도 아니라 `bg.neutral-weak`로 깔았다. 화면 하나를 근거로 공용 컴포넌트를 늘리기에는 일러서 미뤘다. 다른 화면에서 같은 모양이 한 번 더 나오면 그때 올린다.
@@ -52,8 +45,7 @@
 - `tests/lint/tsx-dumb-ui.test.ts:162`의 인라인 `layout.tsx` 픽스처가 아직 Geist를 가리킨다. 이 파일의 픽스처 다섯(`layout`·`page`·`providers`·`button`·`card`)이 전부 실제 소스를 베낀 인라인 사본이라, 소스가 바뀔 때마다 같은 방식으로 썩는다. `design-token-values.test.ts`처럼 `readFileSync`로 실제 파일을 읽게 옮길지는 안 정했다.
 - 관리자 승인 RLS가 `security definer`를 필요로 한다. 컬럼 권한은 역할 단위라 `authenticated`에 `approved_at`을 열면 관리자든 아니든 다 열린다. 지금 스키마는 그 문을 안 열어뒀다.
 - integration 테스트가 만든 사용자를 치우지 않는다. anon 키로는 `auth.users`를 못 지우고, 프로필 행 삭제는 테스트가 지키는 바로 그 정책에 걸린다. 지우려면 service role이 필요한데 금지다. `supabase/config.toml`이 IP당 5분에 서른 번으로 가입을 막는데 e2e도 이제 사용자를 만드니, 계정 task를 여러 회차 돌리면 닿는다.
-- 테마를 고르는 UI와 그 선택을 어디 저장할지가 미정이다. 기기 설정을 따르되 앱에서 덮을 수 있게 하기로는 정했지만, 그 속성을 실제로 걸어줄 화면이 없다. `tokens.md`의 「아직 안 정한 것」에 있다.
-- `scripts/tokens-md.mts`와 `scripts/generate-globals-css.mts`에 `SUBSECTION` 정규식이 각각 있다. 공유 모듈이 export를 안 해서고, 생성기의 `readFences`는 heading에서 번호만 떼는 다른 파서라 표 파서와 계약을 공유하지 않는다. 이번에 막은 「표 파서 두 벌」과는 성격이 달라 그대로 뒀다.
+- 테마를 고르는 UI와 그 선택을 어디 저장할지가 미정이다. 기기 설정을 따르되 앱에서 덮을 수 있게 하기로는 정했지만, 그 속성을 실제로 걸어줄 화면이 없다. `docs/2-design/design-system/tokens.md`의 「아직 안 정한 것」에 있다.
 - 도메인 규칙의 미정 항목은 `docs/2-design/domain/`의 각 파일 "아직 안 정한 것" 절이 정본이다. 디자인 값의 미정 항목은 `docs/2-design/design-system/tokens.md`와 `docs/2-design/design-system/pages/`의 같은 이름 절이 정본이다. 여기 옮겨 적지 않는다.
 - 로컬에서 연타하면 가입 rate limit에 걸린다. `supabase/config.toml`이 IP당 5분에 30번이다. CI는 컨테이너가 매번 새로 떠서 무관하다.
 - `authenticated`에 `profiles` 테이블 단위 insert와 delete 권한이 열려 있다. 정책이 없어 RLS가 전부 막는 구조다. 지금은 기본 거부라 안전하고 테스트가 delete 쪽을 지킨다.
@@ -64,11 +56,15 @@
 - `docs/2-design/design-system/tokens.md`의 "빈 상태 화면"과 "브랜드 색 출처" — 빈 상태 화면은 근무 없는 날·급여 0원·알림 0건을 이 팔레트로 아직 안 그려봤다. 브랜드 색 출처는 지금 brand 계열이 공식 브랜드 가이드가 아니라 홀 이미지와 웹사이트 내비게이션에서 뽑은 값이다.
 - 세그먼트 목록 — 실제 파일을 보고 정한다.
 - `playwright.config.ts`의 CI 리트라이 2 — e2e가 늘고 `workers: 1`까지 겹쳐 전체 실행 시간이 무거워지고 있다. 유지할지 정한다.
-- CI가 1분대에서 4분대로 늘었던 것 중 analytics(logflare·vector) 몫은 껐다. 남은 시간이 여전히 아픈지는 몇 회차 더 겪고 정한다.
+- CI가 1분대에서 4분대로 늘었던 것 중 analytics(logflare·vector) 몫은 껐다. 문서 전용 PR은 이번 회차에서 48초로 줄었지만, 코드가 낀 PR의 남은 시간이 여전히 아픈지는 몇 회차 더 겪고 정한다.
 
 ## 주의
 
-- **`docs/`와 `.claude/`만 바뀐 PR은 CI가 뒤쪽 넷을 건너뛴다.** integration과 build와 e2e와 supabase 기동이다. lint·format·typecheck·단위 테스트는 그때도 돈다 — 문서가 테스트 입력이라 문서만 바꿔도 깨지는 자리가 있다.
+- **`docs/`·`.claude/`·루트 마크다운만 바뀐 PR은 CI가 뒤쪽 넷(integration·build·e2e·supabase 기동)을 건너뛴다.** 스킵 패턴이 이번 회차에서 루트 md까지 넓어졌다. lint·format·typecheck·단위 테스트는 그때도 돈다 — 문서가 테스트 입력이라 문서만 바꿔도 깨지는 자리가 있다.
+- **`pnpm test`에 문서 구조를 지키는 검사 둘이 낀다.** `tests/lint/doc-map.ts`(CLAUDE.md 문서 지도 경로 실존 확인)와 `tests/lint/legacy-doc-paths.ts`(옛 경로 잔존 검사)다. 문서를 옮길 땐 CLAUDE.md 문서 지도를 같이 갱신하고, 옛 경로 문자열을 새로 남기지 않는다. `docs/log/`는 검사 밖이라 당시 경로를 그대로 써도 된다.
+- **`feat/<슬러그>` 브랜치에서 `src/`를 고치려면 `docs/2-design/spec/<슬러그>.md`가 `status: approved`여야 한다.** `.claude/hooks/spec-gate.py`가 막는다. `feat/`가 아닌 브랜치(문서·리팩터링·수리)는 게이트 밖이다.
+- **CLAUDE.md는 이제 라우터다.** 왜에 해당하는 산문은 CLAUDE.md에 없고 ADR과 각 정본 문서(design-system README, 정의문)에 있다. CLAUDE.md만 읽고 근거를 찾으려 하지 않는다.
+- **`docs/2-design/spec/`의 완료 조건은 이제 모든 task에 의무다.** ADR-002의 승격 기준(세 문장 넘으면 승격)은 ADR-005가 대체했다 — 문장 길이와 무관하게 spec이 항상 완료 조건의 집이다.
 - **`.prettierignore`가 `*.md`를 거른다.** 문서에 prettier를 돌려도 아무 일도 안 한다. 저장소 전체 방침이다.
 - **pre-commit 훅이 staged 파일의 포맷을 고쳐 인덱스에 다시 올린다.** 일부만 staged된 파일이 포맷에 어긋나면 고치지 않고 커밋을 막는다 — 훅이 고치면 staged 안 한 변경까지 딸려 들어가기 때문이다. 그때는 `pnpm format` 뒤에 직접 `git add` 한다.
 - **`tests/lint/` 아래 테스트는 `tdd-guard-unit.py`의 사전 차단 밖이다.** 그 훅은 `src/`로 시작하는 `.ts` 파일만 본다. `tests/lint/generate-globals-css.test.ts`와 `tests/lint/contrast-check.test.ts`도 여기 해당해서, 편집 순간 손이 막히는 장치는 없고 CI의 `pnpm test`가 대신 잡는다.
@@ -85,7 +81,6 @@
 - clone이나 worktree를 새로 만들면 `git config core.hooksPath .githooks`를 실행한다. 포맷 훅도 여기 붙어 있다.
 - 새 subagent 정의문은 main에 merge된 뒤에야 호출할 수 있게 등록된다.
 - 새 개념이 코드에 등장하면 먼저 `docs/2-design/domain/`에 있는지 확인한다. 용어 정본과 코드 이름을 잇는 장치가 없어서 어긋나도 아무도 안 막는다.
-- task 완료 조건이 세 문장을 넘거나 예외 규칙이 둘 이상이면 `docs/2-design/spec/<task>.md`로 승격한다(ADR-002).
 - integration 테스트를 돌리려면 로컬에 Docker가 떠 있어야 한다. `pnpm test:integration`이 `supabase start`부터 하니 못 뜨면 그 자리에서 멈춘다.
 - `vitest.config.ts`가 CommonJS로 읽히는데 ESM 문법이라 실행할 때마다 경고가 뜬다. 동작에는 영향이 없다.
 - type-aware lint(`no-floating-promises` 등)는 속도를 이유로 안 켜져 있다. await 빠진 Supabase 호출 같은 건 lint가 못 잡는다.

--- a/docs/log/2026-09-04.md
+++ b/docs/log/2026-09-04.md
@@ -1,0 +1,47 @@
+# 2026-09-04 — docs가 SDLC 여섯 단계로 선다
+
+PR 여덟(#229~#236)이 들어간 회차다. 촉발은 Anthropic의 AI-native SDLC 플레이북 영상이었고, 태관의 진단은 "기획도 설계도 부실"이었다 — 완료 조건 한두 줄이 설계를 대신해 왔다. grilling 인터뷰 열세 문으로 결정을 하나씩 확정했고 근거 전부를 ADR-005(`docs/2-design/adr/ADR-005-sdlc-stage-folders-and-artifact-chain.md`)에 적었다. 그 결정을 여섯 이행 PR이 순서대로 실행했고, 사이에 CI 단축과 CLAUDE.md 슬림화가 태관의 지시로 끼어들었다.
+
+## 결정 열셋과 ADR-005
+
+인터뷰가 확정한 것 중 아홉을 여기 적는다 — 단계 폴더를 쓸지, `domain`을 `design` 아래 둘지, `adr`을 한 곳에 모을지, 메타 문서(handoff·backlog·CHANGELOG·log)를 루트에 남길지, intent→spec→plan 사슬을 어디에 배치할지, `plan.md`를 `backlog.md`로 바꿀지, 게이트를 훅 한 마디로 세울지, 배포·운영 뒤 단계는 자리만 세울지, 이행을 자족 PR 여섯으로 나눌지다. 나머지 넷을 포함해 근거 전부는 ADR-005 하나가 정본이다.
+
+## CHANGELOG는 표로, 식별자는 PR 번호로
+
+진행 중 태관이 CHANGELOG 형식을 바꿨다. 처음 초안은 산문 불릿이었는데 날짜·변경·PR 세 칸 표로 바뀌었다. 식별자로 커밋 ID 대신 PR 번호를 쓴 것은 squash merge 때문이다 — 커밋 ID는 병합이 끝나야 정해지지만 PR 번호는 PR을 여는 순간 정해진다.
+
+## 파일 이름은 소문자 kebab, 예외는 셋
+
+파일 이름 규칙도 진행 중 정해졌다. 소문자 kebab-case가 기본이고 `README.md`·`CHANGELOG.md`·`ADR-NNN-*.md` 셋만 생태계 표준을 따라 대문자로 남는다. ADR-005 「파일 이름」 절이 이 규칙의 정본이다.
+
+## 골격을 세우고 소리 나는 것부터 옮긴다 (#229, #230)
+
+#229는 이동 없이 골격만 세웠다. `docs/1-plan/`부터 `docs/6-maintain/`까지 폴더 여섯을 README와 함께 열고, ADR-005를 적고, `docs/CHANGELOG.md`를 새로 두고, CLAUDE.md 문서 지도를 전환 상태에 맞춰 갱신했다. 기존 문서마다 이사 예정지를 적어 지도가 거짓말하지 않게 했다.
+
+#230에서 실제 이동이 시작됐다. `docs/design-system/`을 `docs/2-design/` 아래로 먼저 뗀 이유는 이 폴더가 코드와 가장 얽혀 있어서다. `tokens.md`는 `globals.css`의 생성 소스라 경로가 어긋나면 테스트가 곧바로 빨개진다. 조용히 깨지는 자리보다 소리 내는 자리부터 옮기는 편이 안전했다. `git mv`로 하위 11개 파일을 통째로 옮겼고 git이 전부 rename으로 인식했다. 경로를 물고 있던 코드 일곱 자리(생성기의 `TOKENS_PATH`, lint 테스트 둘, eslint-rules 셋, `.prettierignore`)를 같이 갱신했다.
+
+## 결정 문서 넷은 총괄이 직접 옮겼다 (#231)
+
+`domain`·`adr`·`spec`·`prd`를 단계 폴더로 옮기는 이행 3단계다. 이 넷이 `implementer` 접촉 금지 목록에 있어서 총괄이 직접 만들었다. 정의문 여섯(session-recorder·implementer·integration-test-writer·pr-diff·test-planner·docs-researcher)과 CLAUDE.md와 당시 `plan.md`·`handoff.md`의 참조를 같이 갱신했다. `docs/log/`는 당시 사실의 기록이라 구 경로를 그대로 뒀다 — #235의 잔존 검사가 이 폴더만 예외로 다룬다.
+
+## CI를 줄이고 CLAUDE.md를 라우터로 깎는다 (#232, #233)
+
+문서 개편 PR이 이어지며 태관이 CI 속도를 지적했다. `docs/`·`.claude/`만 바뀐 PR은 무거운 넷(integration·build·e2e)을 건너뛰는 규칙이 있었는데 루트의 CLAUDE.md가 그 패턴 밖이라 문서 PR마다 4분대 풀 CI를 탔다. #232가 스킵 패턴에 루트 마크다운을 더했고, 다음 문서 전용 PR부터 실행 시간이 48초로 떨어졌다.
+
+#233은 CLAUDE.md를 라우팅만 남기게 깎았다. 108줄이 58줄로 줄었고 협업 구조를 설명하던 서두가 통째로 빠졌다. 세션마다 통째로 로드되는 파일이니 근거 산문은 정본(ADR·design-system README·정의문)으로의 포인터로 바꾸고, 지켜야 할 행동 규칙만 한 줄씩 남겼다. 이 PR이 #232의 스킵 패턴이 걸리는 첫 문서 전용 변경이라 CI 단축이 실전에서 함께 확인됐다.
+
+## backlog로 전환하고 완료 조건을 spec으로 옮긴다 (#234)
+
+이행 4단계다. `docs/plan.md`가 `docs/backlog.md`로 개명되며 슬림해졌다. 열린 task 셋(대시보드 디자인·로그인 화면·대시보드)의 완료 조건 문장을 그대로 옮겨 spec 셋(`dashboard-design`·`login-screens`·`dashboard`)에 심고, 프론트매터 `status: draft`로 시작하게 했다 — 승인 마크는 태관이 task를 잡을 때 찍는다. 완료 task는 로그와 git 역사가 세부를 담고 있어 행 한 줄로 줄었다. `test-planner`와 `implementer`가 완료 조건을 spec에서 읽도록 정의문을 갱신했고, `implementer`는 미승인 spec이면 시작하지 않으며 접촉 금지 목록에 `backlog.md`와 `spec/`이 들어갔다.
+
+## 게이트를 걸고 첫 실전을 돈다 (#235)
+
+이행 5단계다. 완료 조건은 `docs/2-design/spec/sdlc-gate.md`에 있다. 재편이 지키는 기계 없이 서 있으면 셋이 조용히 무너진다 — 승인 안 난 spec으로 구현이 먼저 나가고, CLAUDE.md 문서 지도가 없는 경로를 가리키고, 옮기기 전 경로가 정의문과 코드에 남아 다음 손을 옛 자리로 보낸다. 증축 규칙의 "기계가 대신할 수 있나"가 셋 다 그렇다고 답해 훅 하나와 테스트 둘로 옮겼다. 증축 규칙은 상처가 생긴 자리에만 짓는다고 정해뒀는데 이번 개편은 그 규칙과 정면으로 부딪힌다 — 아직 상처가 안 난 자리에 선검사를 다는 것이기 때문이다. 이 충돌은 "이번 개편만 예외"로 정리했고 ADR-005 「증축 규칙 예외」 절에 적혀 있다.
+
+`spec-gate.py`는 `feat/<슬러그>` 브랜치에서 `src/`를 고칠 때 `docs/2-design/spec/<슬러그>.md`의 프론트매터 `status: approved`를 요구한다. 게이트 식별 방식은 브랜치 규약(`feat/<슬러그>`)으로 태관이 골랐다 — 슬러그가 `feat/` 뒤 나머지 전체라 슬래시가 든 브랜치는 대응 spec이 있을 수 없어 자연히 막힌다. `doc-map.ts`는 CLAUDE.md 문서 지도의 백틱 경로가 실존하는지 훑고, `legacy-doc-paths.ts`는 옛 경로 여섯 종이 문서·정의문·코드에 남았는지 훑는다. 둘 다 자기 자신이 스캔 범위 안에 들어서, 패턴 리터럴을 문자열 조각으로 쪼개 적어 자기참조 함정을 피했다.
+
+이 PR은 새 backlog·spec 체계가 선 뒤 처음으로 도는 기능 파이프라인이었다. spec이 approved로 승인된 뒤 test-planner가 계획을 짰고, unit-test-writer가 실패하는 테스트 열넷과 저장소 전체를 훑는 회귀 검사를 먼저 썼다. implementer가 그 위에 구현을 얹어 358개 전부 초록으로 만들었고 pr-diff가 마무리했다. 테스트를 쓰는 손과 구현하는 손이 갈려 있었고 구현자가 단언을 바꾸지 않았다.
+
+## 기획·설계 뼈대는 자리만 세운다 (#236)
+
+이행 6단계이자 마지막이다. 기획 부실 진단에서 나온 네 갈래(시나리오·로드맵·지표·전체 그림)와 구조 설계 갈래가 들어갈 틀만 세웠다. `docs/1-plan/`에 `scenarios.md`·`roadmap.md`·`metrics.md`, `docs/2-design/architecture/`에 README·`data-model.md`·`api.md`·`flows.md`, `docs/4-test/strategy.md`가 전부 백지다. 채우는 조건만 문서마다 적었다 — `scenarios`·`roadmap`·`metrics`는 태관 인터뷰를 기다리고, `architecture`는 도메인과 API가 실제로 서면 채우고, `strategy`는 지금 정본인 `test-planner` 정의문과 ADR-003이 무거워지면 옮긴다. 내용 채우기는 후속 회차의 몫으로 남겼다.


### PR DESCRIPTION
## 무엇을

PR 여덟(#229~#236)이 들어간 SDLC 개편 회차를 `docs/log/2026-09-04.md`에 남긴다. `docs/backlog.md`에서 「spec 승인 게이트와 문서 구조 검사를 단다」를 완료로 내리고 로그를 링크했다. `docs/handoff.md`를 이번 회차 뒤의 사실로 다시 썼다.

## 왜

회차 로그는 PR 본문에는 안 남고 대화에만 오간 근거를 실었다 — 촉발(Anthropic AI-native SDLC 플레이북)과 진단, grilling 인터뷰가 확정한 결정들, 진행 중 태관이 얹은 지시 넷(CHANGELOG 표 전환과 PR 번호 채택 이유, 파일 이름 규칙, CLAUDE.md 슬림화, CI 스킵 패턴 확장), 게이트 식별 방식과 증축 규칙 충돌의 처리, #235가 새 backlog·spec 체계의 첫 파이프라인 실전이었다는 것이다.

`backlog.md`를 확인하던 중 「다음」 첫 행("근무자 대시보드 디자인을 정한다")이 이미 PR #225(2026-08-30 merge)로 끝난 작업인데, 그 회차를 기록할 PR #226이 `tkyoun0421/design` 브랜치에 아직 열린 채 남아 있어 반영이 안 됐다는 걸 발견했다. 지어내지 않고 `handoff.md`의 「다음 첫 수」와 「열린 결정」에 있는 그대로 적었다 — 그래서 이번 다음 첫 수는 `1-plan/`의 시나리오·로드맵·지표 인터뷰로 잡았다.

`handoff.md`의 열린 결정·주의 목록은 지난 판에서 안 닫힌 항목을 그대로 이어 붙이되, `docs/2-design/` 이하로 옮겨진 경로를 갱신했다. `tests/lint/legacy-doc-paths.ts`가 문서 안 옛 경로 리터럴을 잡길래, 옛 경로를 나열하는 문장 하나는 패턴이 안 걸리게 표현을 바꿨다.

## 검증

`pnpm format:check` 통과. `pnpm test` 28파일 358개 통과 (legacy-doc-paths·doc-map 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)