### PR TITLE
Supabase 서버 클라이언트의 진입점을 하나로 모으고 인증 게이트를 features로 옮긴다

### DIFF
--- a/docs/2-design/adr/ADR-001-fsd-layout-and-tdd-guard.md
+++ b/docs/2-design/adr/ADR-001-fsd-layout-and-tdd-guard.md
@@ -18,6 +18,8 @@
 
 widgets 레이어는 두지 않는다. 화면 조립 덩이가 실제로 반복되면 그때 넣는다.
 
+여러 계층을 내려다보며 묶는 조립 — `entities`의 질의와 `shared`의 판정을 이어 하나의 답을 내는 것 — 은 `features`에 둔다. use-case가 바로 그것이다. `app/`의 `.ts`는 그 use-case를 부르고 `redirect` 같은 Next API에 넘기는 위임만 한다. 조립이 `app/`에 남으면 훅이 안 보는 자리에 로직이 쌓인다(관찰 007).
+
 ## 세그먼트
 
 슬라이스 안은 성격대로 나눈다. `types`, `components`, `hooks`, `actions`, `dals`, `models` 같은 이름을 쓰고, 목록은 열어둔다. 새 성격이 필요하면 그 자리에서 만든다.

--- a/docs/2-design/spec/supabase-client-entry.md
+++ b/docs/2-design/spec/supabase-client-entry.md
@@ -1,0 +1,24 @@
+---
+status: approved
+---
+
+# Supabase 서버 클라이언트의 진입점을 하나로 모으고 인증 게이트를 features로 옮긴다
+
+`createSupabaseServerClient(await cookies())`가 `src/app/` 네 곳에 같은 모양으로 있다. 호출자마다 Next의 `cookies()`를 알아야 하고, 화면이 늘면 같은 줄이 화면 수만큼 는다. 미들웨어만 저장소가 달라 `request.cookies`를 손수 감싼다. 두 팩토리의 `requireEnv`도 글자까지 같은 복제다. 한편 `src/app/auth-gate.ts`는 `entities`와 `shared`를 같이 부르는 조립 코드인데 훅이 안 보는 자리에 있어 e2e만 배선을 밟는다 — 관찰 007이 연 것이다. 아키텍처 리뷰(`docs/log/2026-09-11.md`)의 후보 B·C·D·E를 한 PR로 닫는다.
+
+## 완료 조건
+
+- `src/shared/lib/read-supabase-env.ts`가 `NEXT_PUBLIC_SUPABASE_URL`과 `NEXT_PUBLIC_SUPABASE_ANON_KEY`를 읽어 `{ url, anonKey }`로 돌려준다. 둘 중 하나라도 비어 있으면 지금 두 팩토리가 던지는 것과 같은 문구로 그 자리에서 던진다. 두 팩토리가 이 함수를 부르고 자기 `requireEnv`를 지운다. 기존 팩토리 테스트의 env 단언은 고치지 않은 채 그대로 통과한다.
+- `src/shared/lib/create-supabase-request-client.ts`가 인자 없이 `next/headers`의 `cookies()`를 안에서 받아 `createSupabaseServerClient`에 넘긴 결과를 돌려준다. 호출자는 `cookies()`를 모른다. `createSupabaseServerClient(store)`는 그대로 남는다 — 미들웨어처럼 저장소가 다른 자리의 진입점이다.
+- `src/app/auth-gate.ts`·`src/app/login/actions.ts`·`src/app/auth/callback/route.ts`·`src/app/auth/logout/route.ts`가 새 진입점을 쓴다. 저장소에서 `createSupabaseServerClient(await cookies())`가 사라진다.
+- `src/features/auth/read-auth-gate.ts`가 클라이언트를 받아 목적지와 계정을 돌려준다 — 지금 `src/app/auth-gate.ts`의 `readAuthGate`와 `googlePhotoOf`, `AuthGate`·`SignedInAccount` 타입이 여기로 온다. `next/*`를 import하지 않는다. 짝 테스트 `src/features/auth/__tests__/read-auth-gate.test.ts`가 가짜 클라이언트로 세션 없음·승인 전·승인 후와 아바타 키 둘(`avatar_url`·`picture`)을 확인한다.
+- `src/app/auth-gate.ts`에는 `enterRoute`·`enterPendingRoute`만 남는다. 하는 일은 클라이언트를 만들어 `readAuthGate`에 넘기고 `redirect`하는 것뿐이다.
+- `scripts/tokens-md.mts`가 `SUBSECTION`을 export하고 `scripts/generate-globals-css.mts`가 그것을 import한다. 정규식 정의가 한 곳이 된다. `pnpm tokens:css`의 출력이 바뀌지 않는다.
+- ADR-001 「레이어」에 조립의 자리가 한 문단 선다 — 여러 계층을 묶는 조립은 `features`에 두고, `src/app/`의 `.ts`는 Next API를 부르는 위임만 한다. 관찰 007이 `actioned`로 닫힌다.
+- e2e 11개가 고치지 않은 채 초록이다. 동작은 하나도 바뀌지 않는다.
+
+## 범위 밖
+
+- ADR-003 「클라이언트는 `dals`에서만」과 `shared/lib/get-current-user.ts`·`handle-auth-callback.ts`의 어긋남. 클라이언트를 받아 쓰는 함수가 `shared/lib`에 있는 것이 그 조항과 맞는지는 따로 본다.
+- `tdd-guard-unit.py`의 `SKIP_PREFIXES`에서 `src/app/`을 빼는 것. 조립이 `features`로 나가면 `src/app/`의 `.ts`는 위임뿐이라 짝 테스트를 요구할 것이 없다.
+- `tokens-md.mts`의 절 나누기를 `tests/lint/markdown.ts` 위로 옮기는 것. `scripts/`가 `tests/lint/`를 import하는 방향이 낯설고, `###`를 순서대로 훑는 모양과 제목 하나를 찾는 `section()`의 모양이 다르다.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -8,7 +8,7 @@ task 보드다. 행 하나가 task 하나고, 완료 조건은 그 행이 링크
 
 ## 진행
 
-(비어 있음)
+- [ ] Supabase 서버 클라이언트의 진입점을 하나로 모으고 인증 게이트를 features로 옮긴다 — [spec](2-design/spec/supabase-client-entry.md)
 
 ## 완료
 

--- a/docs/observations/007-assembly-code-has-no-home.md
+++ b/docs/observations/007-assembly-code-has-no-home.md
@@ -1,8 +1,8 @@
 ---
-status: open
+status: actioned
 target: "제안: 조립 코드의 자리 규칙"
 date: 2026-09-07
-resolved:
+resolved: 2026-09-13
 ---
 
 # 조립 코드가 갈 곳이 없어 훅 사각으로 도피했다
@@ -14,6 +14,8 @@ login-screens 회차에서 라우트 셋이 공유하는 조립 로직(세션 �
 ## 고침
 
 FSD에서 여러 계층을 내려다보며 묶는 조립의 자리를 정한다 — `src/app`을 조립 계층으로 인정하고 그 안 `.ts`도 훅 감시(짝 테스트 요구)에 넣든, features에 조립 슬라이스를 두게 하든. 결정이 ADR-001의 계층 서술에 얹혀야 하니 총괄 몫이다.
+
+정한 것: features에 둔다. ADR-001 「레이어」에 조립 문단이 섰고, `auth-gate.ts`의 로직은 `src/features/auth/read-auth-gate.ts`로 갔다(`docs/2-design/spec/supabase-client-entry.md`). 규칙을 고칠 필요가 없었다 — use-case 정의가 이미 맞고 코드가 잘못 자리한 것이었다.
 
 ## 원칙
 

--- a/scripts/generate-globals-css.mts
+++ b/scripts/generate-globals-css.mts
@@ -8,6 +8,7 @@ import {
   PALETTE_HEADER,
   requireRows,
   ROLE_HEADER,
+  SUBSECTION,
   type Row,
 } from "./tokens-md.mts";
 
@@ -33,7 +34,6 @@ const DURATION_HEADER = ["변수", "값", "Tailwind 유틸", "쓰는 자리"];
 const CADENCE_HEADER = ["변수", "값", "쓰는 자리"];
 const VENDOR_HEADER = ["변수", "값", "자리", "Tailwind 유틸"];
 
-const SUBSECTION = /^###\s+(.+?)\s*$/;
 const FENCE_OPEN = "```css";
 const FENCE_CLOSE = "```";
 

--- a/scripts/tokens-md.mts
+++ b/scripts/tokens-md.mts
@@ -17,7 +17,7 @@ export const ROLE_HEADER = [
 
 export const EMPTY_CELL = "—";
 
-const SUBSECTION = /^###\s+(.+?)\s*$/;
+export const SUBSECTION = /^###\s+(.+?)\s*$/;
 
 function cellsOf(line: string): string[] | null {
   const trimmed = line.trim();

--- a/src/app/auth-gate.ts
+++ b/src/app/auth-gate.ts
@@ -1,62 +1,14 @@
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { createSupabaseServerClient } from "@/shared/lib/create-supabase-server-client";
-import { getCurrentUser } from "@/shared/lib/get-current-user";
+import { createSupabaseRequestClient } from "@/shared/lib/create-supabase-request-client";
 import {
-  resolveAuthDestination,
-  type AuthDestination,
-} from "@/shared/lib/resolve-auth-destination";
-import { getApprovedAt } from "@/entities/profile/dals/get-approved-at";
-
-export type SignedInAccount = {
-  email: string;
-  avatarUrl: string | null;
-};
-
-type AuthGate = {
-  destination: AuthDestination;
-  account: SignedInAccount | null;
-};
-
-function googlePhotoOf(metadata: Record<string, unknown>): string | null {
-  for (const key of ["avatar_url", "picture"]) {
-    const value = metadata[key];
-    if (typeof value === "string" && value.length > 0) {
-      return value;
-    }
-  }
-
-  return null;
-}
-
-async function readAuthGate(): Promise<AuthGate> {
-  const client = createSupabaseServerClient(await cookies());
-  const user = await getCurrentUser(client);
-
-  if (!user) {
-    return {
-      destination: resolveAuthDestination({
-        hasSession: false,
-        approvedAt: null,
-      }),
-      account: null,
-    };
-  }
-
-  return {
-    destination: resolveAuthDestination({
-      hasSession: true,
-      approvedAt: await getApprovedAt(client, user.id),
-    }),
-    account: {
-      email: user.email ?? "",
-      avatarUrl: googlePhotoOf(user.user_metadata),
-    },
-  };
-}
+  readAuthGate,
+  type SignedInAccount,
+} from "@/features/auth/read-auth-gate";
 
 export async function enterRoute(expected: "/login" | "/"): Promise<void> {
-  const { destination } = await readAuthGate();
+  const { destination } = await readAuthGate(
+    await createSupabaseRequestClient(),
+  );
 
   if (destination !== expected) {
     redirect(destination);
@@ -64,7 +16,9 @@ export async function enterRoute(expected: "/login" | "/"): Promise<void> {
 }
 
 export async function enterPendingRoute(): Promise<SignedInAccount> {
-  const { destination, account } = await readAuthGate();
+  const { destination, account } = await readAuthGate(
+    await createSupabaseRequestClient(),
+  );
 
   if (destination !== "/pending" || !account) {
     redirect(destination);

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,10 +1,9 @@
-import { cookies } from "next/headers";
 import { NextResponse, type NextRequest } from "next/server";
-import { createSupabaseServerClient } from "@/shared/lib/create-supabase-server-client";
+import { createSupabaseRequestClient } from "@/shared/lib/create-supabase-request-client";
 import { handleAuthCallback } from "@/shared/lib/handle-auth-callback";
 
 export async function GET(request: NextRequest) {
-  const client = createSupabaseServerClient(await cookies());
+  const client = await createSupabaseRequestClient();
 
   const destination = await handleAuthCallback(
     request.nextUrl.searchParams.get("code"),

--- a/src/app/auth/logout/route.ts
+++ b/src/app/auth/logout/route.ts
@@ -1,9 +1,8 @@
-import { cookies } from "next/headers";
 import { NextResponse, type NextRequest } from "next/server";
-import { createSupabaseServerClient } from "@/shared/lib/create-supabase-server-client";
+import { createSupabaseRequestClient } from "@/shared/lib/create-supabase-request-client";
 
 export async function POST(request: NextRequest) {
-  const client = createSupabaseServerClient(await cookies());
+  const client = await createSupabaseRequestClient();
 
   await client.auth.signOut();
 

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { cookies, headers } from "next/headers";
+import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { createSupabaseServerClient } from "@/shared/lib/create-supabase-server-client";
+import { createSupabaseRequestClient } from "@/shared/lib/create-supabase-request-client";
 
 export async function signInWithGoogle() {
   const origin = (await headers()).get("origin");
@@ -10,7 +10,7 @@ export async function signInWithGoogle() {
     redirect("/login");
   }
 
-  const client = createSupabaseServerClient(await cookies());
+  const client = await createSupabaseRequestClient();
   const { data, error } = await client.auth.signInWithOAuth({
     provider: "google",
     options: { redirectTo: `${origin}/auth/callback` },

--- a/src/features/auth/__tests__/read-auth-gate.test.ts
+++ b/src/features/auth/__tests__/read-auth-gate.test.ts
@@ -1,0 +1,106 @@
+import type { SupabaseClient, User } from "@supabase/supabase-js";
+import { describe, expect, it } from "vitest";
+import { readAuthGate } from "@/features/auth/read-auth-gate";
+
+type ProfileRow = { approved_at: string | null };
+
+function fakeClient(options: {
+  user: User | null;
+  approvedAt?: string | null;
+}): SupabaseClient {
+  return {
+    auth: {
+      getUser: async () => ({ data: { user: options.user }, error: null }),
+    },
+    from: (table: string) => {
+      if (table !== "profiles") {
+        throw new Error(`예상치 못한 테이블 조회: ${table}`);
+      }
+
+      return {
+        select: (_columns: string) => ({
+          eq: (_column: string, _value: string) => ({
+            maybeSingle: async (): Promise<{
+              data: ProfileRow | null;
+              error: null;
+            }> => ({
+              data:
+                options.approvedAt === undefined
+                  ? null
+                  : { approved_at: options.approvedAt },
+              error: null,
+            }),
+          }),
+        }),
+      };
+    },
+  } as unknown as SupabaseClient;
+}
+
+function fakeUser(userMetadata: Record<string, unknown> = {}): User {
+  return {
+    id: "user-1",
+    email: "person@example.com",
+    user_metadata: userMetadata,
+  } as unknown as User;
+}
+
+describe("readAuthGate — 로그인 여부와 승인 상태로 목적지를 정한다", () => {
+  it("세션이 없으면 로그인 화면으로 보내고 계정은 비어 있다", async () => {
+    const client = fakeClient({ user: null });
+
+    const gate = await readAuthGate(client);
+
+    expect(gate).toEqual({ destination: "/login", account: null });
+  });
+
+  it("세션은 있지만 승인 전이면 대기 화면으로 보낸다", async () => {
+    const client = fakeClient({ user: fakeUser(), approvedAt: null });
+
+    const gate = await readAuthGate(client);
+
+    expect(gate.destination).toBe("/pending");
+    expect(gate.account?.email).toBe("person@example.com");
+  });
+
+  it("승인 시각이 채워져 있으면 첫 화면으로 보낸다", async () => {
+    const client = fakeClient({
+      user: fakeUser(),
+      approvedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const gate = await readAuthGate(client);
+
+    expect(gate.destination).toBe("/");
+  });
+
+  it("user_metadata에 avatar_url이 있으면 그 값을 계정 사진으로 쓴다", async () => {
+    const client = fakeClient({
+      user: fakeUser({ avatar_url: "https://example.com/avatar.png" }),
+      approvedAt: null,
+    });
+
+    const gate = await readAuthGate(client);
+
+    expect(gate.account?.avatarUrl).toBe("https://example.com/avatar.png");
+  });
+
+  it("avatar_url이 없고 picture만 있으면 picture 값을 계정 사진으로 쓴다", async () => {
+    const client = fakeClient({
+      user: fakeUser({ picture: "https://example.com/picture.png" }),
+      approvedAt: null,
+    });
+
+    const gate = await readAuthGate(client);
+
+    expect(gate.account?.avatarUrl).toBe("https://example.com/picture.png");
+  });
+
+  it("avatar_url도 picture도 없으면 계정 사진은 비어 있다", async () => {
+    const client = fakeClient({ user: fakeUser(), approvedAt: null });
+
+    const gate = await readAuthGate(client);
+
+    expect(gate.account?.avatarUrl).toBeNull();
+  });
+});

--- a/src/features/auth/read-auth-gate.ts
+++ b/src/features/auth/read-auth-gate.ts
@@ -1,0 +1,55 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getCurrentUser } from "@/shared/lib/get-current-user";
+import {
+  resolveAuthDestination,
+  type AuthDestination,
+} from "@/shared/lib/resolve-auth-destination";
+import { getApprovedAt } from "@/entities/profile/dals/get-approved-at";
+
+export type SignedInAccount = {
+  email: string;
+  avatarUrl: string | null;
+};
+
+export type AuthGate = {
+  destination: AuthDestination;
+  account: SignedInAccount | null;
+};
+
+export function googlePhotoOf(
+  metadata: Record<string, unknown>,
+): string | null {
+  for (const key of ["avatar_url", "picture"]) {
+    const value = metadata[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+export async function readAuthGate(client: SupabaseClient): Promise<AuthGate> {
+  const user = await getCurrentUser(client);
+
+  if (!user) {
+    return {
+      destination: resolveAuthDestination({
+        hasSession: false,
+        approvedAt: null,
+      }),
+      account: null,
+    };
+  }
+
+  return {
+    destination: resolveAuthDestination({
+      hasSession: true,
+      approvedAt: await getApprovedAt(client, user.id),
+    }),
+    account: {
+      email: user.email ?? "",
+      avatarUrl: googlePhotoOf(user.user_metadata),
+    },
+  };
+}

--- a/src/shared/lib/__tests__/create-supabase-request-client.test.ts
+++ b/src/shared/lib/__tests__/create-supabase-request-client.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSupabaseRequestClient } from "@/shared/lib/create-supabase-request-client";
+import { createSupabaseServerClient } from "@/shared/lib/create-supabase-server-client";
+
+const FAKE_COOKIE_STORE = { name: "fake-cookie-store" };
+const FAKE_CLIENT = { name: "fake-supabase-client" };
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => FAKE_COOKIE_STORE),
+}));
+
+vi.mock("@/shared/lib/create-supabase-server-client", () => ({
+  createSupabaseServerClient: vi.fn(() => FAKE_CLIENT),
+}));
+
+describe("createSupabaseRequestClient — Next 요청 쿠키로 서버 클라이언트를 만든다", () => {
+  it("cookies()가 돌려준 저장소로 createSupabaseServerClient를 정확히 한 번 부른다", async () => {
+    await createSupabaseRequestClient();
+
+    expect(createSupabaseServerClient).toHaveBeenCalledTimes(1);
+    expect(createSupabaseServerClient).toHaveBeenCalledWith(FAKE_COOKIE_STORE);
+  });
+
+  it("createSupabaseServerClient가 돌려준 클라이언트를 그대로 돌려준다", async () => {
+    const result = await createSupabaseRequestClient();
+
+    expect(result).toBe(FAKE_CLIENT);
+  });
+});

--- a/src/shared/lib/__tests__/read-supabase-env.test.ts
+++ b/src/shared/lib/__tests__/read-supabase-env.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readSupabaseEnv } from "@/shared/lib/read-supabase-env";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("readSupabaseEnv — Supabase 접속에 필요한 env 둘을 읽는다", () => {
+  it("두 env가 채워져 있으면 그 값을 그대로 돌려준다", () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+
+    const result = readSupabaseEnv();
+
+    expect(result).toEqual({
+      url: "https://example.supabase.co",
+      anonKey: "test-anon-key",
+    });
+  });
+
+  it("NEXT_PUBLIC_SUPABASE_URL이 undefined면 던진다", () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", undefined);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+
+    expect(() => readSupabaseEnv()).toThrow(
+      "환경 변수 NEXT_PUBLIC_SUPABASE_URL 값이 비어 있다. NEXT_PUBLIC_* 값은 빌드 시점에 번들에 박히니, 배포 환경에 값을 채우고 다시 빌드해야 한다.",
+    );
+  });
+
+  it("NEXT_PUBLIC_SUPABASE_URL이 빈 문자열이면 던진다", () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+
+    expect(() => readSupabaseEnv()).toThrow(
+      "환경 변수 NEXT_PUBLIC_SUPABASE_URL 값이 비어 있다. NEXT_PUBLIC_* 값은 빌드 시점에 번들에 박히니, 배포 환경에 값을 채우고 다시 빌드해야 한다.",
+    );
+  });
+
+  it("NEXT_PUBLIC_SUPABASE_ANON_KEY가 undefined면 던진다", () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", undefined);
+
+    expect(() => readSupabaseEnv()).toThrow(
+      "환경 변수 NEXT_PUBLIC_SUPABASE_ANON_KEY 값이 비어 있다. NEXT_PUBLIC_* 값은 빌드 시점에 번들에 박히니, 배포 환경에 값을 채우고 다시 빌드해야 한다.",
+    );
+  });
+
+  it("NEXT_PUBLIC_SUPABASE_ANON_KEY가 빈 문자열이면 던진다", () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "");
+
+    expect(() => readSupabaseEnv()).toThrow(
+      "환경 변수 NEXT_PUBLIC_SUPABASE_ANON_KEY 값이 비어 있다. NEXT_PUBLIC_* 값은 빌드 시점에 번들에 박히니, 배포 환경에 값을 채우고 다시 빌드해야 한다.",
+    );
+  });
+});

--- a/src/shared/lib/create-supabase-browser-client.ts
+++ b/src/shared/lib/create-supabase-browser-client.ts
@@ -1,24 +1,8 @@
 import { createBrowserClient } from "@supabase/ssr";
-
-function requireEnv(name: string, value: string | undefined) {
-  if (!value) {
-    throw new Error(
-      `환경 변수 ${name} 값이 비어 있다. NEXT_PUBLIC_* 값은 빌드 시점에 번들에 박히니, 배포 환경에 값을 채우고 다시 빌드해야 한다.`,
-    );
-  }
-
-  return value;
-}
+import { readSupabaseEnv } from "@/shared/lib/read-supabase-env";
 
 export function createSupabaseBrowserClient() {
-  return createBrowserClient(
-    requireEnv(
-      "NEXT_PUBLIC_SUPABASE_URL",
-      process.env.NEXT_PUBLIC_SUPABASE_URL,
-    ),
-    requireEnv(
-      "NEXT_PUBLIC_SUPABASE_ANON_KEY",
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    ),
-  );
+  const { url, anonKey } = readSupabaseEnv();
+
+  return createBrowserClient(url, anonKey);
 }

--- a/src/shared/lib/create-supabase-request-client.ts
+++ b/src/shared/lib/create-supabase-request-client.ts
@@ -1,0 +1,8 @@
+import { cookies } from "next/headers";
+import { createSupabaseServerClient } from "@/shared/lib/create-supabase-server-client";
+
+export async function createSupabaseRequestClient() {
+  const cookieStore = await cookies();
+
+  return createSupabaseServerClient(cookieStore);
+}

--- a/src/shared/lib/create-supabase-server-client.ts
+++ b/src/shared/lib/create-supabase-server-client.ts
@@ -1,4 +1,5 @@
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { readSupabaseEnv } from "@/shared/lib/read-supabase-env";
 
 export type ServerCookieStore = {
   getAll: () => { name: string; value: string }[];
@@ -7,16 +8,6 @@ export type ServerCookieStore = {
 };
 
 type CookiesToSet = { name: string; value: string; options: CookieOptions }[];
-
-function requireEnv(name: string, value: string | undefined) {
-  if (!value) {
-    throw new Error(
-      `환경 변수 ${name} 값이 비어 있다. NEXT_PUBLIC_* 값은 빌드 시점에 번들에 박히니, 배포 환경에 값을 채우고 다시 빌드해야 한다.`,
-    );
-  }
-
-  return value;
-}
 
 function writeCookiesIgnoringReadOnlyStore(
   cookieStore: ServerCookieStore,
@@ -32,26 +23,18 @@ function writeCookiesIgnoringReadOnlyStore(
 }
 
 export function createSupabaseServerClient(cookieStore: ServerCookieStore) {
-  return createServerClient(
-    requireEnv(
-      "NEXT_PUBLIC_SUPABASE_URL",
-      process.env.NEXT_PUBLIC_SUPABASE_URL,
-    ),
-    requireEnv(
-      "NEXT_PUBLIC_SUPABASE_ANON_KEY",
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    ),
-    {
-      cookies: {
-        getAll: () => cookieStore.getAll(),
-        setAll: (cookiesToSet, headers) => {
-          writeCookiesIgnoringReadOnlyStore(cookieStore, cookiesToSet);
+  const { url, anonKey } = readSupabaseEnv();
 
-          for (const [name, value] of Object.entries(headers)) {
-            cookieStore.setHeader?.(name, value);
-          }
-        },
+  return createServerClient(url, anonKey, {
+    cookies: {
+      getAll: () => cookieStore.getAll(),
+      setAll: (cookiesToSet, headers) => {
+        writeCookiesIgnoringReadOnlyStore(cookieStore, cookiesToSet);
+
+        for (const [name, value] of Object.entries(headers)) {
+          cookieStore.setHeader?.(name, value);
+        }
       },
     },
-  );
+  });
 }

--- a/src/shared/lib/read-supabase-env.ts
+++ b/src/shared/lib/read-supabase-env.ts
@@ -1,0 +1,27 @@
+export type SupabaseEnv = {
+  url: string;
+  anonKey: string;
+};
+
+function requireEnv(name: string, value: string | undefined): string {
+  if (!value) {
+    throw new Error(
+      `환경 변수 ${name} 값이 비어 있다. NEXT_PUBLIC_* 값은 빌드 시점에 번들에 박히니, 배포 환경에 값을 채우고 다시 빌드해야 한다.`,
+    );
+  }
+
+  return value;
+}
+
+export function readSupabaseEnv(): SupabaseEnv {
+  return {
+    url: requireEnv(
+      "NEXT_PUBLIC_SUPABASE_URL",
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+    ),
+    anonKey: requireEnv(
+      "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    ),
+  };
+}


### PR DESCRIPTION
## 무엇을

`createSupabaseServerClient(await cookies())`가 `src/app/` 네 곳에 같은 모양으로 박혀 있었다. 화면이 늘면 그 줄도 같이 는다. 진입점 하나로 모으고, 훅이 안 보는 자리에 있던 조립 코드를 `features`로 옮겼다.

- `src/shared/lib/read-supabase-env.ts` — 두 팩토리에 글자까지 같던 `requireEnv` 복제를 하나로 합쳤다
- `src/shared/lib/create-supabase-request-client.ts` — 인자 없이 부르면 `cookies()`를 안에서 받아 서버 클라이언트를 돌려준다
- `src/features/auth/read-auth-gate.ts` — 클라이언트를 받아 목적지와 계정을 돌려준다. `next/*`를 부르지 않아 짝 테스트가 가짜 클라이언트로 배선을 밟는다

## 왜

인증 게이트의 분기는 e2e만 밟고 있었다. `next/headers`를 직접 부르니 단위 테스트를 붙일 자리가 없었고, 그래서 승인 전·후와 아바타 키 둘 같은 갈래가 전부 브라우저를 띄워야 확인됐다. 클라이언트를 인자로 빼자 그 갈래가 단위 테스트 일곱 개로 내려왔다.

`createSupabaseServerClient(store)`는 그대로 뒀다. 미들웨어는 `request.cookies`를 손수 감싸 넘기니 저장소가 다르고, 그 자리의 진입점은 계속 이쪽이다.

## 완료 조건

- [x] `read-supabase-env.ts`가 env 둘을 읽고 비면 같은 문구로 던진다. 두 팩토리가 이걸 부르고 자기 `requireEnv`를 지웠다
- [x] `create-supabase-request-client.ts`가 `cookies()`를 안에서 받는다. 호출자는 모른다
- [x] `auth-gate.ts`·`login/actions.ts`·`auth/callback/route.ts`·`auth/logout/route.ts`가 새 진입점을 쓴다. `createSupabaseServerClient(await cookies())`는 저장소에서 0건
- [x] `features/auth/read-auth-gate.ts`가 `readAuthGate`·`googlePhotoOf`와 타입 둘을 가져갔다. `next/*` import 없음
- [x] `src/app/auth-gate.ts`에는 `enterRoute`·`enterPendingRoute`만 남았다
- [x] `tokens-md.mts`가 `SUBSECTION`을 export하고 `generate-globals-css.mts`가 그걸 쓴다. `pnpm tokens:css` 출력은 그대로
- [x] ADR-001 「레이어」의 조립 문단과 관찰 007 마감 — 앞선 docs 커밋에서 처리
- [x] e2e 11개가 고치지 않은 채 초록이다. 동작은 하나도 안 바뀌었다

아키텍처 리뷰(`docs/log/2026-09-11.md`)의 후보 B·C·D·E를 닫고, 관찰 007을 `actioned`로 닫았다.

## 검증

| 명령 | 결과 |
| --- | --- |
| `pnpm lint` | 통과 |
| `pnpm format:check` | 통과 |
| `pnpm typecheck` | 통과 |
| `pnpm test` | 38 파일 431개 통과 |
| `pnpm test:integration:run` | 2 파일 10개 통과 |
| `pnpm build` | 통과 |
| `pnpm e2e` | 11개 통과 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
