### PR TITLE
CI에 gitleaks 시크릿 스캔을 달고 권한을 최소로 명시한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -60,3 +63,15 @@ jobs:
         if: steps.scope.outputs.code == 'true'
       - run: pnpm e2e
         if: steps.scope.outputs.code == 'true'
+
+  # 로컬 pre-commit 훅은 opt-in이라 우회 가능하다. CI에서 결정적으로 한 번 더 막는다.
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: "false"


### PR DESCRIPTION
## 무엇

보안 스캔 Issue #240의 발견 2건을 고친다.

## 어떻게

- **secrets job 추가** — gitleaks가 PR마다 전체 git 히스토리를 스캔한다. 로컬 pre-commit 훅은 `core.hooksPath` 설정을 안 했거나 `--no-verify`면 우회되지만 이 job은 우회 불가. 정규식이 못 잡던 위치 인자·URL 내장 비밀번호 형태도 gitleaks 규칙이 잡는다
- **`permissions: contents: read` 명시** — ci 워크플로가 조직·저장소 기본 권한에 의존하지 않게 함

gitleaks-action은 개인 계정 저장소에서 무료다. PR 코멘트 기능은 껐다 — 실패 시 job 로그와 summary로 확인한다.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)