### PR TITLE
추론 힘을 일에 맞춘다 — 감사·기록은 낮게, 시안은 중간으로

### DIFF
--- a/.claude/agents/pr-diff.md
+++ b/.claude/agents/pr-diff.md
@@ -3,6 +3,7 @@ name: pr-diff
 description: PR의 diff 전문을 읽고 확인 가능한 사실만 골라 돌려주는 감사자. 삭제된 파일, 총괄 문서 접촉, 시크릿, 테스트 없는 구현을 잡는다. 고치지 않고 취향으로 지적하지도 않는다.
 tools: Bash, Read, Grep, Glob
 model: sonnet
+effort: low
 ---
 
 # diff 감사자

--- a/.claude/agents/session-recorder.md
+++ b/.claude/agents/session-recorder.md
@@ -2,6 +2,7 @@
 name: session-recorder
 description: 회차를 마감하는 기록자. merge된 PR과 git log를 읽어 회차 로그를 쓰고 backlog.md 상태와 handoff.md를 갱신해 PR을 연다. 결정을 내리지 않는다.
 model: sonnet
+effort: low
 tools: Bash, Read, Write, Edit, Grep, Glob
 ---
 

--- a/.claude/agents/sian-writer.md
+++ b/.claude/agents/sian-writer.md
@@ -2,6 +2,7 @@
 name: sian-writer
 description: 시안 HTML을 만드는 작성자. 완성된 페이지 디자인 문서를 받아 pages/<이름>.sian.html을 그린다. 디자인을 결정하지 않는다 — 문서와 tokens.md가 정본이고 시안은 그것을 눈으로 보게 옮길 뿐이다. 페이지 문서가 서고 나서 부른다.
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Write, Edit
 ---
 


### PR DESCRIPTION
## 무엇

subagent 정의문 셋에 `effort`를 박는다.

| 에이전트 | 전 | 후 | 왜 |
| --- | --- | --- | --- |
| `pr-diff` | 기본 | `low` | REVIEW.md가 정한 축을 훑어 사실만 옮긴다 |
| `session-recorder` | 기본 | `low` | merge된 PR을 읽어 정해진 자리에 옮겨 적는다 |
| `sian-writer` | 기본 | `medium` | 문서를 HTML로 옮기지만 볼륨이 크다 |

## 왜 sian-writer만 medium인가

시안은 반복이 많은 작업이다. 이번 회차만 해도 앱바 스물다섯 곳을 같은 모양으로 바꾸고 새 figure를 하나 그린다. 한 곳이 빠지면 시안이 정본과 어긋난 채 남고, 그 어긋남은 다음 사람이 시안을 믿고 읽을 때 드러난다. `docs-researcher`·`explorer`가 `low`인 것은 읽고 요약만 하기 때문이고, 파일을 쓰는 자리는 결이 다르다.

기본값이 이 일에 과했다는 것은 맞다 — 그래서 medium이다.

## 경계

`.claude/agents/`를 만진다. REVIEW.md가 총괄 문서로 잡아둔 자리라 밝혀둔다. 셋 다 frontmatter 한 줄 추가고 정의문 본문은 그대로다.