### PR TITLE
구글 G 로고를 공식 자산에서 잘라 로그인 버튼에 넣는다

### DIFF
--- a/docs/observations/008-verify-before-reporting-blocked.md
+++ b/docs/observations/008-verify-before-reporting-blocked.md
@@ -1,0 +1,20 @@
+---
+status: open
+target: .claude/agents/implementer.md
+date: 2026-09-07
+resolved:
+---
+
+# 막혔다는 보고가 렌더 확인 없이 일반론에서 나왔다
+
+## 일
+
+login-screens 회차에서 implementer가 구글 버튼 로고를 「배포 SVG가 foreignObject 안 conic-gradient라 `<img>`·CSS로는 안 그려진다」며 미완으로 보고했다. 뒤에 태관 결정으로 재시도했더니 chromium·webkit·firefox 세 엔진 다 정상으로 그렸고, viewBox 크롭 한 번으로 끝났다. 첫 보고는 렌더를 실제로 돌려보지 않고 「SVG는 이미지 컨텍스트에서 foreignObject를 안 그린다」는 일반론으로 단정한 것이었다. 그 한 줄 때문에 로고가 한 라운드 밀렸고, 웹 조사와 태관 결정 한 차례가 낭비됐다. implementer 스스로 이 어긋남을 다음 라운드 보고에서 밝혔다.
+
+## 고침
+
+implementer 정의문에 한 조항을 더한다: 무엇이 「안 된다」고 보고하려면 그 안 됨을 실제 실행(렌더·빌드·호출)으로 확인한 결과여야 한다. 기억이나 일반론으로 단정한 막힘은 보고 전에 한 번 돌려본다.
+
+## 원칙
+
+기계가 몇 초에 확인할 수 있는 사실을 추론으로 대신하면, 틀렸을 때 사람 결정 한 차례가 통째로 낭비된다.

--- a/public/google-g.svg
+++ b/public/google-g.svg
@@ -1,0 +1,66 @@
+<!-- 구글 공식 signin-assets.zip 의 "Android + Web/SVG/Dark/Theme=Dark, Show text=No, Shape=Pill" 에서 버튼 배경 path 둘을 지우고 viewBox 를 로고 마스크 박스(10 10 20 20)로 좁힌 것이다. 로고 자체의 path·색·필터는 원본 그대로다. 직접 그리지 않았다. -->
+<svg width="20" height="20" viewBox="10 10 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_1298_12510" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="10" width="20" height="20">
+<path d="M29.3987 18.1814H19.9849V22.0445H25.3598C25.1286 23.294 24.4294 24.3596 23.3676 25.0712C22.4746 25.6716 21.3266 26.0211 19.9849 26.0211C17.3864 26.0211 15.1823 24.2666 14.3947 21.9004C14.1952 21.2989 14.0853 20.6599 14.0853 19.9983C14.0853 19.3367 14.1952 18.6966 14.3947 18.0962C15.1823 15.7311 17.3864 13.9755 19.9849 13.9755C21.4524 13.9755 22.767 14.4816 23.8039 15.4713L26.6653 12.6057C24.936 10.9908 22.6786 10 19.9849 10C16.0832 10 12.705 12.2414 11.0618 15.5076C10.383 16.8592 10 18.3834 10 19.9994C10 21.6155 10.383 23.1396 11.0618 24.4913C12.705 27.7597 16.0832 30 19.9849 30C22.6797 30 24.9485 29.1137 26.6018 27.5861C28.4887 25.8452 29.5732 23.2702 29.5732 20.2275C29.5732 19.5182 29.5131 18.835 29.3987 18.1825V18.1814Z" fill="#E94FFF"/>
+</mask>
+<g mask="url(#mask0_1298_12510)">
+<g filter="url(#filter0_f_1298_12510)">
+<g clip-path="url(#paint0_angular_1298_12510_clip_path)" data-figma-skip-parse="true"><g transform="matrix(0.00804129 -0.00805186 0.00804128 0.00805186 19.6819 19.7927)"><foreignObject x="-2105.64" y="-2105.64" width="4211.29" height="4211.29"><div xmlns="http://www.w3.org/1999/xhtml" style="background:conic-gradient(from 90deg,rgba(255, 70, 65, 1) 0deg,rgba(255, 70, 65, 1) 4.14555deg,rgba(49, 134, 255, 1) 39.154deg,rgba(49, 134, 255, 1) 72.0044deg,rgba(0, 165, 183, 1) 96.7463deg,rgba(14, 188, 95, 1) 120.897deg,rgba(14, 188, 95, 1) 154.722deg,rgba(108, 196, 0, 1) 179.136deg,rgba(255, 204, 0, 1) 203.588deg,rgba(255, 211, 20, 1) 226.915deg,rgba(255, 204, 0, 1) 251.688deg,rgba(255, 106, 43, 1) 273.129deg,rgba(253, 70, 65, 1) 289.305deg,rgba(255, 70, 65, 1) 359.593deg,rgba(255, 70, 65, 1) 360deg);height:100%;width:100%;opacity:1"></div></foreignObject></g></g><path d="M7.25922 19.7927C7.25922 12.6759 13.0209 6.90668 20.1283 6.90668C27.2357 6.90668 32.9973 12.6759 32.9973 19.7927C32.9973 26.9094 27.2357 32.6786 20.1283 32.6786C13.0209 32.6786 7.25921 26.9094 7.25922 19.7927Z" data-figma-gradient-fill="{&#34;type&#34;:&#34;GRADIENT_ANGULAR&#34;,&#34;stops&#34;:[{&#34;color&#34;:{&#34;r&#34;:1.0,&#34;g&#34;:0.27450981736183167,&#34;b&#34;:0.25490197539329529,&#34;a&#34;:1.0},&#34;position&#34;:0.011515417136251926},{&#34;color&#34;:{&#34;r&#34;:0.19215686619281769,&#34;g&#34;:0.52549022436141968,&#34;b&#34;:1.0,&#34;a&#34;:1.0},&#34;position&#34;:0.10876122117042542},{&#34;color&#34;:{&#34;r&#34;:0.19215686619281769,&#34;g&#34;:0.52549022436141968,&#34;b&#34;:1.0,&#34;a&#34;:1.0},&#34;position&#34;:0.20001229643821716},{&#34;color&#34;:{&#34;r&#34;:0.0,&#34;g&#34;:0.64705884456634521,&#34;b&#34;:0.71764707565307617,&#34;a&#34;:1.0},&#34;position&#34;:0.26873961091041565},{&#34;color&#34;:{&#34;r&#34;:0.054901961237192154,&#34;g&#34;:0.73725491762161255,&#34;b&#34;:0.37254902720451355,&#34;a&#34;:1.0},&#34;position&#34;:0.33582508563995361},{&#34;color&#34;:{&#34;r&#34;:0.054901961237192154,&#34;g&#34;:0.73725491762161255,&#34;b&#34;:0.37254902720451355,&#34;a&#34;:1.0},&#34;position&#34;:0.42978334426879883},{&#34;color&#34;:{&#34;r&#34;:0.42528781294822693,&#34;g&#34;:0.77231442928314209,&#34;b&#34;:0.0,&#34;a&#34;:1.0},&#34;position&#34;:0.49760133028030396},{&#34;color&#34;:{&#34;r&#34;:1.0,&#34;g&#34;:0.80000001192092896,&#34;b&#34;:0.0,&#34;a&#34;:1.0},&#34;position&#34;:0.56552332639694214},{&#34;color&#34;:{&#34;r&#34;:1.0,&#34;g&#34;:0.82745099067687988,&#34;b&#34;:0.078431375324726105,&#34;a&#34;:1.0},&#34;position&#34;:0.63031959533691406},{&#34;color&#34;:{&#34;r&#34;:1.0,&#34;g&#34;:0.80000001192092896,&#34;b&#34;:0.0,&#34;a&#34;:1.0},&#34;position&#34;:0.69913208484649658},{&#34;color&#34;:{&#34;r&#34;:1.0,&#34;g&#34;:0.41842123866081238,&#34;b&#34;:0.16917318105697632,&#34;a&#34;:1.0},&#34;position&#34;:0.75869029760360718},{&#34;color&#34;:{&#34;r&#34;:0.99215686321258545,&#34;g&#34;:0.27450981736183167,&#34;b&#34;:0.25490197539329529,&#34;a&#34;:1.0},&#34;position&#34;:0.80362409353256226},{&#34;color&#34;:{&#34;r&#34;:1.0,&#34;g&#34;:0.27450981736183167,&#34;b&#34;:0.25490197539329529,&#34;a&#34;:1.0},&#34;position&#34;:0.99887031316757202}],&#34;stopsVar&#34;:[{&#34;color&#34;:{&#34;r&#34;:1.0,&#34;g&#34;:0.27450981736183167,&#34;b&#34;:0.25490197539329529,&#34;a&#34;:1.0},&#34;position&#34;:0.011515417136251926},{&#34;color&#34;:{&#34;r&#34;:0.19215686619281769,&#34;g&#34;:0.52549022436141968,&#34;b&#34;:1.0,&#34;a&#34;:1.0},&#34;position&#34;:0.10876122117042542},{&#34;color&#34;:{&#34;r&#34;:0.19215686619281769,&#34;g&#34;:0.52549022436141968,&#34;b&#34;:1.0,&#34;a&#34;:1.0},&#34;position&#34;:0.20001229643821716},{&#34;color&#34;:{&#34;r&#34;:0.0,&#34;g&#34;:0.64705884456634521,&#34;b&#34;:0.71764707565307617,&#34;a&#34;:1.0},&#34;position&#34;:0.26873961091041565},{&#34;color&#34;:{&#34;r&#34;:0.054901961237192154,&#34;g&#34;:0.73725491762161255,&#34;b&#34;:0.37254902720451355,&#34;a&#34;:1.0},&#34;position&#34;:0.33582508563995361},{&#34;color&#34;:{&#34;r&#34;:0.054901961237192154,&#34;g&#34;:0.73725491762161255,&#34;b&#34;:0.37254902720451355,&#34;a&#34;:1.0},&#34;position&#34;:0.42978334426879883},{&#34;color&#34;:{&#34;r&#34;:0.42528781294822693,&#34;g&#34;:0.77231442928314209,&#34;b&#34;:0.0,&#34;a&#34;:1.0},&#34;position&#34;:0.49760133028030396},{&#34;color&#34;:{&#34;r&#34;:1.0,&#34;g&#34;:0.80000001192092896,&#34;b&#34;:0.0,&#34;a&#34;:1.0},&#34;position&#34;:0.56552332639694214},{&#34;color&#34;:{&#34;r&#34;:1.0,&#34;g&#34;:0.82745099067687988,&#34;b&#34;:0.078431375324726105,&#34;a&#34;:1.0},&#34;position&#34;:0.63031959533691406},{&#34;color&#34;:{&#34;r&#34;:1.0,&#34;g&#34;:0.80000001192092896,&#34;b&#34;:0.0,&#34;a&#34;:1.0},&#34;position&#34;:0.69913208484649658},{&#34;color&#34;:{&#34;r&#34;:1.0,&#34;g&#34;:0.41842123866081238,&#34;b&#34;:0.16917318105697632,&#34;a&#34;:1.0},&#34;position&#34;:0.75869029760360718},{&#34;color&#34;:{&#34;r&#34;:0.99215686321258545,&#34;g&#34;:0.27450981736183167,&#34;b&#34;:0.25490197539329529,&#34;a&#34;:1.0},&#34;position&#34;:0.80362409353256226},{&#34;color&#34;:{&#34;r&#34;:1.0,&#34;g&#34;:0.27450981736183167,&#34;b&#34;:0.25490197539329529,&#34;a&#34;:1.0},&#34;position&#34;:0.99887031316757202}],&#34;transform&#34;:{&#34;m00&#34;:16.082571029663086,&#34;m01&#34;:16.082569122314453,&#34;m02&#34;:3.5993347167968750,&#34;m10&#34;:-16.103721618652344,&#34;m11&#34;:16.103721618652344,&#34;m12&#34;:19.792665481567383},&#34;opacity&#34;:1.0,&#34;blendMode&#34;:&#34;NORMAL&#34;,&#34;visible&#34;:true}"/>
+</g>
+<g filter="url(#filter1_f_1298_12510)">
+<ellipse cx="20.0496" cy="20.2413" rx="5.39634" ry="2.83537" transform="rotate(24.4473 20.0496 20.2413)" fill="#3186FF"/>
+</g>
+<g filter="url(#filter2_f_1298_12510)">
+<ellipse cx="33.3538" cy="18.2155" rx="7.43918" ry="3.09357" fill="#3186FF"/>
+</g>
+<g filter="url(#filter3_f_1298_12510)">
+<ellipse cx="25.2744" cy="16.2195" rx="7.40854" ry="2.37805" fill="#FF4641"/>
+</g>
+<g filter="url(#filter4_f_1298_12510)">
+<ellipse cx="29.5427" cy="12.9268" rx="7.40854" ry="2.37805" fill="#FF5B8B"/>
+</g>
+<g filter="url(#filter5_f_1298_12510)">
+<ellipse cx="24.4817" cy="19.878" rx="8.5061" ry="3.10976" fill="#3186FF"/>
+</g>
+<g filter="url(#filter6_f_1298_12510)">
+<ellipse cx="25.1842" cy="14.0197" rx="4.53882" ry="2.37805" transform="rotate(-28.6599 25.1842 14.0197)" fill="#FF4641"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_f_1298_12510" x="5.25922" y="4.90668" width="29.7381" height="29.772" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="1" result="effect1_foregroundBlur_1298_12510"/>
+</filter>
+<clipPath id="paint0_angular_1298_12510_clip_path"><path d="M7.25922 19.7927C7.25922 12.6759 13.0209 6.90668 20.1283 6.90668C27.2357 6.90668 32.9973 12.6759 32.9973 19.7927C32.9973 26.9094 27.2357 32.6786 20.1283 32.6786C13.0209 32.6786 7.25921 26.9094 7.25922 19.7927Z"/></clipPath><filter id="filter1_f_1298_12510" x="12.9977" y="14.828" width="14.1038" height="10.8265" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="1" result="effect1_foregroundBlur_1298_12510"/>
+</filter>
+<filter id="filter2_f_1298_12510" x="23.9146" y="13.1219" width="18.8784" height="10.1871" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="1" result="effect1_foregroundBlur_1298_12510"/>
+</filter>
+<filter id="filter3_f_1298_12510" x="15.8659" y="11.8415" width="18.8171" height="8.7561" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="1" result="effect1_foregroundBlur_1298_12510"/>
+</filter>
+<filter id="filter4_f_1298_12510" x="20.1341" y="8.54878" width="18.8171" height="8.7561" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="1" result="effect1_foregroundBlur_1298_12510"/>
+</filter>
+<filter id="filter5_f_1298_12510" x="13.9756" y="14.7683" width="21.0122" height="10.2195" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="1" result="effect1_foregroundBlur_1298_12510"/>
+</filter>
+<filter id="filter6_f_1298_12510" x="19.0404" y="9.00419" width="12.2878" height="10.0309" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="1" result="effect1_foregroundBlur_1298_12510"/>
+</filter>
+</defs>
+</svg>

--- a/src/screens/login/ui/login-screen.tsx
+++ b/src/screens/login/ui/login-screen.tsx
@@ -40,9 +40,10 @@ export function LoginScreen({ onSignIn }: { onSignIn: () => Promise<void> }) {
           type="submit"
           className={cn(
             APPEAR,
-            "flex h-12 w-full items-center justify-center rounded-full border border-google-stroke bg-google-bg text-sm font-medium text-google-fg transition-transform duration-[var(--duration-fast)] [--tw-animation-delay:calc(var(--stagger-step)*3)] motion-safe:active:scale-[0.97]",
+            "flex h-12 w-full items-center justify-center gap-3 rounded-full border border-google-stroke bg-google-bg text-sm font-medium text-google-fg transition-transform duration-[var(--duration-fast)] [--tw-animation-delay:calc(var(--stagger-step)*3)] motion-safe:active:scale-[0.97]",
           )}
         >
+          <span className="size-6 shrink-0 bg-[url(/google-g.svg)] bg-contain bg-center bg-no-repeat" />
           Google 계정으로 로그인
         </button>
         <p


### PR DESCRIPTION
검수 1회차 반려 4를 푼다. `pages/login.md` 304행이 「로고 에셋은 구글이 배포하는 `signin-assets.zip`을 받아 쓴다」고 정한 그 방식이다. 비공식 4색 path SVG는 안 썼다.

## 무엇

`public/google-g.svg` 하나가 생기고 로그인 버튼에 로고가 붙었다.

## 어떻게 잘랐나

구글이 배포하는 `signin-assets.zip`의 `Android + Web/SVG/Dark/Theme=Dark, Show text=No, Shape=Pill` 을 열면 구조가 이렇다.

```
<svg viewBox="0 0 40 40">
  <path fill="#131314"/>          ← 버튼 원형 면
  <path stroke="#8E918F"/>        ← 버튼 원형 테두리
  <mask x=10 y=10 width=20 height=20> … G 글자꼴 … </mask>
  <g mask="…">  … 그라디언트 원 + 흐린 색 덩이 여섯 … </g>
  <defs> … 블러 필터 일곱 … </defs>
</svg>
```

**손댄 것은 둘뿐이다.** 앞의 `<path>` 둘(버튼 면과 테두리)을 지우고, `viewBox`를 `0 0 40 40`에서 로고 마스크가 스스로 선언한 박스인 `10 10 20 20`으로 좁혔다. 로고의 글자꼴 path도, 마스크도, 그라디언트도, 블러 필터도 원본 바이트 그대로다. 2016년에 `viewBox`를 `0 0 18 18`로 잘라 로고만 뽑던 것과 같은 수다.

마스크가 `maskUnits="userSpaceOnUse" x="10" y="10" width="20" height="20"`라고 자기 영역을 적어둬서 자를 좌표를 추측할 필요가 없었다. 색 덩이 몇은 그 박스 밖까지 뻗지만 전부 `<g mask>` 안에 있어 어차피 글자꼴로 잘리므로, 좁힌 뷰박스가 그리는 것을 하나도 안 버린다.

## 렌더가 원본과 같은지

지난 라운드에 **「`foreignObject` 안의 conic-gradient라 `<img>`로는 색이 안 나온다」고 보고했는데, 그게 틀렸다.** 이번에 실제로 렌더해 보고 확인했다.

세 엔진에서 세 가지 방식으로 그려 비교했다.

| | 인라인 | `<img>` | `background-image` |
| --- | --- | --- | --- |
| chromium | 정상 | 정상 | 정상 |
| webkit | 정상 | 정상 | 정상 |
| firefox | 정상 | 정상 | 정상 |

`background-image`로 그린 200×200 픽셀은 인라인으로 그린 것과 **PNG 바이트가 완전히 같았다.** `<img>`는 36바이트 차이인데 안티에일리어싱 수준이고 눈으로는 구분이 안 된다.

webkit을 같이 돌린 것은 이 앱이 PWA고 주 타깃이 아이폰 사파리라서다. 거기서 로고가 안 나오면 크롬에서 되는 것은 의미가 없다.

## 어떻게 붙였나

`public/` 자산으로 두고 `background-image`로 부른다. **SVG 안의 hex는 구글 원본 그대로 남고 우리 `.tsx`에는 색이 한 글자도 안 들어간다** — `house/no-color-literals`에 구멍을 내지 않으려고 인라인을 피했다. 승인 대기 화면의 프로필 사진이 이미 쓰는 방식이라 결도 같다.

**크기는 구글의 공식 텍스트 버튼에서 비율을 재서 옮겼다.** 그쪽은 높이 40에 로고 20(높이의 50%), 로고와 글자 사이가 12다. 우리 버튼이 `h-12`니 로고는 `size-6`, 사이는 `gap-3`이 된다. `pages/login.md` 302행이 「크기는 조정한다, 다만 종횡비는 유지한다」고 열어둔 자리 안이고 1:1이라 찌그러지지 않는다.

`pages/login.md`의 「구글 버튼은 구글이 정한다」 절이 요구한 것들이다.

- 배경은 셋 중 어두운 것 (`bg-google-bg`)
- G 로고의 색과 비율을 안 바꿈 (원본 path·필터 그대로)
- 로고만 두지 않음 — 버튼 경계와 글자가 같이 있음
- "Google" 한 단어로 로그인 동작을 나타내지 않음
- 문구는 우리말, 모양은 알약

파일 맨 위에 어디서 가져와 무엇을 지웠는지 주석으로 박아뒀다. 나중에 누가 「직접 그린 것 아니냐」고 물을 자리다.

## 확인

`pnpm lint`(에러 0·경고 0) / `format:check` / `typecheck` / `test`(378) / `test:integration:run`(10) / `build` / `e2e`(11) 전부 초록이다. **e2e 단언은 하나도 안 고쳤고 로고를 넣어도 11개가 그대로 통과한다** — 로고를 `alt` 없는 배경으로 넣어서 버튼의 접근 가능한 이름이 「Google 계정으로 로그인」 그대로다.

라이트와 다크 양쪽에서 화면을 띄워 눈으로 봤고, 3배 확대로 로고가 뭉개지지 않는 것도 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
