### PR TITLE
login-screens spec을 승인한다

### DIFF
--- a/docs/2-design/spec/login-screens.md
+++ b/docs/2-design/spec/login-screens.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: approved
 ---
 
 # 로그인 화면과 승인 대기 화면을 만든다


### PR DESCRIPTION
## 무엇

`docs/2-design/spec/login-screens.md`의 `status`를 `draft`에서 `approved`로 바꾼다.

## 왜

태관이 2026-09-06 세션에서 로그인 화면 task 착수를 승인했다. 완료 조건 넷은 spec에 이미 서 있고, 이 승인 마크가 `spec-gate.py` 관문을 연다.

승인 대기 화면의 도는 문구 4개 문장은 아직 미정이다 — 구현 중 제안을 받아 정하기로 했다. 나머지 미정(구글 버튼 테마·서체, 권한 거부 뒤 모습)은 실제 화면을 보고 정한다는 기존 결정 그대로다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)