### PR TITLE
시안을 근무 신청 개정에 맞춘다 — worker 확정 전 세 상태, admin 문안 교정

### DIFF
--- a/docs/2-design/design-system/pages/schedule-admin.sian.html
+++ b/docs/2-design/design-system/pages/schedule-admin.sian.html
@@ -358,7 +358,7 @@ code {
 .dow { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; margin-top: 14px; }
 .dow span { text-align: center; font-size: var(--t-xs); color: var(--fg-neutral-subtle); }
 .cal { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; margin-top: 4px; }
-/* 칸 하나가 두 단이다 — 위에 날짜, 바닥에 희망 수. 채움은 칸에서 뺐다 */
+/* 칸 하나가 두 단이다 — 위에 날짜, 바닥에 신청 수. 채움은 칸에서 뺐다 */
 .cell {
   height: 64px; border-radius: var(--r-sm); display: flex; flex-direction: column; align-items: center;
   justify-content: space-between; padding: 6px 0 4px; font-variant-numeric: tabular-nums; position: relative;
@@ -368,8 +368,8 @@ code {
 .cell.off b { color: var(--fg-neutral-subtle); font-weight: 400; }
 /* 열린 날은 옅은 면이다 — 처음엔 카드(흰 면+그림자+테두리)였다(개정 2026-09-07 2차 검수) */
 .cell.open { background: var(--bg-neutral-weak); cursor: pointer; }
-/* 희망 수는 사람 아이콘과 숫자다 — 처음엔 「○2」였다(2026-09-07).
-   그날 일하는 인원으로도 읽히니 달력 바로 아래 범례가 「휴무 희망」임을 못 박는다 */
+/* 신청 수는 사람 아이콘과 숫자다 — 처음엔 「○2」였다(2026-09-07).
+   그날 일하는 인원으로도 읽히니 달력 바로 아래 범례가 「근무 신청」임을 못 박는다 */
 .cell .hope { display: flex; align-items: center; gap: 2px; font-size: var(--t-xs); line-height: var(--lh-xs); color: var(--fg-neutral-subtle); font-style: normal; }
 .cell .hope svg { flex: 0 0 auto; }
 /* 확정 뒤에만 서는 바닥 단 — 빈 자리가 남은 날의 점선 원 + 수(확정 2026-09-07 — 처음 제안은 글자 「빈 1」). 0이면 그 단이 빈다 */
@@ -621,7 +621,7 @@ code {
           <div class="cap-key">HOME</div>
           <div class="cap-name">관리자 홈 뼈대</div>
           <p class="cap-body">타일 요약 줄이 들어가기 전에 상태를 말한다. <strong>가입 대기는 자리만 잡았다</strong> — 대기 인원 수까지다.</p>
-          <p class="cap-body" style="margin-top:8px">요약 줄이 네 모습이다. 목업은 「만드는 중」 하나뿐이고 나머지 셋은 글로 남긴다 — 아직 없음이 「10월 근무표가 아직 없어요」, 확정 뒤가 「10월 근무표를 확정했어요 · 빈 자리 2」다. <strong>확정 뒤 예식이 사흘 안인데 빈 자리가 남으면 요약 줄이 경고 블록으로 승격한다</strong> — 08절 확정 시트와 같은 <code>bg.warning-weak</code> 면에 <code>warning-500</code> 아이콘이고, 글은 「10월 10일 예식에 빈 자리 1 · 3일 남았어요」다. 빈 자리 재촉 셋 중 홈의 몫이다.</p>
+          <p class="cap-body" style="margin-top:8px">요약 줄이 네 모습이다. 목업은 「만드는 중」 하나뿐이고 나머지 셋은 글로 남긴다 — 아직 없음이 「10월 근무표가 아직 없어요」, 확정 뒤가 「10월 근무표를 확정했어요 · 빈 자리 2」다. <strong>확정 뒤 예식이 사흘 안인데 빈 자리가 남으면 요약 줄이 경고 블록으로 승격한다</strong> — 08절 확정 시트와 같은 <code>bg.warning-weak</code> 면에 <code>warning-500</code> 아이콘이고, 글은 「10월 10일 예식에 빈 자리 1 · 2일 남았어요」다. 빈 자리 재촉 셋 중 홈의 몫이다.</p>
         </figcaption>
       </figure>
 
@@ -693,7 +693,7 @@ code {
             <div class="emptyblock">
               <span class="ic"><svg width="44" height="44" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="17" rx="3"/><path d="M8 2v4M16 2v4M3 10h18"/></svg></span>
               <div class="empty-title">10월 근무표가 아직 없어요</div>
-              <div class="empty-sub">만들면 근무자들이 10월 휴무 희망을 넣을 수 있어요</div>
+              <div class="empty-sub">만들면 근무자들이 10월 근무 신청을 넣을 수 있어요</div>
               <button class="btn">10월 근무표 만들기</button>
             </div>
           </div>
@@ -720,7 +720,7 @@ code {
             <div class="emptyblock">
               <span class="ic"><svg width="44" height="44" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="17" rx="3"/><path d="M8 2v4M16 2v4M3 10h18"/></svg></span>
               <div class="empty-title">10월 근무표가 아직 없어요</div>
-              <div class="empty-sub">만들면 근무자들이 10월 휴무 희망을 넣을 수 있어요</div>
+              <div class="empty-sub">만들면 근무자들이 10월 근무 신청을 넣을 수 있어요</div>
               <button class="btn">10월 근무표 만들기</button>
             </div>
           </div>
@@ -733,7 +733,7 @@ code {
               <div class="box">10월 2일(금)</div>
               <div class="fhint">오늘 이전은 고를 수 없어요</div>
             </div>
-            <div class="fhint" style="margin-top:12px">만드는 순간 10월 휴무 희망 접수가 열려요</div>
+            <div class="fhint" style="margin-top:12px">만드는 순간 10월 근무 신청 접수가 열리고, 근무자 전원에게 알림이 가요</div>
             <div class="rowbtns">
               <button class="btn secondary">닫기</button>
               <button class="btn">만들기</button>
@@ -755,7 +755,7 @@ code {
     <div class="sec-head">
       <span class="sec-num">03 / 월 달력</span>
       <h2>주 단위 묶음이 그대로 보인다</h2>
-      <p>10월 근무표는 10월 5일(월)부터 11월 1일(일)까지다. 범위 줄이 그 답을 미리 하고, 칸은 두 단이다 — 위에 날짜, 바닥에 사람 표시와 휴무 희망 수뿐이다.</p>
+      <p>10월 근무표는 10월 5일(월)부터 11월 1일(일)까지다. 범위 줄이 그 답을 미리 하고, 칸은 두 단이다 — 위에 날짜, 바닥에 사람 표시와 신청 수뿐이다.</p>
     </div>
     <div class="grid">
 
@@ -794,10 +794,10 @@ code {
               <span class="cell open"><b>31</b><em class="hope"><svg width="10" height="10" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true"><circle cx="6" cy="3.4" r="2.3"/><path d="M1.8 11.4a4.2 4.2 0 0 1 8.4 0z"/></svg>1</em></span>
               <span class="cell open"><b>11/1</b><em class="hope"><svg width="10" height="10" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true"><circle cx="6" cy="3.4" r="2.3"/><path d="M1.8 11.4a4.2 4.2 0 0 1 8.4 0z"/></svg>2</em></span>
             </div>
-            <div class="legend">사람 표시는 휴무 희망이에요</div>
+            <div class="legend">사람 표시는 근무 신청이에요</div>
             <div class="rule" style="margin-top:14px"></div>
             <div class="lrow">
-              <span class="lk" style="font-size:var(--t-sm)">휴무 희망 12건 모아보기</span>
+              <span class="lk" style="font-size:var(--t-sm)">근무 신청 12건 모아보기</span>
               <span class="chev" style="margin-left:auto"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 6 6 6-6 6"/></svg></span>
             </div>
             <div class="spacer"></div>
@@ -810,7 +810,7 @@ code {
         <figcaption>
           <div class="cap-key">CAL / EDITING</div>
           <div class="cap-name">편집 중, 스케줄 신청 마감 전</div>
-          <p class="cap-body">칸에 채움 「9/11」이 없다 — 어느 날이 덜 찼는지는 날 상세의 셈과 홈 타일이 말하고 <strong>달력은 날을 여닫고 들어가는 지도로 남는다.</strong> 바닥 단의 <strong>사람 표시가 휴무 희망 수</strong>고, 그날 일하는 인원으로 안 읽히게 바로 아래 범례가 못 박는다. 0건이면 그 단이 빈다(9일·18일).</p>
+          <p class="cap-body">칸에 채움 「9/11」이 없다 — 어느 날이 덜 찼는지는 날 상세의 셈과 홈 타일이 말하고 <strong>달력은 날을 여닫고 들어가는 지도로 남는다.</strong> 바닥 단의 <strong>사람 표시가 신청 수</strong>고, 그날 일하는 인원으로 안 읽히게 바로 아래 범례가 못 박는다. 0건이면 그 단이 빈다(9일·18일).</p>
           <p class="cap-body" style="margin-top:8px">확정하기는 스케줄 신청 마감일 전이라 잠겨 있고, 보조 문구가 되는 날을 센다. <strong>경계는 마감일 다음 날 0시고, 화면을 열어둔 채 자정을 넘기면 그 자리에서는 안 풀린다</strong> — 다시 열거나 새로고침하는 <strong>다음 진입에서 풀린다.</strong> 타이머를 안 둔다.</p>
         </figcaption>
       </figure>
@@ -922,7 +922,7 @@ code {
           </div>
           <div class="body">
             <div class="kvline"><span class="k">근무 시간</span><span class="v">10:00–19:00</span></div>
-            <div class="hopeline">휴무 희망 2 · 박서연, 김지우</div>
+            <div class="hopeline">근무 신청 2 · 박서연, 김지우</div>
             <div class="rule"></div>
             <div class="posrow">
               <div class="poshead"><span class="pname">팀장</span><span class="pcnt">1/1</span><span class="sp"></span></div>
@@ -977,7 +977,7 @@ code {
             <div class="kvline"><span class="k">근무 시간</span><span class="v">10:00–19:00</span>
               <span class="chev"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 6 6 6-6 6"/></svg></span>
             </div>
-            <div class="hopeline">휴무 희망 2 · 박서연, 김지우</div>
+            <div class="hopeline">근무 신청 2 · 박서연, 김지우</div>
             <div class="rule"></div>
             <div class="posrow">
               <div class="poshead"><span class="pname">팀장</span><span class="pcnt">1/1</span><span class="sp"></span><button class="tbtn">교육 붙이기</button><span class="lockic"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg></span></div>
@@ -1125,7 +1125,7 @@ code {
             <button class="btn ghost" style="margin:8px auto 0" data-expand>전체 보기</button>
             <div class="morewrap" data-more hidden>
               <div class="rule" style="margin-top:8px"></div>
-              <div class="prow"><span class="pavatar">박</span><span class="pname">박서연</span><span class="pstat">휴무 희망</span></div>
+              <div class="prow blocked"><span class="pavatar">박</span><span class="pname">박서연</span><span class="pstat">신청 안 함</span></div>
               <div class="prow"><span class="pavatar">김</span><span class="pname">김지우</span><span class="pstat">스캔 자격 없음</span></div>
               <div class="prow blocked"><span class="pavatar">강</span><span class="pname">강하늘</span><span class="pstat">안내에 배정됨</span></div>
               <div class="prow blocked"><span class="pavatar">한</span><span class="pname">한지민</span><span class="pstat">매니저에 배정됨</span></div>
@@ -1136,7 +1136,7 @@ code {
         <figcaption>
           <div class="cap-key">PICKER — 눌러보기</div>
           <div class="cap-name">기본과 전체 보기</div>
-          <p class="cap-body">기본 목록은 자격 있고, 그날 배정이 없고, 휴무 희망을 안 낸 사람이다. <strong>배정된 줄을 누르면 토스트</strong>가 「겸임은 자리를 합쳐 만드세요」라고 알린다.</p>
+          <p class="cap-body">기본 목록은 자격 있고, 그날 배정이 없고, 근무 신청을 낸 사람이다. <strong>배정된 줄을 누르면 토스트</strong>가 「겸임은 자리를 합쳐 만드세요」라고 알린다.</p>
         </figcaption>
       </figure>
 
@@ -1181,7 +1181,7 @@ code {
   <!-- 07 -->
   <section>
     <div class="sec-head">
-      <span class="sec-num">07 / 휴무 희망 모아보기</span>
+      <span class="sec-num">07 / 근무 신청 모아보기</span>
       <h2>날짜순이 기본, 사람순이 옆에</h2>
       <p>탭은 실제로 눌린다. 마감일 바꾸기가 여기 있고, 열리는 시트가 「스케줄 신청 마감일」이다 — 바꾸면 전원에게 알림이 간다는 것을 경고 줄이 미리 말한다. 그 시트는 목업을 안 세웠다.</p>
     </div>
@@ -1195,7 +1195,7 @@ code {
           </span></div>
           <div class="appbar">
             <span class="backic"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 6-6 6 6 6"/></svg></span>
-            <span class="title">10월 휴무 희망</span>
+            <span class="title">10월 근무 신청</span>
           </div>
           <div class="body">
             <div class="hrow num">마감 10월 2일(금) · 3일 남았어요<span class="sp"></span><span class="linknote">마감일 바꾸기</span></div>
@@ -1248,7 +1248,7 @@ code {
           </span></div>
           <div class="appbar">
             <span class="backic"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 6-6 6 6 6"/></svg></span>
-            <span class="title">10월 휴무 희망</span>
+            <span class="title">10월 근무 신청</span>
           </div>
           <div class="body">
             <div class="hrow num">마감 10월 2일(금) · 3일 남았어요<span class="sp"></span><span class="linknote">마감일 바꾸기</span></div>
@@ -1257,7 +1257,7 @@ code {
               <button class="tab">사람순</button>
             </div>
             <div style="margin-top:120px;text-align:center">
-              <div style="font-size:var(--t-sm);line-height:var(--lh-sm);color:var(--fg-neutral-muted)">아직 들어온 희망이 없어요</div>
+              <div style="font-size:var(--t-sm);line-height:var(--lh-sm);color:var(--fg-neutral-muted)">아직 들어온 신청이 없어요</div>
               <div class="num" style="margin-top:2px;font-size:var(--t-sm);line-height:var(--lh-sm);color:var(--fg-neutral-muted)">마감은 10월 2일이에요</div>
             </div>
             <div class="spacer"></div>
@@ -1265,7 +1265,7 @@ code {
         </div>
         <figcaption>
           <div class="cap-key">HOPES / EMPTY</div>
-          <div class="cap-name">희망 0건</div>
+          <div class="cap-name">신청 0건</div>
           <p class="cap-body">삽화 없이 두 줄이다. 마감일이 같이 서서 <strong>아직 시간이 남았다는 것</strong>을 말한다.</p>
         </figcaption>
       </figure>
@@ -1313,7 +1313,7 @@ code {
               <span class="cell open"><b>31</b><em class="hope"><svg width="10" height="10" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true"><circle cx="6" cy="3.4" r="2.3"/><path d="M1.8 11.4a4.2 4.2 0 0 1 8.4 0z"/></svg>1</em></span>
               <span class="cell open"><b>11/1</b><em class="hope"><svg width="10" height="10" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true"><circle cx="6" cy="3.4" r="2.3"/><path d="M1.8 11.4a4.2 4.2 0 0 1 8.4 0z"/></svg>2</em></span>
             </div>
-            <div class="legend">사람 표시는 휴무 희망이에요</div>
+            <div class="legend">사람 표시는 근무 신청이에요</div>
             <div class="spacer"></div>
           </div>
           <div class="ctabar">
@@ -1443,7 +1443,7 @@ code {
               <span class="cell open"><b>31</b></span>
               <span class="cell open"><b>11/1</b></span>
             </div>
-            <!-- 범례도 모아보기 줄도 없다. 희망 수가 확정 뒤에 숨으니 풀 것이 남지 않는다.
+            <!-- 범례도 모아보기 줄도 없다. 신청 수가 확정 뒤에 숨으니 풀 것이 남지 않는다.
                  바닥 단에 남는 것은 빈 자리가 있는 날의 점선 원 + 수뿐이다(확정 2026-09-07) -->
             <div class="spacer"></div>
           </div>
@@ -1451,7 +1451,7 @@ code {
         <figcaption>
           <div class="cap-key">AFTER / CAL</div>
           <div class="cap-name">확정 배지와 확정 줄</div>
-          <p class="cap-body">확정하기와 마감 줄이 사라지고 <strong>날 열기는 남는다.</strong> 오늘(8일)이 브랜드로 차고, 희망 수와 범례와 모아보기 줄이 같이 숨는다 — 마감이 지나 희망이 더 안 들어오고 확정 뒤의 일은 빈 자리 채우기라서다. 대신 <strong>빈 자리가 남은 날 칸에 점선 원과 수가 선다</strong>(10일·17일). 0이면 그 단이 빈다. 처음 제안은 글자 「빈 1」이었고 2차 검수가 점선 원으로 정했다(2026-09-07).</p>
+          <p class="cap-body">확정하기와 마감 줄이 사라지고 <strong>날 열기는 남는다.</strong> 오늘(8일)이 브랜드로 차고, 신청 수와 범례와 모아보기 줄이 같이 숨는다 — 마감이 지나 신청이 더 안 들어오고 확정 뒤의 일은 빈 자리 채우기라서다. 대신 <strong>빈 자리가 남은 날 칸에 점선 원과 수가 선다</strong>(10일·17일). 0이면 그 단이 빈다. 처음 제안은 글자 「빈 1」이었고 2차 검수가 점선 원으로 정했다(2026-09-07).</p>
           <p class="cap-body" style="margin-top:8px">여기서 <strong>새로 연 날은 자리 구성을 자유로 고친다</strong> — 그 날 상세에는 확정 전과 같은 자물쇠·끌기·자리 추가가 서고, 사람이 든 자리를 버리면 강제 변경 빼기와 같은 확인과 알림이 걸린다. 점선 원은 빈 자리 재촉 셋 중 달력의 몫이고, 나머지 둘은 홈 타일의 경고 승격(01절)과 관리자 푸시다.</p>
         </figcaption>
       </figure>
@@ -1548,7 +1548,7 @@ code {
               <span class="cell open"><b>31</b><em class="hope"><svg width="10" height="10" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true"><circle cx="6" cy="3.4" r="2.3"/><path d="M1.8 11.4a4.2 4.2 0 0 1 8.4 0z"/></svg>1</em></span>
               <span class="cell open"><b>11/1</b><em class="hope"><svg width="10" height="10" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true"><circle cx="6" cy="3.4" r="2.3"/><path d="M1.8 11.4a4.2 4.2 0 0 1 8.4 0z"/></svg>2</em></span>
             </div>
-            <div class="legend">사람 표시는 휴무 희망이에요</div>
+            <div class="legend">사람 표시는 근무 신청이에요</div>
             <div class="spacer"></div>
           </div>
           <div class="ctabar">
@@ -1577,7 +1577,7 @@ code {
           </div>
           <div class="body">
             <div class="kvline"><span class="k">근무 시간</span><span class="v">10:00–19:00</span></div>
-            <div class="hopeline">휴무 희망 2 · 박서연, 김지우</div>
+            <div class="hopeline">근무 신청 2 · 박서연, 김지우</div>
             <div class="rule"></div>
             <div class="posrow">
               <div class="poshead"><span class="pname">팀장</span><span class="pcnt">1/1</span><span class="sp"></span><button class="tbtn">교육 붙이기</button><span class="lockic"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg></span></div>

--- a/docs/2-design/design-system/pages/schedule-worker.sian.html
+++ b/docs/2-design/design-system/pages/schedule-worker.sian.html
@@ -29,6 +29,8 @@
   · 근무 취소 버튼의 마감. 도메인 미정이라 교대와 같은 「전날까지」로 그렸다
   · 아코디언 기본 펼침. 전부 접힘으로 두고 04·05는 한 날을 누른 뒤를 그렸다
     · 10/사유 글자 상한 100자. 카운터를 「98 / 100」으로 고정해 거의 찬 상태를 보였다
+  · 11/확정 전 — 근무 신청. 고른 날 칸 조합·BottomCTA 「보내기」·마감 뒤와 접수 전 안내 문구,
+    전부 문서가 이미 「제안」으로 표시해둔 것을 그대로 옮겼다. 시안이 새로 제안한 것이 아니다
 -->
 <title>근무자 근무표 시안</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -349,6 +351,21 @@ body.view-scene .stage.scene-live { display: block; }
 .cell.today b { color: var(--fg-brand-contrast); }
 .legend { margin-top: 8px; font-size: var(--t-xs); line-height: var(--lh-xs); color: var(--fg-neutral-subtle); }
 
+/* 11/확정 전 — 근무 신청. 「확정 전」 점선 칸이 components.md 근무자 조회 표의 마지막 줄이다 */
+.cell.pre { border: 1px dashed var(--stroke-neutral-muted); }
+.cell.pre b { color: var(--fg-neutral-subtle); font-weight: 400; }
+/* 고른 날 — 관리자 날 열기 모드의 선택 칸과 같은 조합을 빌렸다(문서가 「제안」으로 명시) */
+.cell.pre.sel { background: var(--bg-brand-weak-selected); border: 1px solid var(--stroke-brand-solid); }
+.cell.pre.sel b { color: var(--fg-neutral); font-weight: 500; }
+.cell.pre.sel::after { content: "✓"; font-size: var(--t-xs); line-height: var(--lh-xs); color: var(--fg-brand); }
+/* 마감 줄 — 접수 중과 마감 뒤가 같은 자리·같은 색을 쓴다 */
+.deadline { padding: 4px 0 12px; font-size: var(--t-xs); line-height: var(--lh-xs); color: var(--fg-neutral-subtle); font-variant-numeric: tabular-nums; }
+/* 확정 대기 · 접수 전 안내 한 줄 */
+.waitline { margin-top: 6px; font-size: var(--t-sm); line-height: var(--lh-sm); color: var(--fg-neutral-muted); }
+.body > .waitline:first-child { margin-top: 4px; }
+/* BottomCTA — components.md의 정의대로 컨테이너는 bg.neutral에 위쪽 선 stroke.neutral, 버튼은 Button primary다 */
+.ctabar { flex: 0 0 auto; border-top: 1px solid var(--stroke-neutral); background: var(--bg-neutral); padding: 10px 24px 22px; }
+
 /* 바텀시트와 덮개 */
 .scrim {
   position: absolute; inset: 0; z-index: 3; background: var(--scrim-ink);
@@ -435,10 +452,6 @@ body.view-scene .stage.scene-live { display: block; }
   margin-top: 14px; border-radius: var(--r-lg); background: var(--bg-critical-weak); color: var(--fg-critical);
   padding: 12px 14px; font-size: var(--t-sm); line-height: var(--lh-sm); font-weight: 500;
 }
-/* 교대 후보 빈 목록 */
-.emptypick { margin: 40px 0; text-align: center; }
-.emptypick .ep-t { font-size: var(--t-sm); line-height: var(--lh-sm); color: var(--fg-neutral-muted); }
-.emptypick .ep-s { margin-top: 4px; font-size: var(--t-xs); line-height: var(--lh-xs); color: var(--fg-neutral-subtle); }
 
 /* 잠금 화면과 푸시 — OS 크롬이다. 우리 컴포넌트가 아니고 팔레트만 빌렸다 */
 .lock { flex: 1 1 auto; display: flex; flex-direction: column; align-items: center; padding: 24px 16px; }
@@ -577,7 +590,7 @@ body.view-scene .stage.scene-live { display: block; }
           <div class="cap-name">달력 순 · 기본</div>
           <p class="cap-body">알약에 글자가 없다 — 접근성 라벨이 <strong>「달력 순」·「포지션 순」</strong>이다. 「내 배정만」은 이 보기에 안 선다(점이 이미 내 근무만 가리킨다). 열린 날은 전부 눌리고 시트가 올라온다 — 내 근무가 없어도 누가 나가는지 본다.</p>
           <p class="cap-body" style="margin-top:8px"><strong>오늘 칸(8일)이 내 근무 날인데 점이 없다.</strong> components.md의 근무자 조회 표가 오늘 칸에 표식을 안 두기 때문이고, 범례 「점이 내 근무예요」와 부딪히는 자리라 시안이 드러내 둔다. 04의 아코디언은 같은 8일을 「안내」로 적는다.</p>
-          <p class="cap-body" style="margin-top:8px">확정 전인 달과 근무표를 아직 안 만든 달의 모습은 <strong>문서의 「아직 안 정한 것」이라 안 그렸다.</strong> 휴무 희망 제출 화면과 같이 정한다.</p>
+          <p class="cap-body" style="margin-top:8px">확정 전인 달과 근무표를 아직 안 만든 달의 모습은 <strong>11절 「확정 전 — 근무 신청」</strong>에서 근무 신청 화면으로 그린다 — 이 절의 달력과는 다른 자리다.</p>
         </figcaption>
       </figure>
 
@@ -1406,19 +1419,205 @@ body.view-scene .stage.scene-live { display: block; }
           <div class="rsheet">
             <div class="grab"></div>
             <div class="sh-title num">교대 요청 · 10월 10일(토) 안내</div>
-            <div class="sh-sub">여러 명에게 보낼 수 있어요. 수락한 사람 중 관리자가 정해요</div>
-            <div class="emptypick">
-              <div class="ep-t">보낼 사람이 없어요</div>
-              <div class="ep-s">관리자에게 바로 보낼 수 있어요</div>
-            </div>
-            <div class="rowbtns"><button class="btn" type="button">관리자에게만 보내기</button></div>
+            <div class="sh-sub">보낼 사람이 없어요. 관리자에게 바로 보낼 수 있어요</div>
+            <div class="rowbtns" style="margin-top:28px"><button class="btn" type="button">관리자에게만 보내기</button></div>
           </div>
         </div>
         <figcaption>
           <div class="cap-key">10 / SWAP · EMPTY</div>
           <div class="cap-name">교대 후보가 없다</div>
-          <p class="cap-body">승인된 근무자가 나뿐이면 후보 목록이 빈다. 빈 자리에 <strong>「보낼 사람이 없어요. 관리자에게 바로 보낼 수 있어요」</strong>가 서고, 고르는 CTA 대신 <strong>「관리자에게만 보내기」 버튼 하나</strong>만 남는다 — 06의 텍스트 링크가 아니라 이 화면의 유일한 액션이라 Button primary로 세웠다.</p>
-          <p class="cap-body" style="margin-top:8px">부제는 후보가 있을 때와 같은 문구를 그대로 뒀다 — 문서가 빈 상태 전용 부제를 따로 안 적어서다. 어색하면 검수에서 고친다.</p>
+          <p class="cap-body">승인된 근무자가 나뿐이면 후보 목록이 빈다. <strong>부제 자체가 「보낼 사람이 없어요. 관리자에게 바로 보낼 수 있어요」로 바뀐다</strong>(「제안」) — 06의 「여러 명에게 보낼 수 있어요…」 자리를 그대로 갈아 끼운다. 고르는 CTA 대신 <strong>「관리자에게만 보내기」 버튼 하나</strong>만 남는다 — 06의 텍스트 링크가 아니라 이 화면의 유일한 액션이라 Button primary로 세웠다.</p>
+        </figcaption>
+      </figure>
+
+    </div>
+  </section>
+
+  <!-- 11 -->
+  <section>
+    <div class="sec-head">
+      <span class="sec-num">11 / 확정 전 — 근무 신청</span>
+      <h2>같은 달력이 접수 중엔 신청서, 마감 뒤엔 대기표다</h2>
+      <p>별도 제출 화면이 없다. 확정 전 달로 넘기면 이 달력이 곧 근무 신청 모드고, 확정되면 같은 자리가 01의 근무표로 바뀐다. 알약이 안 선다 — 명단이 없어 포지션 순이 보여줄 것이 없다. 세 목업은 위 01~10이 그리는 「10월 8일, 확정 푸시 직후」보다 <strong>앞선 시점</strong>이다 — 같은 10월이 만들어지고, 접수받고, 마감되는 과정이다.</p>
+    </div>
+    <div class="grid">
+
+      <figure class="item" id="m-apply">
+        <div class="mock">
+          <div class="statusbar"><span>09:20</span><span class="sb-right">
+            <svg width="16" height="11" viewBox="0 0 16 11" fill="currentColor" aria-hidden="true"><rect y="7" width="3" height="4" rx="1"/><rect x="4.3" y="5" width="3" height="6" rx="1"/><rect x="8.6" y="2.5" width="3" height="8.5" rx="1"/><rect x="12.9" width="3" height="11" rx="1" opacity=".35"/></svg>
+            <svg width="22" height="11" viewBox="0 0 22 11" fill="none" aria-hidden="true"><rect x=".5" y=".5" width="18" height="10" rx="3" stroke="currentColor" opacity=".4"/><rect x="2" y="2" width="12" height="7" rx="1.6" fill="currentColor"/><path d="M20 4v3a2 2 0 0 0 0-3z" fill="currentColor" opacity=".4"/></svg>
+          </span></div>
+          <div class="appbar">
+            <span class="backic"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 6-6 6 6 6"/></svg></span>
+            <span class="title">
+              <span class="nav"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 6-6 6 6 6"/></svg></span>
+              10월 근무표
+              <span class="nav"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 6 6 6-6 6"/></svg></span>
+            </span>
+          </div>
+          <div class="body">
+            <div class="deadline num">스케줄 신청 마감 10월 2일(금) · 3일 남았어요</div>
+            <div class="dow"><span>월</span><span>화</span><span>수</span><span>목</span><span>금</span><span>토</span><span>일</span></div>
+            <div class="cal">
+              <span class="cell pre"><b>5</b></span>
+              <span class="cell pre"><b>6</b></span>
+              <span class="cell pre"><b>7</b></span>
+              <span class="cell pre sel"><b>8</b></span>
+              <span class="cell pre"><b>9</b></span>
+              <span class="cell pre sel"><b>10</b></span>
+              <span class="cell pre"><b>11</b></span>
+              <span class="cell pre"><b>12</b></span>
+              <span class="cell pre"><b>13</b></span>
+              <span class="cell pre"><b>14</b></span>
+              <span class="cell pre"><b>15</b></span>
+              <span class="cell pre"><b>16</b></span>
+              <span class="cell pre sel"><b>17</b></span>
+              <span class="cell pre sel"><b>18</b></span>
+              <span class="cell pre"><b>19</b></span>
+              <span class="cell pre"><b>20</b></span>
+              <span class="cell pre"><b>21</b></span>
+              <span class="cell pre"><b>22</b></span>
+              <span class="cell pre"><b>23</b></span>
+              <span class="cell pre sel"><b>24</b></span>
+              <span class="cell pre"><b>25</b></span>
+              <span class="cell pre"><b>26</b></span>
+              <span class="cell pre"><b>27</b></span>
+              <span class="cell pre"><b>28</b></span>
+              <span class="cell pre"><b>29</b></span>
+              <span class="cell pre"><b>30</b></span>
+              <span class="cell pre"><b>31</b></span>
+              <span class="cell pre"><b>11/1</b></span>
+            </div>
+            <div class="spacer"></div>
+          </div>
+          <div class="ctabar">
+            <button class="btn" type="button">보내기</button>
+          </div>
+        </div>
+        <figcaption>
+          <div class="cap-key">11 / APPLY · OPEN</div>
+          <div class="cap-name">근무 신청 · 마감 전</div>
+          <p class="cap-body">점선 칸은 <code>stroke.neutral-muted</code>다. 눌러 고른 날은 <strong>관리자 날 열기 모드의 선택 칸과 같은 조합</strong> — <code>bg.brand-weak-selected</code> 면에 <code>stroke.brand-solid</code> 테두리와 체크다(components.md에 없어 「제안」으로 빌렸다). <strong>개수 상한이 없어</strong> 다 골라도 된다.</p>
+          <p class="cap-body" style="margin-top:8px">마감 줄이 달력 위에 선다 — 관리자 달력의 마감 줄과 같은 문구다. 하단 고정 <strong>「보내기」는 BottomCTA</strong>다(「제안」). <strong>0개로도 보낸다</strong>(「제안」) — 이미 낸 신청을 전부 무르는 길이 이것뿐이라서다. 보내면 토스트 「10월 근무 신청을 보냈어요」가 뜨고 달력은 고른 채 그대로다(「제안」) — 이 목업은 토스트가 뜨기 전, 고르는 중을 그렸다.</p>
+          <p class="cap-body" style="margin-top:8px">마감 전 재진입도 같은 모습이다 — <strong>보낸 날짜가 선택된 채 열리고</strong>, 고쳐 다시 보내면 이전 제출을 덮어쓴다. 이 목업 하나가 첫 제출 중과 재진입 둘 다를 겸한다.</p>
+        </figcaption>
+      </figure>
+
+      <figure class="item" id="m-apply-closed">
+        <div class="mock">
+          <div class="statusbar"><span>09:20</span><span class="sb-right">
+            <svg width="16" height="11" viewBox="0 0 16 11" fill="currentColor" aria-hidden="true"><rect y="7" width="3" height="4" rx="1"/><rect x="4.3" y="5" width="3" height="6" rx="1"/><rect x="8.6" y="2.5" width="3" height="8.5" rx="1"/><rect x="12.9" width="3" height="11" rx="1" opacity=".35"/></svg>
+            <svg width="22" height="11" viewBox="0 0 22 11" fill="none" aria-hidden="true"><rect x=".5" y=".5" width="18" height="10" rx="3" stroke="currentColor" opacity=".4"/><rect x="2" y="2" width="12" height="7" rx="1.6" fill="currentColor"/><path d="M20 4v3a2 2 0 0 0 0-3z" fill="currentColor" opacity=".4"/></svg>
+          </span></div>
+          <div class="appbar">
+            <span class="backic"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 6-6 6 6 6"/></svg></span>
+            <span class="title">
+              <span class="nav"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 6-6 6 6 6"/></svg></span>
+              10월 근무표
+              <span class="nav"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 6 6 6-6 6"/></svg></span>
+            </span>
+          </div>
+          <div class="body">
+            <div class="deadline num">스케줄 신청이 10월 2일에 마감됐어요</div>
+            <div class="waitline">근무표를 만들고 있어요. 확정되면 여기에 보여요</div>
+            <div class="dow" style="margin-top:12px"><span>월</span><span>화</span><span>수</span><span>목</span><span>금</span><span>토</span><span>일</span></div>
+            <div class="cal">
+              <span class="cell pre"><b>5</b></span>
+              <span class="cell pre"><b>6</b></span>
+              <span class="cell pre"><b>7</b></span>
+              <span class="cell pre sel"><b>8</b></span>
+              <span class="cell pre"><b>9</b></span>
+              <span class="cell pre sel"><b>10</b></span>
+              <span class="cell pre"><b>11</b></span>
+              <span class="cell pre"><b>12</b></span>
+              <span class="cell pre"><b>13</b></span>
+              <span class="cell pre"><b>14</b></span>
+              <span class="cell pre"><b>15</b></span>
+              <span class="cell pre"><b>16</b></span>
+              <span class="cell pre sel"><b>17</b></span>
+              <span class="cell pre sel"><b>18</b></span>
+              <span class="cell pre"><b>19</b></span>
+              <span class="cell pre"><b>20</b></span>
+              <span class="cell pre"><b>21</b></span>
+              <span class="cell pre"><b>22</b></span>
+              <span class="cell pre"><b>23</b></span>
+              <span class="cell pre sel"><b>24</b></span>
+              <span class="cell pre"><b>25</b></span>
+              <span class="cell pre"><b>26</b></span>
+              <span class="cell pre"><b>27</b></span>
+              <span class="cell pre"><b>28</b></span>
+              <span class="cell pre"><b>29</b></span>
+              <span class="cell pre"><b>30</b></span>
+              <span class="cell pre"><b>31</b></span>
+              <span class="cell pre"><b>11/1</b></span>
+            </div>
+            <div class="spacer"></div>
+          </div>
+        </div>
+        <figcaption>
+          <div class="cap-key">11 / APPLY · CLOSED</div>
+          <div class="cap-name">마감 뒤 · 확정 전</div>
+          <p class="cap-body">달력이 읽기 전용이다. 내가 보낸 신청이 고른 날 표시 그대로 남고, 날짜가 안 눌리고, <strong>보내기가 없다</strong> — BottomCTA 자체가 사라졌다. 마감 줄이 「스케줄 신청이 10월 2일에 마감됐어요」로 바뀐다.</p>
+          <p class="cap-body" style="margin-top:8px">그 아래 확정 대기 안내 한 줄 — <strong>「근무표를 만들고 있어요. 확정되면 여기에 보여요」</strong>(「제안」). <code>fg.neutral-muted</code> · <code>text-sm</code>이다.</p>
+        </figcaption>
+      </figure>
+
+      <figure class="item" id="m-apply-empty">
+        <div class="mock">
+          <div class="statusbar"><span>09:20</span><span class="sb-right">
+            <svg width="16" height="11" viewBox="0 0 16 11" fill="currentColor" aria-hidden="true"><rect y="7" width="3" height="4" rx="1"/><rect x="4.3" y="5" width="3" height="6" rx="1"/><rect x="8.6" y="2.5" width="3" height="8.5" rx="1"/><rect x="12.9" width="3" height="11" rx="1" opacity=".35"/></svg>
+            <svg width="22" height="11" viewBox="0 0 22 11" fill="none" aria-hidden="true"><rect x=".5" y=".5" width="18" height="10" rx="3" stroke="currentColor" opacity=".4"/><rect x="2" y="2" width="12" height="7" rx="1.6" fill="currentColor"/><path d="M20 4v3a2 2 0 0 0 0-3z" fill="currentColor" opacity=".4"/></svg>
+          </span></div>
+          <div class="appbar">
+            <span class="backic"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 6-6 6 6 6"/></svg></span>
+            <span class="title">
+              <span class="nav"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 6-6 6 6 6"/></svg></span>
+              10월 근무표
+              <span class="nav"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 6 6 6-6 6"/></svg></span>
+            </span>
+          </div>
+          <div class="body">
+            <div class="waitline">아직 10월 근무 신청을 받지 않아요. 열리면 알려드릴게요</div>
+            <div class="dow" style="margin-top:12px"><span>월</span><span>화</span><span>수</span><span>목</span><span>금</span><span>토</span><span>일</span></div>
+            <div class="cal">
+              <span class="cell pre"><b>5</b></span>
+              <span class="cell pre"><b>6</b></span>
+              <span class="cell pre"><b>7</b></span>
+              <span class="cell pre"><b>8</b></span>
+              <span class="cell pre"><b>9</b></span>
+              <span class="cell pre"><b>10</b></span>
+              <span class="cell pre"><b>11</b></span>
+              <span class="cell pre"><b>12</b></span>
+              <span class="cell pre"><b>13</b></span>
+              <span class="cell pre"><b>14</b></span>
+              <span class="cell pre"><b>15</b></span>
+              <span class="cell pre"><b>16</b></span>
+              <span class="cell pre"><b>17</b></span>
+              <span class="cell pre"><b>18</b></span>
+              <span class="cell pre"><b>19</b></span>
+              <span class="cell pre"><b>20</b></span>
+              <span class="cell pre"><b>21</b></span>
+              <span class="cell pre"><b>22</b></span>
+              <span class="cell pre"><b>23</b></span>
+              <span class="cell pre"><b>24</b></span>
+              <span class="cell pre"><b>25</b></span>
+              <span class="cell pre"><b>26</b></span>
+              <span class="cell pre"><b>27</b></span>
+              <span class="cell pre"><b>28</b></span>
+              <span class="cell pre"><b>29</b></span>
+              <span class="cell pre"><b>30</b></span>
+              <span class="cell pre"><b>31</b></span>
+              <span class="cell pre"><b>11/1</b></span>
+            </div>
+            <div class="spacer"></div>
+          </div>
+        </div>
+        <figcaption>
+          <div class="cap-key">11 / APPLY · NOT MADE</div>
+          <div class="cap-name">근무표를 아직 안 만든 달</div>
+          <p class="cap-body">관리자가 근무표를 만들어야 접수가 열린다. 안 만든 달은 빈 달력이다 — 같은 점선 칸인데 <strong>아무 날짜도 안 눌리고</strong>, 마감 줄 자리에 안내 한 줄만 선다 — <strong>「아직 10월 근무 신청을 받지 않아요. 열리면 알려드릴게요」</strong>(「제안」). <code>fg.neutral-muted</code> · <code>text-sm</code>이다.</p>
+          <p class="cap-body" style="margin-top:8px">확정된 달인데 열린 날이 하나도 없는 경우는 문서가 「실제로 없다」고 못 박아서 안 그렸다.</p>
         </figcaption>
       </figure>
 


### PR DESCRIPTION
## 무엇이 바뀌나

#265가 문서를 앞세웠고 시안이 뒤처져 있었다. sian-writer 둘이 두 파일을 문서에 맞췄다. 디자인 결정은 없다 — 문서와 tokens.md를 눈으로 보게 옮겼고, 문서의 「제안」은 캡션에 그대로 「제안」으로 남겼다.

## schedule-worker.sian.html (+225)

- **11절 「확정 전 — 근무 신청」 신설, 목업 셋** — 제출 모드(점선 달력·고른 날 브랜드 면+테두리+체크·마감 줄·BottomCTA 「보내기」), 마감 뒤(읽기 전용 + 확정 대기 안내), 안 만든 달(빈 점선 달력 + 접수 전 안내)
- 교대 후보 없음(#m-swap-empty) 부제를 문서 문구 「보낼 사람이 없어요. 관리자에게 바로 보낼 수 있어요」로 교체 — 문서에 없던 별도 안내 블록은 제거, 「관리자에게만 보내기」 버튼은 유지
- 시나리오 보기는 안 건드림 — 새 상태 셋은 그리드 보기에만 있다

## schedule-admin.sian.html (±50)

- 「휴무 희망」 계열 문안 27건 전수 교체 (빈 상태·시트 안내·범례·모아보기·날 상세·07절 앱바·캡션·CSS 주석)
- 픽커 전체 보기 — 옛 「휴무 희망 / 눌린다」 줄을 「신청 안 함 / 안 눌린다」 비활성으로 교정 (의미 반전 반영)
- 홈 경고 캡션 날짜를 문서 정본에 맞춤 (「3일」→「2일」)

두 파일 다 `휴무|희망` grep 0건.

## 검수 요청

시안 검수 라운드 대상이다. 특히 — 11절 캡션의 「01~10보다 앞선 시점」 서술은 시안이 붙인 설명이고 문서에 없는 말이다. schedule-worker.md 「제안」 일곱(고른 날 칸 조합·BottomCTA·0개 제출·토스트·안내 문구 둘·교대 부제)의 판정도 이 라운드 몫이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)