### PR TITLE
주간 보안 스캔을 CI에 단다

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,49 @@
+name: security-scan
+
+on:
+  schedule:
+    - cron: "0 0 * * 1" # 매주 월요일 09:00 KST
+  workflow_dispatch:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: security 라벨 준비
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh label create security --description "보안 스캔 발견" --color D93F0B --force
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+
+            이 저장소 전체를 보안 관점에서 스캔해라. PUBLIC 저장소다.
+
+            보는 것:
+            - 커밋된 시크릿 — 키·토큰·비밀번호 패턴, .env 파일
+            - 인증·인가 결함 — Supabase RLS 부재, 클라이언트만 믿는 로직
+            - 주입 — SQL, XSS, 명령 주입이 가능한 입력 경로
+            - 설정 실수 — CORS, 헤더, 워크플로 권한 과다
+            - .githooks와 .claude/hooks 스크립트의 우회 가능성
+
+            먼저 `gh issue list --label security --state open`으로 이미 보고된
+            발견을 확인하고, 같은 건은 다시 만들지 않는다.
+
+            새 발견이 있으면 `gh issue create --label security`로 Issue 하나에
+            모아 보고한다. 항목마다 심각도(critical/high/medium/low)와
+            확신도(high/medium/low), `경로:줄번호`를 적는다. 확인 가능한
+            사실만 적고, 값이 의심되는 시크릿은 위치와 형태만 적는다.
+            새 발견이 없으면 Issue를 만들지 않는다. Issue는 한국어로 쓴다.
+          claude_args: |
+            --allowedTools "Read,Grep,Glob,Bash(gh issue list:*),Bash(gh issue create:*)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Next.js 16(App Router, TypeScript) + Tailwind CSS 4 + shadcn/ui, zustand, TanSta
 - `pnpm test:integration` — 로컬 Supabase 필요 (Docker). 스택이 떠 있으면 `pnpm test:integration:run`
 - `pnpm e2e` — 먼저 `pnpm build`
 
-CI는 PR마다 lint → test → integration → build → e2e. 문서만 바뀐 PR은 뒤쪽 무거운 넷을 건너뛰고, lint·format·typecheck·단위 테스트는 항상 돈다 — 문서가 테스트 입력인 자리가 있다. PR마다 claude 자동 리뷰가 `REVIEW.md` 기준으로 코멘트를 단다.
+CI는 PR마다 lint → test → integration → build → e2e. 문서만 바뀐 PR은 뒤쪽 무거운 넷을 건너뛰고, lint·format·typecheck·단위 테스트는 항상 돈다 — 문서가 테스트 입력인 자리가 있다. PR마다 claude 자동 리뷰가 `REVIEW.md` 기준으로 코멘트를 달고, 매주 월요일 보안 스캔이 돌아 발견을 `security` 라벨 Issue로 남긴다.
 
 ## 코드 구조
 


### PR DESCRIPTION
## 무엇

매주 월요일 09:00 KST에 claude가 저장소 전체를 보안 관점으로 스캔하고, 새 발견을 `security` 라벨 Issue 하나로 보고한다. `workflow_dispatch`로 수동 실행도 된다.

## 어떻게

- 검사 축 다섯: 커밋된 시크릿 / 인증·인가 결함(Supabase RLS 포함) / 주입 경로 / 설정 실수 / 훅 스크립트 우회 가능성
- 항목마다 심각도·확신도·`경로:줄번호`를 적는다 — 플레이북의 confidence rating 방식
- 실행 전 열린 `security` Issue를 확인해 같은 건은 다시 만들지 않는다. 발견 없으면 Issue도 없다
- 인증은 PR 리뷰와 같은 `CLAUDE_CODE_OAUTH_TOKEN`, 추가 비용 없음

## 왜 셀프 구축인가

플레이북이 권한 Claude Security(대시보드형 정기 스캔)는 Enterprise 요금제 전용 공개 베타라 개인 계정에선 못 쓴다. 같은 취지를 claude-code-action + schedule 트리거로 옮겼다.

## 확인

merge 후 `gh workflow run security-scan` 한 번 돌려 첫 스캔이 Issue를 제대로 남기는지 본다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)